### PR TITLE
Add method for `users/show_many.json?external_ids=...`

### DIFF
--- a/src/Zendesk/API/Users.php
+++ b/src/Zendesk/API/Users.php
@@ -78,6 +78,38 @@ class Users extends ClientAbstract {
     }
 
     /**
+     * Find users by ids or external_ids
+     *
+     * @param array $params
+     *
+     * @throws ResponseException
+     * @throws \Exception
+     *
+     * @return mixed
+     */
+    public function showMany(array $params = array()) {
+        if (isset($params['ids']) && isset($params['external_ids'])) {
+            throw new \Exception('Only one parameter of ids or external_ids is allowed');
+        } elseif (!isset($params['ids']) && !isset($params['external_ids'])) {
+            throw new \Exception('Missing parameters ids or external_ids');
+        } elseif (isset($params['ids']) && is_array($params['ids'])) {
+            $path = 'users/show_many.json?ids='.implode(',', $params['ids']);
+        } elseif (isset($params['external_ids']) && is_array($params['external_ids'])) {
+            $path = 'users/show_many.json?external_ids='.implode(',', $params['external_ids']);
+        } else {
+            throw new \Exception('Parameters ids or external_ids must be arrays');
+        }
+
+        $endPoint = Http::prepare($path, $this->client->getSideload($params));
+        $response = Http::send($this->client, $endPoint);
+        if ((!is_object($response)) || ($this->client->getDebug()->lastResponseCode != 200)) {
+            throw new ResponseException(__METHOD__);
+        }
+        $this->client->setSideload(null);
+        return $response;
+    }
+
+    /**
      * Get related information about the user
      *
      * @param array $params

--- a/tests/Zendesk/API/LiveTests/UsersTest.php
+++ b/tests/Zendesk/API/LiveTests/UsersTest.php
@@ -17,7 +17,7 @@ class UsersTest extends BasicTest {
         parent::authTokenTest();
     }
 
-    protected $id, $id_s, $ticket_id, $number;
+    protected $id, $id_s, $ticket_id, $number, $external_id, $external_id_s;
 
     public function setUp() {
         $this->number = strval(time());
@@ -26,9 +26,11 @@ class UsersTest extends BasicTest {
             'name' => 'Roger Wilco'.$this->number,
             'email' => 'roge'.$this->number.'@example.org',
             'role' => 'agent',
-            'verified' => true
+            'verified' => true,
+            'external_id' => '3000'
         ));
         $this->id = $user->user->id;
+        $this->external_id = $user->user->external_id;
 
         $testTicket = array(
             'subject' => 'User Test',
@@ -46,9 +48,11 @@ class UsersTest extends BasicTest {
             'name' => 'Roger Wilco2'.$this->number,
             'email' => 'roge2'.$this->number.'@example.org',
             'role' => 'agent',
-            'verified' => true
+            'verified' => true,
+            'external_id' => '3001'
         ));
         $this->id_s = $user_s->user->id;
+        $this->external_id_s = $user_s->user->external_id;
 
         $this->assertEquals(is_object($user), true, 'Should return an object');
         $this->assertEquals(is_object($user->user), true, 'Should return an object called "user"');
@@ -76,6 +80,20 @@ class UsersTest extends BasicTest {
 
     public function testFindMultiple() {
         $users = $this->client->users(array($this->id, $this->id_s))->find();
+        $this->assertEquals(is_object($users), true, 'Should return an object');
+        $this->assertEquals(is_array($users->users), true, 'Should return an array called "users"');
+        $this->assertEquals(is_object($users->users[0]), true, 'Should return an object as first "users" array element');
+    }
+
+    public function testShowManyUsingIds() {
+        $users = $this->client->users()->showMany(array('ids' => array($this->id, $this->id_s)));
+        $this->assertEquals(is_object($users), true, 'Should return an object');
+        $this->assertEquals(is_array($users->users), true, 'Should return an array called "users"');
+        $this->assertEquals(is_object($users->users[0]), true, 'Should return an object as first "users" array element');
+    }
+
+    public function testShowManyUsingExternalIds() {
+        $users = $this->client->users()->showMany(array('external_ids' => array($this->external_id, $this->external_id_s)));
         $this->assertEquals(is_object($users), true, 'Should return an object');
         $this->assertEquals(is_array($users->users), true, 'Should return an array called "users"');
         $this->assertEquals(is_object($users->users[0]), true, 'Should return an object as first "users" array element');


### PR DESCRIPTION
The current `find` method does not allow using the `external_ids` param as documented at https://developer.zendesk.com/rest_api/docs/core/users#show-many-users

This adds a new method specifically for the `show_many` endpoint.