### PR TITLE
Simplify the ternary operator in Http:send() and some code cleanup

### DIFF
--- a/src/Zendesk/API/Http.php
+++ b/src/Zendesk/API/Http.php
@@ -37,41 +37,50 @@ class Http {
      */
     public static function send($client, $endPoint, $json = null, $method = 'GET', $contentType = 'application/json') {
 
-        $url = $client->getApiUrl().$endPoint;
+        $url    = $client->getApiUrl() . $endPoint;
         $method = strtoupper($method);
         if (null == $json) {
             $json = new \stdClass();
         } else if ($contentType == 'application/json' && $method != 'GET' && $method != 'DELETE') {
             $json = json_encode($json);
         }
-        
-        if($method == 'POST') {
+
+        if ($method == 'POST') {
             $curl = curl_init($url);
             curl_setopt($curl, CURLOPT_POST, true);
             curl_setopt($curl, CURLOPT_POSTFIELDS, $json);
-            if(is_array($json) && isset($json['filename'])) {
-							$file = fopen($json['filename'], 'r');
-							$size = filesize($json['filename']);
-							$filedata = fread($file, $size);
-							curl_setopt($curl, CURLOPT_POSTFIELDS, $filedata);
-							curl_setopt($curl, CURLOPT_INFILE, $file);
-							curl_setopt($curl, CURLOPT_INFILESIZE, $size);
-							curl_setopt($curl, CURLOPT_HTTPHEADER, array('Content-type: application/binary'));
-						}
-        } else
-        if($method == 'PUT') {
+            if (is_array($json) && isset($json['filename'])) {
+                $file     = fopen($json['filename'], 'r');
+                $size     = filesize($json['filename']);
+                $fileData = fread($file, $size);
+                curl_setopt($curl, CURLOPT_POSTFIELDS, $fileData);
+                curl_setopt($curl, CURLOPT_INFILE, $file);
+                curl_setopt($curl, CURLOPT_INFILESIZE, $size);
+                curl_setopt($curl, CURLOPT_HTTPHEADER, array('Content-type: application/binary'));
+            }
+        } else if ($method == 'PUT') {
             $curl = curl_init($url);
             curl_setopt($curl, CURLOPT_CUSTOMREQUEST, 'PUT');
             curl_setopt($curl, CURLOPT_POSTFIELDS, $json);
         } else {
-            $curl = curl_init($url.($json != (object) null ? (strpos($url, '?') === false ? '?' : '&').http_build_query($json) : ''));
+            $curl = curl_init(
+                $url . ($json != (object)null ? (strpos($url, '?') === false ? '?' : '&') . http_build_query($json) : '')
+            );
             curl_setopt($curl, CURLOPT_CUSTOMREQUEST, ($method ? $method : 'GET'));
         }
-        if($client->getAuthType() == 'oauth_token') {
-            curl_setopt($curl, CURLOPT_HTTPHEADER, array('Content-Type: '.$contentType, 'Accept: application/json', 'Authorization: Bearer '.$client->getAuthText()));
+        if ($client->getAuthType() == 'oauth_token') {
+            curl_setopt(
+                $curl,
+                CURLOPT_HTTPHEADER,
+                array(
+                    'Content-Type: ' . $contentType,
+                    'Accept: application/json',
+                    'Authorization: Bearer ' . $client->getAuthText()
+                )
+            );
         } else {
             curl_setopt($curl, CURLOPT_USERPWD, $client->getAuthText());
-            curl_setopt($curl, CURLOPT_HTTPHEADER, array('Content-Type: '.$contentType, 'Accept: application/json'));
+            curl_setopt($curl, CURLOPT_HTTPHEADER, array('Content-Type: ' . $contentType, 'Accept: application/json'));
         }
         curl_setopt($curl, CURLINFO_HEADER_OUT, true);
         curl_setopt($curl, CURLOPT_RETURNTRANSFER, true);
@@ -84,9 +93,9 @@ class Http {
         curl_setopt($curl, CURLOPT_MAXREDIRS, 3);
         $response = curl_exec($curl);
         if ($response === false) {
-            throw new \Exception('No response from curl_exec in '.__METHOD__);
+            throw new \Exception('No response from curl_exec in ' . __METHOD__);
         }
-        $headerSize = curl_getinfo($curl, CURLINFO_HEADER_SIZE);
+        $headerSize   = curl_getinfo($curl, CURLINFO_HEADER_SIZE);
         $responseBody = substr($response, $headerSize);
         $client->setDebug(
             curl_getinfo($curl, CURLINFO_HEADER_OUT),


### PR DESCRIPTION
The ternary to set the `$json` variable was pretty nested. A simple `if` would make it more readable.

This also includes some code cleanup in improve readability.
