### PR TITLE
Bad Exception fixed

### DIFF
--- a/src/Zendesk/API/VoiceAgents.php
+++ b/src/Zendesk/API/VoiceAgents.php
@@ -49,7 +49,7 @@ class VoiceAgents extends ClientAbstract {
         }
         $endPoint = Http::prepare('channels/voice/agents/'.$params['agent_id'].'/tickets/'.$params['ticket_id'].'/display.json');
         $response = Http::send($this->client, $endPoint, null, 'POST');
-        if ((!is_object($response)) || ($this->client->getDebug()->lastResponseCode != 200)) {
+        if (($this->client->getDebug()->lastResponseCode != 200)) {
             throw new ResponseException(__METHOD__);
         }
         $this->client->setSideload(null);


### PR DESCRIPTION
When you call: 

```
$client->voice()->agents()->openTicket(['agent_id' => $agent_id,'ticket_id' => $ticket_id]); 
```

The API calls the channels/voice/agents/'.$params['agent_id'].'/tickets/'.$params['ticket_id'].'/display.json endpoint successfully and returns a 200 code, but beacouse it returns no data, the method was throwing an ResponseException.
