### PR TITLE
A couple of updates as mentioned in the community forum

### DIFF
--- a/src/Zendesk/API/Attachments.php
+++ b/src/Zendesk/API/Attachments.php
@@ -11,9 +11,11 @@ class Attachments extends ClientAbstract {
      * Upload an attachment
      * $params must include:
      *    'file' - an attribute with the absolute local file path on the server
+     *    'filename' - Name to send to the API
      *    'type' - the MIME type of the file
      * Optional:
      *    'optional_token' - an existing token
+     *		'name' - preferred filename  Note: this is not used at all, not sure why it's here.
      */
     public function upload(array $params) {
         if(!$this->hasKeys($params, array('file'))) {
@@ -22,8 +24,13 @@ class Attachments extends ClientAbstract {
         if(!file_exists($params['file'])) {
             throw new CustomException('File '.$params['file'].' could not be found in '.__METHOD__);
         }
-        $endPoint = Http::prepare('uploads.json?filename='.$params['file'].(isset($params['optional_token']) ? '&token='.$params['optional_token'] : ''));
-        $response = Http::send($this->client, $endPoint, array('filename' => '@'.$params['file']), 'POST', (isset($params['type']) ? $params['type'] : 'application/binary'));
+        if(!isset($params['name'])) {
+          $path_array = explode('/', $params['file']);
+          $file_index = count($path_array) - 1;
+          $params['name'] = $path_array[$file_index];
+        }
+        $endPoint = Http::prepare('uploads.json?filename='.$params['filename'].(isset($params['optional_token']) ? '&token='.$params['optional_token'] : ''));
+        $response = Http::send($this->client, $endPoint, array('file' => $params['file'], 'filename'=>$params['filename']), 'POST', (isset($params['type']) ? $params['type'] : 'application/binary'));
         if ((!is_object($response)) || ($this->client->getDebug()->lastResponseCode != 201)) {
             throw new ResponseException(__METHOD__);
         }

--- a/src/Zendesk/API/Client.php
+++ b/src/Zendesk/API/Client.php
@@ -56,10 +56,15 @@ class Client {
     protected $locales;
     protected $debug;
 
-    public function __construct($subdomain, $username) {
+   /***
+    * @param $secure boolean,  defaults to true.  99.999% of users will not need to use this.
+    *       Just for those of us across the pond where it's 1.2-1.5 seconds faster to fiddle a hosts file entry and
+    *       talk HTTP to a machine in the US which then talks HTTPs to the Zendesk API
+    * */
+    public function __construct($subdomain, $username, $secure=true) {
         $this->subdomain = $subdomain;
         $this->username = $username;
-        $this->apiUrl = 'https://'.$subdomain.'.zendesk.com/api/'.$this->apiVer.'/';
+        $this->apiUrl = 'http'.($secure?'s':'').'://'.$subdomain.'.zendesk.com/api/'.$this->apiVer.'/';
         $this->debug = new Debug();
         $this->tickets = new Tickets($this);
         $this->ticketFields = new TicketFields($this);

--- a/src/Zendesk/API/Http.php
+++ b/src/Zendesk/API/Http.php
@@ -118,10 +118,14 @@ class Http {
 
     /*
      * Specific case for OAuth. Run /oauth.php via your browser to get an access token
-     */
-    public static function oauth($client, $code, $oAuthId, $oAuthSecret) {
+     *
+     * @param $secure boolean,  defaults to true.  99.999% of users will not need to use this.
+     *       Just for those of us across the pond where it's 1.2-1.5 seconds faster to fiddle a hosts file entry and
+     *       talk HTTP to a machine in the US which then talks HTTPs to the Zendesk API
+     * */
+    public static function oauth($client, $code, $oAuthId, $oAuthSecret, $secure=true) {
 
-        $url = 'http://'.$client->getSubdomain().'.zendesk.com/oauth/tokens';
+        $url = 'http'.($secure?'s':'').'://'.$client->getSubdomain().'.zendesk.com/oauth/tokens';
         $method = 'POST';
 
         $curl = curl_init($url);


### PR DESCRIPTION
There are a few updates here.

1) Attachments were not working in the originally released library. The library was assuming zendesk API was taking standard HTTP POST'ed files. However it does not do this - it actually saves the entirety of the POST body. This meant that when you uploaded a file, the resulting file on Zendesk was mime encoded with multipart headers, etc. This now uploads correctly.

2) Modified the attachment process so that the user can supply the 'filename' param to specify what filename should be send to zendesk. This means that if you are accepting an uploaded file from a form and then uploading that to zendesk, you no longer have to do a file rename before uploading to have the file named (e.g.) Picture.jpg, instead of tmp228agdd2.

3) Corrected issue in Http.php whereby prepare was not removing the collection iterators from the params array after adding them to the endpoint url.

4) Corrected second issue in Http.php whereby send was not correctly building the url for a GET request, and checking for a ? character first. This was resulting in (e.g.) ?page=2?query=x