### PR TITLE
Fixed bug where http_build_query encoding would remove parts of query strings

### DIFF
--- a/src/Zendesk/API/Http.php
+++ b/src/Zendesk/API/Http.php
@@ -60,6 +60,8 @@ class Http {
             $json = new \stdClass();
         } else if ($contentType == 'application/json' && $method != 'GET' && $method != 'DELETE') {
             $json = json_encode($json);
+        } else if (is_array($json)) {
+          $json = http_build_query($json);
         }
 
         if ($method == 'POST') {
@@ -82,7 +84,7 @@ class Http {
             curl_setopt($curl, CURLOPT_POSTFIELDS, $json);
         } else {
             $curl = curl_init(
-                $url . ($json != (object)null ? (strpos($url, '?') === false ? '?' : '&') . http_build_query($json) : '')
+                $url . ($json != (object)null ? (strpos($url, '?') === false ? '?' : '&') . $json : '')
             );
             curl_setopt($curl, CURLOPT_CUSTOMREQUEST, ($method ? $method : 'GET'));
         }

--- a/src/Zendesk/API/Http.php
+++ b/src/Zendesk/API/Http.php
@@ -61,7 +61,7 @@ class Http {
         } else if ($contentType == 'application/json' && $method != 'GET' && $method != 'DELETE') {
             $json = json_encode($json);
         } else if (is_array($json)) {
-          $json = http_build_query($json);
+            $json = http_build_query($json);
         }
 
         if ($method == 'POST') {

--- a/src/Zendesk/API/Search.php
+++ b/src/Zendesk/API/Search.php
@@ -24,7 +24,7 @@ class Search extends ClientAbstract {
             throw new MissingParametersException(__METHOD__, array('query'));
         }
         $endPoint = Http::prepare('search.json', null, $params);
-        $response = Http::send($this->client, $endPoint, $params, 'GET');
+        $response = Http::send($this->client, $endPoint, 'query=' . $params['query'], 'GET', 'application/json', FALSE);
         if ((!is_object($response)) || ($this->client->getDebug()->lastResponseCode != 200)) {
             throw new ResponseException(__METHOD__);
         }

--- a/tests/Zendesk/API/Tests/SearchTest.php
+++ b/tests/Zendesk/API/Tests/SearchTest.php
@@ -42,10 +42,20 @@ class SearchTest extends \PHPUnit_Framework_TestCase {
      * @depends testAuthToken
      */
     public function testSearch() {
-        $results = $this->client->performSearch(array('query' => 'hello'));
+        $results = $this->client->search(array('query' => 'hello'));
         $this->assertEquals(is_object($results), true, 'Should return an object');
         $this->assertEquals(is_array($results->results), true, 'Should return an object containing an array called "results"');
         $this->assertGreaterThan(0, $results->results[0]->id, 'Returns a non-numeric id for results[0]');
+        $this->assertEquals($this->client->getDebug()->lastResponseCode, '200', 'Does not return HTTP code 200');
+    }
+
+    /**
+     * @depends testAuthToken
+     */
+    public function testComplexSearch() {
+        $results = $this->client->search(array('query' => 'status<solved+type:ticket'));
+        $this->assertEquals(is_object($results), true, 'Should return an object');
+        $this->assertEquals(is_array($results->results), true, 'Should return an object containing an array called "results"');
         $this->assertEquals($this->client->getDebug()->lastResponseCode, '200', 'Does not return HTTP code 200');
     }
 


### PR DESCRIPTION
So trying this code:
```
$zendesk = new ZendeskAPI('acquia', $zendesk_creds['email']);
$zendesk->setAuth('token', $zendesk_creds['token']);
$query = 'status<solved+type:ticket';
$params = array(
  'query' => $query
);
$search = $zendesk->search($params);
```
throws this error:
```
Invalid search: Invalid status type: solved+type:ticket
```
It looks like the http_build_query call in HTTP::send is encoding the query in a way the API isn't expecting. 

I've added code to check if $json is an array in HTTP::send, and only in that case will http_build_query be called. This allows functions that call HTTP::send encode the GET params themselves, which I used to fix the issue with Search::performSearch.

It should be noted that the actual query I'm making is quite long, and this is the only way I've gotten it to work with the API.

Please let me know if anything needs to be changed in the PR.