### PR TITLE
add incremental export feature

### DIFF
--- a/src/Zendesk/API/Organizations.php
+++ b/src/Zendesk/API/Organizations.php
@@ -238,6 +238,29 @@ class Organizations extends ClientAbstract {
         return $response;
     }
 
+    /**
+     * Incremental user updates with a supplied start_time. 
+     * 
+     * @link https://developer.zendesk.com/rest_api/docs/core/incremental_export
+     *
+     * @param array $params
+     *  int start_time Timestamp indicating the minimum updated_at of the users to retrieve.
+     *  
+     * @param boolean $sample Retrieve just a sample (for debugging/testing).
+     *
+     * @throws MissingParametersException
+     * @throws ResponseException
+     * @throws \Exception
+     * 
+     * @todo DRY up this copy of {@see Tickets#incremental}
+     *
+     * @return mixed
+     */
+    public function incremental(array $params, $sample = false)
+    {
+        return Tickets::incremental($params, $sample);
+    }
+
     /*
      * Syntactic sugar methods:
      * Handy aliases:

--- a/src/Zendesk/API/Users.php
+++ b/src/Zendesk/API/Users.php
@@ -410,6 +410,29 @@ class Users extends ClientAbstract {
         return $response;
     }
 
+    /**
+     * Incremental user updates with a supplied start_time. 
+     * 
+     * @link https://developer.zendesk.com/rest_api/docs/core/incremental_export
+     *
+     * @param array $params
+     *  int start_time Timestamp indicating the minimum updated_at of the users to retrieve.
+     *  
+     * @param boolean $sample Retrieve just a sample (for debugging/testing).
+     *
+     * @throws MissingParametersException
+     * @throws ResponseException
+     * @throws \Exception
+     * 
+     * @todo DRY up this copy of {@see Tickets#incremental}
+     *
+     * @return mixed
+     */
+    public function incremental(array $params, $sample = false)
+    {
+        return Tickets::incremental($params, $sample);
+    }
+
     /*
      * Syntactic sugar methods:
      * Handy aliases:

--- a/tests/Zendesk/API/LiveTests/OrganizationsTest.php
+++ b/tests/Zendesk/API/LiveTests/OrganizationsTest.php
@@ -80,7 +80,7 @@ class OrganizationsTest extends BasicTest {
     }
 
     public function testIncremental() {
-        $organizations = $this->client->organizations()->export(array('start_time' => '1332034771'));
+        $organizations = $this->client->organizations()->incremental(array('start_time' => '1332034771'));
         $this->assertEquals(is_object($organizations), true, 'Should return an object');
         $this->assertEquals(is_array($organizations->organizations), true, 'Should return an object containing an array called "organizations"');
         $this->assertEquals($this->client->getDebug()->lastResponseCode, '200', 'Does not return HTTP code 200');

--- a/tests/Zendesk/API/LiveTests/OrganizationsTest.php
+++ b/tests/Zendesk/API/LiveTests/OrganizationsTest.php
@@ -79,6 +79,13 @@ class OrganizationsTest extends BasicTest {
         $this->assertEquals($this->client->getDebug()->lastResponseCode, '200', 'Does not return HTTP code 200');
     }
 
+    public function testIncremental() {
+        $organizations = $this->client->organizations()->export(array('start_time' => '1332034771'));
+        $this->assertEquals(is_object($organizations), true, 'Should return an object');
+        $this->assertEquals(is_array($organizations->organizations), true, 'Should return an object containing an array called "organizations"');
+        $this->assertEquals($this->client->getDebug()->lastResponseCode, '200', 'Does not return HTTP code 200');
+    }
+
     public function tearDown() {
         $this->assertGreaterThan(0, $this->id, 'Cannot find an organization id to test with. Did setUp fail?');
         $organization = $this->client->organization($this->id)->delete();

--- a/tests/Zendesk/API/LiveTests/TicketsTest.php
+++ b/tests/Zendesk/API/LiveTests/TicketsTest.php
@@ -170,6 +170,13 @@ class TicketsTest extends BasicTest {
         $this->assertEquals($this->client->getDebug()->lastResponseCode, '200', 'Does not return HTTP code 200');
     }
 
+    public function testIncremental() {
+        $tickets = $this->client->tickets()->export(array('start_time' => '1332034771'));
+        $this->assertEquals(is_object($tickets), true, 'Should return an object');
+        $this->assertEquals(is_array($tickets->tickets), true, 'Should return an object containing an array called "tickets"');
+        $this->assertEquals($this->client->getDebug()->lastResponseCode, '200', 'Does not return HTTP code 200');
+    }
+
     public function testCreateFromTweet() {
         $this->markTestSkipped(
             'Skipped for now because it requires a new (unique) twitter id for each test'

--- a/tests/Zendesk/API/LiveTests/TicketsTest.php
+++ b/tests/Zendesk/API/LiveTests/TicketsTest.php
@@ -171,7 +171,7 @@ class TicketsTest extends BasicTest {
     }
 
     public function testIncremental() {
-        $tickets = $this->client->tickets()->export(array('start_time' => '1332034771'));
+        $tickets = $this->client->tickets()->incremental(array('start_time' => '1332034771'));
         $this->assertEquals(is_object($tickets), true, 'Should return an object');
         $this->assertEquals(is_array($tickets->tickets), true, 'Should return an object containing an array called "tickets"');
         $this->assertEquals($this->client->getDebug()->lastResponseCode, '200', 'Does not return HTTP code 200');

--- a/tests/Zendesk/API/LiveTests/UsersTest.php
+++ b/tests/Zendesk/API/LiveTests/UsersTest.php
@@ -239,6 +239,13 @@ class UsersTest extends BasicTest {
         $this->assertEquals($this->client->getDebug()->lastResponseCode, '200', 'Does not return HTTP code 200');
     }
 
+    public function testIncremental() {
+        $users = $this->client->users()->incremental(array('start_time' => '1332034771'));
+        $this->assertEquals(is_object($users), true, 'Should return an object');
+        $this->assertEquals(is_array($users->users), true, 'Should return an object containing an array called "users"');
+        $this->assertEquals($this->client->getDebug()->lastResponseCode, '200', 'Does not return HTTP code 200');
+    }
+
     public function tearDown() {
         $this->client->ticket($this->ticket_id)->delete();
 


### PR DESCRIPTION
Adds support for [incremental exports](https://developer.zendesk.com/rest_api/docs/core/incremental_export) for tickets, users and organizations. Which is something different from the current /export implemented for Tickets.

also see issue #58