### PR TITLE
Attachment file name should be URL encoded when added as a URL param

### DIFF
--- a/src/Zendesk/API/Attachments.php
+++ b/src/Zendesk/API/Attachments.php
@@ -42,7 +42,7 @@ class Attachments extends ClientAbstract {
 	        $params['name'] = $params['file'];
         } 
         
-        $endPoint = Http::prepare('uploads.json?filename='.$params['name'].(isset($params['optional_token']) ? '&token='.$params['optional_token'] : ''));
+        $endPoint = Http::prepare('uploads.json?filename='.urlencode($params['name']).(isset($params['optional_token']) ? '&token='.$params['optional_token'] : ''));
         $response = Http::send($this->client, $endPoint, array('filename' => $params['file']), 'POST', (isset($params['type']) ? $params['type'] : 'application/binary'));
        if ((!is_object($response)) || ($this->client->getDebug()->lastResponseCode != 201)) {
             throw new ResponseException(__METHOD__);

--- a/tests/Zendesk/API/Tests/AttachmentsTest.php
+++ b/tests/Zendesk/API/Tests/AttachmentsTest.php
@@ -38,7 +38,7 @@ class AttachmentsTest extends \PHPUnit_Framework_TestCase {
         $attachment = $this->client->attachments()->upload(array(
             'file' => getcwd().'/tests/assets/UK.png',
             'type' => 'image/png',
-            'name' => 'UK.png'
+            'name' => 'UK test non-alpha chars.png'
         ));
         $this->assertEquals($this->client->getDebug()->lastResponseCode, '201', 'Does not return HTTP code 201');
         $this->assertEquals(is_object($attachment), true, 'Should return an object');


### PR DESCRIPTION
If an attachment name contains non-alphanumeric chars, they need to be URL encoded. Zendesk will otherwise return HTTP 400 Bad Request
