### PR TITLE
Fix attachment upload

### DIFF
--- a/src/Zendesk/API/Http.php
+++ b/src/Zendesk/API/Http.php
@@ -87,8 +87,7 @@ class Http {
                 $size = filesize($filename);
                 $fileData = fread($file, $size);
                 $json = $fileData;
-                $contentType = '';
-            }            
+            }
             $httpHeader[] = 'Content-Type: '.$contentType;
         } else {
             $contentType = '';


### PR DESCRIPTION
Content type was being reset on attachment upload where file type was passed to `Http::send()`
This causes the curl request response code of 500 if trying to send a file.