### PR TITLE
Adds ability to use Debug class as a string

### DIFF
--- a/src/Zendesk/API/Debug.php
+++ b/src/Zendesk/API/Debug.php
@@ -30,8 +30,12 @@ class Debug {
      */
     public function __toString()
     {
+    	$lastError = $this->lastResponseError;
+    	if (! is_string($lastError)) {
+    		$lastError = json_encode($lastError);
+    	} 
     	$output = 'LastResponseCode: ' . $this->lastResponseCode
-    		. ', LastResponseError: ' . $this->lastResponseError
+    		. ', LastResponseError: ' . $lastError 
     		. ', LastResponseHeaders: ' . $this->lastResponseHeaders
     		. ', LastRequestHeaders: ' . $this->lastRequestHeaders;
     	

--- a/src/Zendesk/API/Debug.php
+++ b/src/Zendesk/API/Debug.php
@@ -24,5 +24,17 @@ class Debug {
      * @var mixed
      */
     public $lastResponseError;
-
+    
+    /**
+     * @return string 
+     */
+    public function __toString()
+    {
+    	$output = 'LastResponseCode: ' . $this->lastResponseCode
+    		. ', LastResponseError: ' . $this->lastResponseError
+    		. ', LastResponseHeaders: ' . $this->lastResponseHeaders
+    		. ', LastRequestHeaders: ' . $this->lastRequestHeaders;
+    	
+    	return $output;
+    }
 }


### PR DESCRIPTION
This is useful for logging. Conversion happens for lastResponseError if needed since all the other ones will be strings as option is passed in during curl_getinfo() calls. 