### PR TITLE
Fix broken attachment class preventing uploading of files

### DIFF
--- a/src/Zendesk/API/Attachments.php
+++ b/src/Zendesk/API/Attachments.php
@@ -33,7 +33,7 @@ class Attachments extends ClientAbstract {
         } 
         
         $endPoint = Http::prepare('uploads.json?filename='.$params['name'].(isset($params['optional_token']) ? '&token='.$params['optional_token'] : ''));
-        $response = Http::send($this->client, $endPoint, array('filename' => '@'.$params['file']), 'POST', (isset($params['type']) ? $params['type'] : 'application/binary'));
+        $response = Http::send($this->client, $endPoint, array('filename' => $params['file']), 'POST', (isset($params['type']) ? $params['type'] : 'application/binary'));
        if ((!is_object($response)) || ($this->client->getDebug()->lastResponseCode != 201)) {
             throw new ResponseException(__METHOD__);
         }


### PR DESCRIPTION
Need to remove @ since we are loading the file in HTTP::send instead of passing that value as a parameter to curl. Else fopen keeps breaking and we are unable to upload an attachment.
