### PR TITLE
Fixed issue where API call would fail if per_page or page parameters wer...

### DIFF
--- a/src/Zendesk/API/Http.php
+++ b/src/Zendesk/API/Http.php
@@ -60,7 +60,7 @@ class Http {
             curl_setopt($curl, CURLOPT_CUSTOMREQUEST, 'PUT');
             curl_setopt($curl, CURLOPT_POSTFIELDS, $json);
         } else {
-            $curl = curl_init($url.($json != (object) null ? '?'.http_build_query($json) : ''));
+            $curl = curl_init($url.($json != (object) null ? (strpos($url, '?') === false ? '?' : '&').http_build_query($json) : ''));
             curl_setopt($curl, CURLOPT_CUSTOMREQUEST, ($method ? $method : 'GET'));
         }
         if($client->getAuthType() == 'oauth_token') {


### PR DESCRIPTION
When trying to make an API call with per_page or page with a query and I was getting no data back from the API call. The issue was related to the fact that the Http->prepare method was adding the per_page/page iterators to the url before the http->send method added the query parameters to the url.

I changed the code to look for an existing ? before adding the query parm.
