### PR TITLE
Attachment filenames urlencoded

### DIFF
--- a/src/Zendesk/API/Attachments.php
+++ b/src/Zendesk/API/Attachments.php
@@ -42,7 +42,7 @@ class Attachments extends ClientAbstract {
 	        $params['name'] = $params['file'];
         } 
         
-        $endPoint = Http::prepare('uploads.json?filename='.$params['name'].(isset($params['optional_token']) ? '&token='.$params['optional_token'] : ''));
+        $endPoint = Http::prepare('uploads.json?filename='.urlencode($params['name']).(isset($params['optional_token']) ? '&token='.$params['optional_token'] : ''));
         $response = Http::send($this->client, $endPoint, array('filename' => $params['file']), 'POST', (isset($params['type']) ? $params['type'] : 'application/binary'));
        if ((!is_object($response)) || ($this->client->getDebug()->lastResponseCode != 201)) {
             throw new ResponseException(__METHOD__);

--- a/src/Zendesk/API/Http.php
+++ b/src/Zendesk/API/Http.php
@@ -9,6 +9,20 @@ namespace Zendesk\API;
 class Http {
 
     /**
+     * The number of retry attempts when rate limiting encountered
+     * @var integer
+     */
+    private static $rateLimitRetryAttempts = 10;
+
+    /**
+     * Sets the number of attempts when rate limiting encountered
+     * @param int $n The number of attempts
+     */
+    public static function setRateLimitRetryAttempts($n) {
+        self::$rateLimitRetryAttempts = (int) $n;
+    }
+
+    /**
      * Prepares an endpoint URL with optional side-loading
      *
      * @param string $endPoint
@@ -109,7 +123,9 @@ class Http {
         curl_setopt($curl, CURLOPT_VERBOSE, true);
         curl_setopt($curl, CURLOPT_FOLLOWLOCATION, true);
         curl_setopt($curl, CURLOPT_MAXREDIRS, 3);
-        $response = curl_exec($curl);
+        
+        $response = self::makeRateLimitProtectedCall($curl);
+
         if ($response === false) {
             throw new \Exception('No response from curl_exec in ' . __METHOD__);
         }
@@ -163,7 +179,9 @@ class Http {
         curl_setopt($curl, CURLOPT_VERBOSE, true);
         curl_setopt($curl, CURLOPT_FOLLOWLOCATION, true);
         curl_setopt($curl, CURLOPT_MAXREDIRS, 3);
-        $response = curl_exec($curl);
+
+        $response = self::makeRateLimitProtectedCall($curl);
+
         if ($response === false) {
             throw new \Exception('No response from curl_exec in '.__METHOD__);
         }
@@ -178,6 +196,41 @@ class Http {
 
         return json_decode($responseBody);
 
+    }
+
+    /**
+     * Calls cURL until a response is not rate-limited, or has attempted to do so as many times as
+     * specified by self::$rateLimitRetryAttempts.
+     *
+     * @throws \Exception If more than the specified number of attempts to send the request fail
+     * 
+     * @param  resource $curl The cURL handle to execute
+     * @return string         The response from the server
+     */
+    private static function makeRateLimitProtectedCall($curl) {
+        $sanity = self::$rateLimitRetryAttempts;
+
+        do {
+            $response = curl_exec($curl);
+            $code = curl_getinfo($curl, CURLINFO_HTTP_CODE);
+
+            if ($code == 429) {
+                if (!preg_match('/Retry-After: (\d+)/', $response, $match)) {
+                    $delay = 5;
+                } else {
+                    $delay = (int) $match[1];
+                }
+
+                sleep($delay);
+            }
+        } while (($code == 429) && $sanity--);
+
+        if ($code == 429) {
+            $msg = sprintf('Rate-limiting still in effect after %d attempts', self::$rateLimitRetryAttempts);
+            throw new \Exception($msg);
+        }
+
+        return $response;
     }
 
 }

--- a/src/Zendesk/API/Http.php
+++ b/src/Zendesk/API/Http.php
@@ -203,6 +203,7 @@ class Http {
      * specified by self::$rateLimitRetryAttempts.
      *
      * @throws \Exception If more than the specified number of attempts to send the request fail
+     * @throws \Exception If cURL experiences an error
      * 
      * @param  resource $curl The cURL handle to execute
      * @return string         The response from the server
@@ -212,6 +213,12 @@ class Http {
 
         do {
             $response = curl_exec($curl);
+
+            if ($errNo = curl_errno($curl)) {
+                $errMsg = curl_errno($curl);
+                throw new \Exception(sprintf('cURL error %d: %s', $errNo, $errMsg));
+            }
+
             $code = curl_getinfo($curl, CURLINFO_HTTP_CODE);
 
             if ($code == 429) {


### PR DESCRIPTION
I added a call to urlencode() on the $params['name'] parameter to allow filenames with spaces etc. to be uploaded to Zendesk.