### PR TITLE
[bugfix] Attachment content not uploading

### DIFF
--- a/src/Zendesk/API/Attachments.php
+++ b/src/Zendesk/API/Attachments.php
@@ -33,7 +33,7 @@ class Attachments extends ClientAbstract {
         } 
         
         $endPoint = Http::prepare('uploads.json?filename='.$params['name'].(isset($params['optional_token']) ? '&token='.$params['optional_token'] : ''));
-        $response = Http::send($this->client, $endPoint, array('filename' => $params['file']), 'POST', (isset($params['type']) ? $params['type'] : 'application/binary'));
+        $response = Http::send($this->client, $endPoint, array('filename' => '@'.$params['file']), 'POST', (isset($params['type']) ? $params['type'] : 'application/binary'));
        if ((!is_object($response)) || ($this->client->getDebug()->lastResponseCode != 201)) {
             throw new ResponseException(__METHOD__);
         }


### PR DESCRIPTION
Hey folks!

I work for WP Engine (a Zendesk customer! wOOt!) and noticed that after updating our api client, we were experiencing an issue where when we uploaded an attachment, the content of it was no longer making into the file. I believe this is the fix -- hope it helps!

Cheers!
Ryan
