### PR TITLE
Enable searching for tickets by external_id

### DIFF
--- a/src/Zendesk/API/Tickets.php
+++ b/src/Zendesk/API/Tickets.php
@@ -76,12 +76,16 @@ class Tickets extends ClientAbstract {
             $params['user_id'] = $this->client->users()->getLastId();
             $this->client->users()->setLastId(null);
         }
+        $queryParams = array();
+        if($this->hasKeys($params, array('external_id'))) {
+            $queryParams['external_id'] = $params['external_id'];
+        }
         $endPoint = Http::prepare(
                 (isset($params['organization_id']) ? 'organizations/'.$params['organization_id'].'/tickets' :
                 (isset($params['user_id']) ? 'users/'.$params['user_id'].'/tickets/'.(isset($params['ccd']) ? 'ccd' : 'requested') :
                 (isset($params['recent']) ? 'tickets/recent' : 'tickets'))
             ).'.json', $this->client->getSideload($params), $params);
-        $response = Http::send($this->client, $endPoint);
+        $response = Http::send($this->client, $endPoint, $queryParams);
         if ((!is_object($response)) || ($this->client->getDebug()->lastResponseCode != 200)) {
             throw new ResponseException(__METHOD__);
         }


### PR DESCRIPTION
It is currently not possible to search for tickets by external_id, which is extremely important for API integrations (so you can retrieve tickets by their local record id). This patch adds in that capability.