### PR TITLE
Added a isset() to avoid notices on certain PHP configurations.

### DIFF
--- a/src/Zendesk/API/Tickets.php
+++ b/src/Zendesk/API/Tickets.php
@@ -43,7 +43,7 @@ class Tickets extends ClientAbstract {
         }
         $endPoint = Http::prepare(
                 (isset($params['organization_id']) ? 'organizations/'.$params['organization_id'].'/tickets' : 
-                (isset($params['user_id']) ? 'users/'.$params['user_id'].'/tickets/'.($params['ccd'] ? 'ccd' : 'requested') : 
+                (isset($params['user_id']) ? 'users/'.$params['user_id'].'/tickets/'.(isset($params['ccd']) ? 'ccd' : 'requested') : 
                 (isset($params['recent']) ? 'tickets/recent' : 'tickets'))
             ).'.json', $this->client->getSideload($params), $params);
         $response = Http::send($this->client, $endPoint);


### PR DESCRIPTION
Using the Zendesk API client with Laravel causes an E_NOTICE when using the Tickets::findAll methods due to a direct access to the `$params['ccd']` variable.

Wrapping the test in `isset` fixed the problem.

I could not test this change using the Zendesk PHPUnit test suite because all tests fail or are skipped due to an authentication failure.
