### PR TITLE
Issue #3: Adds compatibility with PHP versions prior to 5.3.3

### DIFF
--- a/src/Zendesk/API/Client.php
+++ b/src/Zendesk/API/Client.php
@@ -200,7 +200,7 @@ class Client {
     public function activities($id = null) { return ($id != null ? $this->activityStream()->setLastId($id) : $this->activityStream()); }
     public function activity($id) { return $this->activityStream()->setLastId($id); }
     public function jobStatus($id) { return $this->jobStatuses()->setLastId($id); }
-    public function search(array $params) { return $this->search->search($params); }
+    public function search(array $params) { return $this->search->performSearch($params); }
     public function anonymousSearch(array $params) { return $this->search->anonymousSearch($params); }
 
 }

--- a/src/Zendesk/API/Search.php
+++ b/src/Zendesk/API/Search.php
@@ -10,7 +10,7 @@ class Search extends ClientAbstract {
     /*
      * Perform a search
      */
-    public function search(array $params) {
+    public function performSearch(array $params) {
         if(!$this->hasKeys($params, array('query'))) {
             throw new MissingParametersException(__METHOD__, array('query'));
         }

--- a/tests/Zendesk/API/Tests/SearchTest.php
+++ b/tests/Zendesk/API/Tests/SearchTest.php
@@ -42,7 +42,7 @@ class SearchTest extends \PHPUnit_Framework_TestCase {
      * @depends testAuthToken
      */
     public function testSearch() {
-        $results = $this->client->search(array('query' => 'hello'));
+        $results = $this->client->performSearch(array('query' => 'hello'));
         $this->assertEquals(is_object($results), true, 'Should return an object');
         $this->assertEquals(is_array($results->results), true, 'Should return an object containing an array called "results"');
         $this->assertGreaterThan(0, $results->results[0]->id, 'Returns a non-numeric id for results[0]');


### PR DESCRIPTION
Related to https://github.com/zendesk/zendesk_api_client_php/issues/3

search function in Search class is being used as a constructor in versions of PHP prior to 5.3.3.
