### PR TITLE
Add access to SatisfactionRatings API. Add satisfaction filter params.

### DIFF
--- a/src/Zendesk/API/Client.php
+++ b/src/Zendesk/API/Client.php
@@ -39,6 +39,7 @@ namespace Zendesk\API;
  * @method OAuthTokens oauthTokens()
  * @method OrganizationFields organizationFields()
  * @method Organizations organizations()
+ * @method SatisfactionRatings satisfactionRatings()
  * @method SharingAgreements sharingAgreements()
  * @method SuspendedTickets suspendedTickets()
  * @method Tags tags()
@@ -183,6 +184,10 @@ class Client {
      */
     protected $organizations;
     /**
+     * @var SatisfactionRatings
+     */
+    protected $satisfactionRatings;
+    /**
      * @var Search
      */
     protected $search;
@@ -254,6 +259,7 @@ class Client {
         $this->oauthTokens = new OAuthTokens($this);
         $this->organizationFields = new OrganizationFields($this);
         $this->organizations = new Organizations($this);
+        $this->satisfactionRatings = new SatisfactionRatings($this);
         $this->search = new Search($this);
         $this->sharingAgreements = new SharingAgreements($this);
         $this->suspendedTickets = new SuspendedTickets($this);

--- a/src/Zendesk/API/SatisfactionRatings.php
+++ b/src/Zendesk/API/SatisfactionRatings.php
@@ -27,7 +27,12 @@ class SatisfactionRatings extends ClientAbstract {
             $this->client->tickets()->setLastId(null);
         }
         $endPoint = Http::prepare('satisfaction_ratings.json', null, $params);
-        $response = Http::send($this->client, $endPoint);
+        $allowedFilter = array('score', 'start_time', 'end_time');
+        $response = Http::send(
+            $this->client,
+            $endPoint,
+            array_intersect_key($params, array_flip($allowedFilter))
+        );
         if ((!is_object($response)) || ($this->client->getDebug()->lastResponseCode != 200)) {
             throw new ResponseException(__METHOD__);
         }


### PR DESCRIPTION
New method `Client::satisfactionRatings()` provides access to the SatisfactionRatings API class, which wasn't publicly available.

`SatisfactionRatings::findAll()` now accepts the [documented filter params](https://developer.zendesk.com/rest_api/docs/core/satisfaction_ratings#filter).