### PR TITLE
Pass-through sort_by param as well as sort_order

### DIFF
--- a/src/Zendesk/API/Http.php
+++ b/src/Zendesk/API/Http.php
@@ -26,7 +26,7 @@ class Http {
         // Next look for special collection iterators
         if(is_array($iterators)) {
             foreach($iterators as $k => $v) {
-                if(in_array($k, array('per_page', 'page', 'sort_order'))) {
+                if(in_array($k, array('per_page', 'page', 'sort_order', 'sort_by'))) {
                     $addParams[$k] = $v;
                 }
             }


### PR DESCRIPTION
I wasn't able to use `sort_by` in `findAll()` params, as in

``` php
$zd->tickets()->findAll(array("sort_by" => "created_at", "sort_order" => "desc"))
```

without this change.
