### PR TITLE
Support uploading files directly from a string in memory by setting a `body` parameter

### DIFF
--- a/src/Zendesk/API/Attachments.php
+++ b/src/Zendesk/API/Attachments.php
@@ -52,6 +52,40 @@ class Attachments extends ClientAbstract {
     }
 
     /**
+     * Upload an attachment from a buffer in memory
+     * $params must include:
+     *    'body' - the raw file data to upload
+     *    'name' - the filename
+     *    'type' - the MIME type of the file
+     * Optional:
+     *    'optional_token' - an existing token
+     *
+     * @param array $params
+     *
+     * @throws CustomException
+     * @throws MissingParametersException
+     * @throws ResponseException
+     * @throws \Exception
+     *
+     * @return mixed
+     */
+    public function uploadWithBody(array $params) {
+        if(!$this->hasKeys($params, array('body'))) {
+            throw new MissingParametersException(__METHOD__, array('body'));
+        }
+        if(!$params['name']) {
+            throw new MissingParametersException(__METHOD__, array('name'));
+        }
+        $endPoint = Http::prepare('uploads.json?filename='.$params['name'].(isset($params['optional_token']) ? '&token='.$params['optional_token'] : ''));
+        $response = Http::send($this->client, $endPoint, array('body' => $params['body']), 'POST', (isset($params['type']) ? $params['type'] : 'application/binary'));
+        if ((!is_object($response)) || ($this->client->getDebug()->lastResponseCode != 201)) {
+            throw new ResponseException(__METHOD__);
+        }
+        $this->client->setSideload(null);
+        return $response;
+    }
+
+    /**
      * Delete one or more attachments by token or id
      * $params must include one of these:
      *        'token' - the token given to you after the original upload

--- a/src/Zendesk/API/Http.php
+++ b/src/Zendesk/API/Http.php
@@ -66,15 +66,21 @@ class Http {
             $curl = curl_init($url);
             curl_setopt($curl, CURLOPT_POST, true);
             curl_setopt($curl, CURLOPT_POSTFIELDS, $json);
-            if (is_array($json) && (isset($json['filename']) || isset($json['uploaded_data']))) {
-                $filename = isset($json['filename']) ? $json['filename'] : $json['uploaded_data'];
-                $file     = fopen($filename, 'r');
-                $size     = filesize($filename);
-                $fileData = fread($file, $size);
-                curl_setopt($curl, CURLOPT_POSTFIELDS, $fileData);
-                curl_setopt($curl, CURLOPT_INFILE, $file);
-                curl_setopt($curl, CURLOPT_INFILESIZE, $size);
-                curl_setopt($curl, CURLOPT_HTTPHEADER, array('Content-type: application/binary'));
+            if (is_array($json)) {
+                if (isset($json['body'])) {
+                    curl_setopt($curl, CURLOPT_POSTFIELDS, $json['body']);
+                    curl_setopt($curl, CURLOPT_INFILESIZE, strlen($json['body']));
+                } else if (isset($json['uploaded_data'])) {
+                    curl_setopt($curl, CURLOPT_POSTFIELDS, $json['uploaded_data']);
+                } else if (isset($json['filename'])) {
+                    $filename = $json['filename'];
+                    $file     = fopen($filename, 'r');
+                    $size     = filesize($filename);
+                    $fileData = fread($file, $size);
+                    curl_setopt($curl, CURLOPT_POSTFIELDS, $fileData);
+                    curl_setopt($curl, CURLOPT_INFILE, $file);
+                    curl_setopt($curl, CURLOPT_INFILESIZE, $size);
+                }
             }
         } else if ($method == 'PUT') {
             $curl = curl_init($url);

--- a/tests/Zendesk/API/Tests/AttachmentsTest.php
+++ b/tests/Zendesk/API/Tests/AttachmentsTest.php
@@ -63,6 +63,27 @@ class AttachmentsTest extends \PHPUnit_Framework_TestCase {
         $this->assertEquals($this->client->getDebug()->lastResponseCode, '200', 'Does not return HTTP code 200');
     }
 
+    /**
+     * @depends testAuthToken
+     */
+    public function testUploadAttachmentBody() {
+        $body = file_get_contents(getcwd().'/tests/assets/UK.png');
+        $attachment = $this->client->attachments()->uploadWithBody(array(
+            'body' => $body,
+            'type' => 'image/png',
+            'name' => 'UK.png'
+        ));
+        $this->assertEquals($this->client->getDebug()->lastResponseCode, '201', 'Does not return HTTP code 201');
+        $this->assertEquals(is_object($attachment), true, 'Should return an object');
+        $this->assertEquals(is_object($attachment->upload), true, 'Should return an object called "upload"');
+        $this->assertEquals(($attachment->upload->token != ''), true, 'Should return a token');
+        $this->assertEquals(is_array($attachment->upload->attachments), true, 'Should return an array called "upload->attachments"');
+        $this->assertGreaterThan(0, $attachment->upload->attachments[0]->id, 'Returns a non-numeric id for upload->attachments[0]');
+        $this->assertEquals(strlen($body), $attachment->upload->attachments[0]->size, 'returns a file with correct filesize');
+        $stack = array($attachment);
+        return $stack;
+    }
+
 }
 
 ?>


### PR DESCRIPTION
A Zendesk customer would like to use zendesk_api_client_php to upload files directly from a string in memory, rather than having to upload from a file on disk.

Reading through the code for the `Http::send` method in https://github.com/zendesk/zendesk_api_client_php/blob/master/src/Zendesk/API/Http.php, it does not appear that this is possible, or not possible cleanly. We always attempt to `fopen` and `fread` a file.

This PR adds support for a `body` parameter which contains the raw data to upload. When `body` is present, we don't attempt to read any file off disk, and put the contents of `body` into `CURLOPT_POSTFIELDS` without setting any other curl parameters like `CURLOPT_INFILE`.

I've changed `Http::send` to check for three cases:
- If `body` is set, use that as the raw POST request body.
- If `uploaded_data` is set, more or less do the same thing, but don't try to determine the size. This is more for legacy; this was used in a couple places in our code and others might depend on it. We put the value here into `CURLOPT_POSTFIELDS`.
- If `filename` is present, open and read the file off disk and upload it.

Added an `uploadWithBody` method to the `Attachments` class, contributed by Bryan Nobuhara @ Tumblr. Added a test for same.

/cc @dpawluk @rtatsumi @maximeprades 
### Todo
- Add test for `uploadWithBody`
### References
- Support ticket: https://support.zendesk.com/agent/tickets/916448
### Risks
- None
