### PR TITLE
Reformat code to match PSR-2

### DIFF
--- a/index.php
+++ b/index.php
@@ -13,21 +13,21 @@ $client->setAuth('token', $token); // set either token or password
 
 // Get all tickets
 $tickets = $client->tickets()->findAll();
-print_r ($tickets);
+print_r($tickets);
 
 // Create a new ticket
-$newTicket = $client->tickets()->create(array (
-	'subject' => 'The quick brown fox jumps over the lazy dog',
-	'comment' => array (
-		'body' => 'Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.'
-	),
-	'priority' => 'normal'
+$newTicket = $client->tickets()->create(array(
+    'subject' => 'The quick brown fox jumps over the lazy dog',
+    'comment' => array(
+        'body' => 'Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.'
+    ),
+    'priority' => 'normal'
 ));
-print_r ($newTicket);
+print_r($newTicket);
 
 // Update multiple tickets
-$client->ticket(array (123, 456))->update(array (
-	'status' => 'urgent'
+$client->ticket(array(123, 456))->update(array(
+    'status' => 'urgent'
 ));
 
 // Delete a ticket

--- a/oauth.php
+++ b/oauth.php
@@ -7,20 +7,20 @@ use Zendesk\API\Http;
 $subdomain = "subdomain";       // Your Zendesk subdomain
 $username = "username";         // Your Zendesk login
 $oAuthId = "oauth_id";          // The value you entered into the OAuth 'Unique Identifier' field
-$oAuthSecret = "oauth_secret";	// The OAuth secret given to you by Zendesk
+$oAuthSecret = "oauth_secret";    // The OAuth secret given to you by Zendesk
 
 $client = new ZendeskAPI($subdomain, $username);
 if ($_REQUEST['code']) {
-	$response = Http::oauth($client, $_REQUEST['code'], $oAuthId, $oAuthSecret);
-	if (($client->getDebug()->lastResponseCode == 200) && ($response->access_token)) {
-		echo "<h1>Success!</h1>";
-		echo "<p>Your OAuth token is: ".$response->access_token."</p>";
-		echo "<p>Use this code before any other API call:</p>";
-		echo "<code>&lt;?<br />\$client = new ZendeskAPI(\$subdomain, \$username);<br />\$client->setAuth('oauth_token', '".$response->access_token."');<br />?&gt;</code>";
-	} else {
-		echo "<h1>Error!</h1>";
-		echo "<p>We couldn't get an access token for you. Please check your credentials and try again.</p>";
-	}
+    $response = Http::oauth($client, $_REQUEST['code'], $oAuthId, $oAuthSecret);
+    if (($client->getDebug()->lastResponseCode == 200) && ($response->access_token)) {
+        echo "<h1>Success!</h1>";
+        echo "<p>Your OAuth token is: " . $response->access_token . "</p>";
+        echo "<p>Use this code before any other API call:</p>";
+        echo "<code>&lt;?<br />\$client = new ZendeskAPI(\$subdomain, \$username);<br />\$client->setAuth('oauth_token', '" . $response->access_token . "');<br />?&gt;</code>";
+    } else {
+        echo "<h1>Error!</h1>";
+        echo "<p>We couldn't get an access token for you. Please check your credentials and try again.</p>";
+    }
 } else {
-	echo "<a href=\"https://".$subdomain.".zendesk.com/oauth/authorizations/new?response_type=code&redirect_uri=".($_SERVER['HTTPS'] ? 'https://' : 'http://').$_SERVER['HTTP_HOST'].$_SERVER['PHP_SELF']."&client_id=".$oAuthId."&scope=read%20write\">Click to request an OAuth token</a>";
+    echo "<a href=\"https://" . $subdomain . ".zendesk.com/oauth/authorizations/new?response_type=code&redirect_uri=" . ($_SERVER['HTTPS'] ? 'https://' : 'http://') . $_SERVER['HTTP_HOST'] . $_SERVER['PHP_SELF'] . "&client_id=" . $oAuthId . "&scope=read%20write\">Click to request an OAuth token</a>";
 }

--- a/src/Zendesk/API/ActivityStream.php
+++ b/src/Zendesk/API/ActivityStream.php
@@ -6,7 +6,8 @@ namespace Zendesk\API;
  * The ActivityStream class exposes methods for retrieving settings parameters
  * @package Zendesk\API
  */
-class ActivityStream extends ClientAbstract {
+class ActivityStream extends ClientAbstract
+{
 
     const OBJ_NAME = 'activity';
     const OBJ_NAME_PLURAL = 'activities';
@@ -21,13 +22,15 @@ class ActivityStream extends ClientAbstract {
      *
      * @return mixed
      */
-    public function findAll(array $params = array ()) {
+    public function findAll(array $params = array())
+    {
         $endPoint = Http::prepare('activities.json', null, $params);
         $response = Http::send($this->client, $endPoint);
         if ((!is_object($response)) || ($this->client->getDebug()->lastResponseCode != 200)) {
             throw new ResponseException(__METHOD__);
         }
         $this->client->setSideload(null);
+
         return $response;
     }
 
@@ -42,20 +45,22 @@ class ActivityStream extends ClientAbstract {
      *
      * @return mixed
      */
-    public function find(array $params = array()) {
-        if($this->lastId != null) {
+    public function find(array $params = array())
+    {
+        if ($this->lastId != null) {
             $params['id'] = $this->lastId;
             $this->lastId = null;
         }
-        if(!$this->hasKeys($params, array('id'))) {
+        if (!$this->hasKeys($params, array('id'))) {
             throw new MissingParametersException(__METHOD__, array('id'));
         }
-        $endPoint = Http::prepare('activities/'.$params['id'].'.json');
+        $endPoint = Http::prepare('activities/' . $params['id'] . '.json');
         $response = Http::send($this->client, $endPoint);
         if ((!is_object($response)) || ($this->client->getDebug()->lastResponseCode != 200)) {
             throw new ResponseException(__METHOD__);
         }
         $this->client->setSideload(null);
+
         return $response;
     }
 

--- a/src/Zendesk/API/AppInstallations.php
+++ b/src/Zendesk/API/AppInstallations.php
@@ -6,7 +6,8 @@ namespace Zendesk\API;
  * The AppInstallations class exposes app installation methods
  * @package Zendesk\API
  */
-class AppInstallations extends ClientAbstract {
+class AppInstallations extends ClientAbstract
+{
 
     const OBJ_NAME = 'installation';
     const OBJ_NAME_PLURAL = 'installations';
@@ -21,13 +22,16 @@ class AppInstallations extends ClientAbstract {
      *
      * @return mixed
      */
-    public function findAll(array $params = array()) {
-        $endPoint = Http::prepare('apps/installations.json'.(isset($params['include']) ? '?include='.$params['include'] : ''), null, $params);
+    public function findAll(array $params = array())
+    {
+        $endPoint = Http::prepare('apps/installations.json' . (isset($params['include']) ? '?include=' . $params['include'] : ''),
+            null, $params);
         $response = Http::send($this->client, $endPoint);
         if ((!is_object($response)) || ($this->client->getDebug()->lastResponseCode != 200)) {
             throw new ResponseException(__METHOD__);
         }
         $this->client->setSideload(null);
+
         return $response;
     }
 
@@ -42,20 +46,22 @@ class AppInstallations extends ClientAbstract {
      *
      * @return mixed
      */
-    public function update(array $params) {
-        if($this->lastId != null) {
+    public function update(array $params)
+    {
+        if ($this->lastId != null) {
             $params['id'] = $this->lastId;
             $this->lastId = null;
         }
-        if(!$this->hasKeys($params, array('id'))) {
+        if (!$this->hasKeys($params, array('id'))) {
             throw new MissingParametersException(__METHOD__, array('id'));
         }
-        $endPoint = Http::prepare('apps/installations/'.$params['id'].'.json');
+        $endPoint = Http::prepare('apps/installations/' . $params['id'] . '.json');
         $response = Http::send($this->client, $endPoint, $params, 'PUT');
         if ((!is_object($response)) || ($this->client->getDebug()->lastResponseCode != 200)) {
             throw new ResponseException(__METHOD__);
         }
         $this->client->setSideload(null);
+
         return $response;
     }
 
@@ -70,21 +76,23 @@ class AppInstallations extends ClientAbstract {
      *
      * @return bool
      */
-    public function delete(array $params = array()) {
-        if($this->lastId != null) {
+    public function delete(array $params = array())
+    {
+        if ($this->lastId != null) {
             $params['id'] = $this->lastId;
             $this->lastId = null;
         }
-        if(!$this->hasKeys($params, array('id'))) {
+        if (!$this->hasKeys($params, array('id'))) {
             throw new MissingParametersException(__METHOD__, array('id'));
         }
         $id = $params['id'];
-        $endPoint = Http::prepare('apps/installations/'.$id.'.json');
+        $endPoint = Http::prepare('apps/installations/' . $id . '.json');
         $response = Http::send($this->client, $endPoint, null, 'DELETE');
         if ($this->client->getDebug()->lastResponseCode != 200) {
             throw new ResponseException(__METHOD__);
         }
         $this->client->setSideload(null);
+
         return true;
     }
 

--- a/src/Zendesk/API/Apps.php
+++ b/src/Zendesk/API/Apps.php
@@ -6,7 +6,8 @@ namespace Zendesk\API;
  * The Apps class exposes app management methods
  * @package Zendesk\API
  */
-class Apps extends ClientAbstract {
+class Apps extends ClientAbstract
+{
 
     /**
      * @var AppInstallations
@@ -16,7 +17,8 @@ class Apps extends ClientAbstract {
     /**
      * @param Client $client
      */
-     public function __construct(Client $client) {
+    public function __construct(Client $client)
+    {
         parent::__construct($client);
         $this->installations = new AppInstallations($client);
     }
@@ -32,8 +34,9 @@ class Apps extends ClientAbstract {
      *
      * @return mixed
      */
-    public function upload(array $params) {
-        if(!$this->hasKeys($params, array('file'))) {
+    public function upload(array $params)
+    {
+        if (!$this->hasKeys($params, array('file'))) {
             throw new MissingParametersException(__METHOD__, array('file'));
         }
         $endPoint = Http::prepare('apps/uploads.json');
@@ -42,6 +45,7 @@ class Apps extends ClientAbstract {
             throw new ResponseException(__METHOD__);
         }
         $this->client->setSideload(null);
+
         return $response;
     }
 
@@ -55,13 +59,15 @@ class Apps extends ClientAbstract {
      *
      * @return mixed
      */
-    public function create(array $params) {
+    public function create(array $params)
+    {
         $endPoint = Http::prepare('apps.json');
         $response = Http::send($this->client, $endPoint, $params, 'POST');
         if ((!is_object($response)) || ($this->client->getDebug()->lastResponseCode != 202)) {
             throw new ResponseException(__METHOD__);
         }
         $this->client->setSideload(null);
+
         return $response;
     }
 
@@ -75,16 +81,18 @@ class Apps extends ClientAbstract {
      *
      * @return mixed
      */
-    public function jobStatus(array $params) {
-        if(!$this->hasKeys($params, array('id'))) {
+    public function jobStatus(array $params)
+    {
+        if (!$this->hasKeys($params, array('id'))) {
             throw new MissingParametersException(__METHOD__, array('id'));
         }
-        $endPoint = Http::prepare('apps/job_statuses/'.$params['id'].'.json');
+        $endPoint = Http::prepare('apps/job_statuses/' . $params['id'] . '.json');
         $response = Http::send($this->client, $endPoint);
         if ((!is_object($response)) || ($this->client->getDebug()->lastResponseCode != 200)) {
             throw new ResponseException(__METHOD__);
         }
         $this->client->setSideload(null);
+
         return $response;
     }
 
@@ -99,20 +107,22 @@ class Apps extends ClientAbstract {
      *
      * @return mixed
      */
-    public function update(array $params) {
-        if($this->lastId != null) {
+    public function update(array $params)
+    {
+        if ($this->lastId != null) {
             $params['id'] = $this->lastId;
             $this->lastId = null;
         }
-        if(!$this->hasKeys($params, array('file', 'id'))) {
+        if (!$this->hasKeys($params, array('file', 'id'))) {
             throw new MissingParametersException(__METHOD__, array('file', 'id'));
         }
-        $endPoint = Http::prepare('apps/'.$params['id'].'.json');
+        $endPoint = Http::prepare('apps/' . $params['id'] . '.json');
         $response = Http::send($this->client, $endPoint, array('uploaded_data' => $params['file']), 'PUT');
         if ((!is_object($response)) || ($this->client->getDebug()->lastResponseCode != 200)) {
             throw new ResponseException(__METHOD__);
         }
         $this->client->setSideload(null);
+
         return $response;
     }
 
@@ -127,21 +137,23 @@ class Apps extends ClientAbstract {
      *
      * @return bool
      */
-    public function delete(array $params = array()) {
-        if($this->lastId != null) {
+    public function delete(array $params = array())
+    {
+        if ($this->lastId != null) {
             $params['id'] = $this->lastId;
             $this->lastId = null;
         }
-        if(!$this->hasKeys($params, array('id'))) {
+        if (!$this->hasKeys($params, array('id'))) {
             throw new MissingParametersException(__METHOD__, array('id'));
         }
         $id = $params['id'];
-        $endPoint = Http::prepare('apps/'.$id.'.json');
+        $endPoint = Http::prepare('apps/' . $id . '.json');
         $response = Http::send($this->client, $endPoint, null, 'DELETE');
         if ($this->client->getDebug()->lastResponseCode != 200) {
             throw new ResponseException(__METHOD__);
         }
         $this->client->setSideload(null);
+
         return true;
     }
 
@@ -155,13 +167,15 @@ class Apps extends ClientAbstract {
      *
      * @return mixed
      */
-    public function sendNotification(array $params) {
+    public function sendNotification(array $params)
+    {
         $endPoint = Http::prepare('apps/notify.json');
         $response = Http::send($this->client, $endPoint, $params, 'POST');
         if ((!is_object($response)) || ($this->client->getDebug()->lastResponseCode != 200)) {
             throw new ResponseException(__METHOD__);
         }
         $this->client->setSideload(null);
+
         return $response;
     }
 
@@ -175,13 +189,19 @@ class Apps extends ClientAbstract {
      *
      * @return AppInstallations
      */
-    public function installations($id = null) { return ($id != null ? $this->installations->setLastId($id) : $this->installations); }
+    public function installations($id = null)
+    {
+        return ($id != null ? $this->installations->setLastId($id) : $this->installations);
+    }
 
     /**
      * @param int $id
      *
      * @return AppInstallations
      */
-    public function installation($id) { return $this->installations->setLastId($id); }
+    public function installation($id)
+    {
+        return $this->installations->setLastId($id);
+    }
 
 }

--- a/src/Zendesk/API/Attachments.php
+++ b/src/Zendesk/API/Attachments.php
@@ -6,7 +6,8 @@ namespace Zendesk\API;
  * The Attachments class exposes methods for uploading and retrieving attachments
  * @package Zendesk\API
  */
-class Attachments extends ClientAbstract {
+class Attachments extends ClientAbstract
+{
 
     /**
      * Upload an attachment
@@ -15,7 +16,7 @@ class Attachments extends ClientAbstract {
      *    'type' - the MIME type of the file
      * Optional:
      *    'optional_token' - an existing token
-     *		'name' - preferred filename
+     *        'name' - preferred filename
      *
      * @param array $params
      *
@@ -26,28 +27,31 @@ class Attachments extends ClientAbstract {
      *
      * @return mixed
      */
-    public function upload(array $params) {
-        if(!$this->hasKeys($params, array('file'))) {
+    public function upload(array $params)
+    {
+        if (!$this->hasKeys($params, array('file'))) {
             throw new MissingParametersException(__METHOD__, array('file'));
         }
-        if(!file_exists($params['file'])) {
-            throw new CustomException('File '.$params['file'].' could not be found in '.__METHOD__);
+        if (!file_exists($params['file'])) {
+            throw new CustomException('File ' . $params['file'] . ' could not be found in ' . __METHOD__);
         }
-        if(!$params['name'] && strrpos($params['file'], '/') > -1) {
-          $path_array = explode('/', $params['file']);
-          $file_index = count($path_array) - 1;
-          $params['name'] = $path_array[$file_index];
+        if (!$params['name'] && strrpos($params['file'], '/') > -1) {
+            $path_array = explode('/', $params['file']);
+            $file_index = count($path_array) - 1;
+            $params['name'] = $path_array[$file_index];
         }
-        if(!$params['name'] && strrpos($params['file'], '/') == FALSE) {
-	        $params['name'] = $params['file'];
+        if (!$params['name'] && strrpos($params['file'], '/') == false) {
+            $params['name'] = $params['file'];
         }
 
-        $endPoint = Http::prepare('uploads.json?filename='.urlencode($params['name']).(isset($params['optional_token']) ? '&token='.$params['optional_token'] : ''));
-        $response = Http::send($this->client, $endPoint, array('filename' => $params['file']), 'POST', (isset($params['type']) ? $params['type'] : 'application/binary'));
-       if ((!is_object($response)) || ($this->client->getDebug()->lastResponseCode != 201)) {
+        $endPoint = Http::prepare('uploads.json?filename=' . urlencode($params['name']) . (isset($params['optional_token']) ? '&token=' . $params['optional_token'] : ''));
+        $response = Http::send($this->client, $endPoint, array('filename' => $params['file']), 'POST',
+            (isset($params['type']) ? $params['type'] : 'application/binary'));
+        if ((!is_object($response)) || ($this->client->getDebug()->lastResponseCode != 201)) {
             throw new ResponseException(__METHOD__);
         }
         $this->client->setSideload(null);
+
         return $response;
     }
 
@@ -69,19 +73,22 @@ class Attachments extends ClientAbstract {
      *
      * @return mixed
      */
-    public function uploadWithBody(array $params) {
-        if(!$this->hasKeys($params, array('body'))) {
+    public function uploadWithBody(array $params)
+    {
+        if (!$this->hasKeys($params, array('body'))) {
             throw new MissingParametersException(__METHOD__, array('body'));
         }
-        if(!$params['name']) {
+        if (!$params['name']) {
             throw new MissingParametersException(__METHOD__, array('name'));
         }
-        $endPoint = Http::prepare('uploads.json?filename='.$params['name'].(isset($params['optional_token']) ? '&token='.$params['optional_token'] : ''));
-        $response = Http::send($this->client, $endPoint, array('body' => $params['body']), 'POST', (isset($params['type']) ? $params['type'] : 'application/binary'));
+        $endPoint = Http::prepare('uploads.json?filename=' . $params['name'] . (isset($params['optional_token']) ? '&token=' . $params['optional_token'] : ''));
+        $response = Http::send($this->client, $endPoint, array('body' => $params['body']), 'POST',
+            (isset($params['type']) ? $params['type'] : 'application/binary'));
         if ((!is_object($response)) || ($this->client->getDebug()->lastResponseCode != 201)) {
             throw new ResponseException(__METHOD__);
         }
         $this->client->setSideload(null);
+
         return $response;
     }
 
@@ -99,16 +106,18 @@ class Attachments extends ClientAbstract {
      *
      * @return bool
      */
-    public function delete(array $params) {
-        if(!$this->hasAnyKey($params, array('id', 'token'))) {
+    public function delete(array $params)
+    {
+        if (!$this->hasAnyKey($params, array('id', 'token'))) {
             throw new MissingParametersException(__METHOD__, array('id', 'token'));
         }
-        $endPoint = Http::prepare(($params['token'] ? 'uploads/'.$params['token'] : 'attachments/'.$params['id']).'.json');
+        $endPoint = Http::prepare(($params['token'] ? 'uploads/' . $params['token'] : 'attachments/' . $params['id']) . '.json');
         $response = Http::send($this->client, $endPoint, null, 'DELETE');
         if ($this->client->getDebug()->lastResponseCode != 200) {
             throw new ResponseException(__METHOD__);
         }
         $this->client->setSideload(null);
+
         return true;
     }
 
@@ -125,17 +134,19 @@ class Attachments extends ClientAbstract {
      *
      * @return mixed
      */
-    public function find(array $params) {
-        if(!$this->hasKeys($params, array('id'))) {
+    public function find(array $params)
+    {
+        if (!$this->hasKeys($params, array('id'))) {
             throw new MissingParametersException(__METHOD__, array('id'));
         }
         $id = $params['id'];
-        $endPoint = Http::prepare('attachments/'.$id.'.json');
+        $endPoint = Http::prepare('attachments/' . $id . '.json');
         $response = Http::send($this->client, $endPoint);
         if ((!is_object($response)) || ($this->client->getDebug()->lastResponseCode != 200)) {
             throw new ResponseException(__METHOD__);
         }
         $this->client->setSideload(null);
+
         return $response;
     }
 

--- a/src/Zendesk/API/AuditLogs.php
+++ b/src/Zendesk/API/AuditLogs.php
@@ -6,7 +6,8 @@ namespace Zendesk\API;
  * The AuditLogs class is as per http://developer.zendesk.com/documentation/rest_api/audit_logs.html
  * @package Zendesk\API
  */
-class AuditLogs extends ClientAbstract {
+class AuditLogs extends ClientAbstract
+{
 
     const OBJ_NAME = 'audit_log';
     const OBJ_NAME_PLURAL = 'audit_logs';
@@ -21,13 +22,15 @@ class AuditLogs extends ClientAbstract {
      *
      * @return mixed
      */
-    public function findAll(array $params = array()) {
+    public function findAll(array $params = array())
+    {
         $endPoint = Http::prepare('audit_logs.json', null, $params);
         $response = Http::send($this->client, $endPoint, $params, 'GET');
         if ((!is_object($response)) || ($this->client->getDebug()->lastResponseCode != 200)) {
             throw new ResponseException(__METHOD__);
         }
         $this->client->setSideload(null);
+
         return $response;
     }
 
@@ -42,20 +45,22 @@ class AuditLogs extends ClientAbstract {
      *
      * @return mixed
      */
-    public function find(array $params = array()) {
-        if($this->lastId != null) {
+    public function find(array $params = array())
+    {
+        if ($this->lastId != null) {
             $params['id'] = $this->lastId;
             $this->lastId = null;
         }
-        if(!$this->hasKeys($params, array('id'))) {
+        if (!$this->hasKeys($params, array('id'))) {
             throw new MissingParametersException(__METHOD__, array('id'));
         }
-        $endPoint = Http::prepare('audit_logs/'.$params['id'].'.json');
+        $endPoint = Http::prepare('audit_logs/' . $params['id'] . '.json');
         $response = Http::send($this->client, $endPoint);
         if ((!is_object($response)) || ($this->client->getDebug()->lastResponseCode != 200)) {
             throw new ResponseException(__METHOD__);
         }
         $this->client->setSideload(null);
+
         return $response;
     }
 

--- a/src/Zendesk/API/Autocomplete.php
+++ b/src/Zendesk/API/Autocomplete.php
@@ -6,7 +6,8 @@ namespace Zendesk\API;
  * The Autocomplete class is as per http://developer.zendesk.com/documentation/rest_api/autocomplete.html
  * @package Zendesk\API
  */
-class Autocomplete extends ClientAbstract {
+class Autocomplete extends ClientAbstract
+{
 
     const OBJ_NAME = 'name';
     const OBJ_NAME_PLURAL = 'names';
@@ -21,8 +22,9 @@ class Autocomplete extends ClientAbstract {
      * @throws \Exception
      * @return mixed
      */
-    public function tags(array $params) {
-        if(!$this->hasKeys($params, array('name'))) {
+    public function tags(array $params)
+    {
+        if (!$this->hasKeys($params, array('name'))) {
             throw new MissingParametersException(__METHOD__, array('name'));
         }
         $endPoint = Http::prepare('autocomplete/tags.json');
@@ -31,6 +33,7 @@ class Autocomplete extends ClientAbstract {
             throw new ResponseException(__METHOD__);
         }
         $this->client->setSideload(null);
+
         return $response;
     }
 

--- a/src/Zendesk/API/Automations.php
+++ b/src/Zendesk/API/Automations.php
@@ -6,7 +6,8 @@ namespace Zendesk\API;
  * The Automations class exposes methods seen at http://developer.zendesk.com/documentation/rest_api/automations.html
  * @package Zendesk\API
  */
-class Automations extends ClientAbstract {
+class Automations extends ClientAbstract
+{
 
     const OBJ_NAME = 'automation';
     const OBJ_NAME_PLURAL = 'automations';
@@ -21,13 +22,16 @@ class Automations extends ClientAbstract {
      *
      * @return mixed
      */
-    public function findAll(array $params = array()) {
-        $endPoint = Http::prepare((isset($params['active']) ? 'automations/active.json' : 'automations.json'), null, $params);
+    public function findAll(array $params = array())
+    {
+        $endPoint = Http::prepare((isset($params['active']) ? 'automations/active.json' : 'automations.json'), null,
+            $params);
         $response = Http::send($this->client, $endPoint);
         if ((!is_object($response)) || ($this->client->getDebug()->lastResponseCode != 200)) {
             throw new ResponseException(__METHOD__);
         }
         $this->client->setSideload(null);
+
         return $response;
     }
 
@@ -42,20 +46,22 @@ class Automations extends ClientAbstract {
      *
      * @return mixed
      */
-    public function find(array $params = array()) {
-        if($this->lastId != null) {
+    public function find(array $params = array())
+    {
+        if ($this->lastId != null) {
             $params['id'] = $this->lastId;
             $this->lastId = null;
         }
-        if(!$this->hasKeys($params, array('id'))) {
+        if (!$this->hasKeys($params, array('id'))) {
             throw new MissingParametersException(__METHOD__, array('id'));
         }
-        $endPoint = Http::prepare('automations/'.$params['id'].'.json');
+        $endPoint = Http::prepare('automations/' . $params['id'] . '.json');
         $response = Http::send($this->client, $endPoint);
         if ((!is_object($response)) || ($this->client->getDebug()->lastResponseCode != 200)) {
             throw new ResponseException(__METHOD__);
         }
         $this->client->setSideload(null);
+
         return $response;
     }
 
@@ -69,13 +75,15 @@ class Automations extends ClientAbstract {
      *
      * @return mixed
      */
-    public function create(array $params) {
+    public function create(array $params)
+    {
         $endPoint = Http::prepare('automations.json');
         $response = Http::send($this->client, $endPoint, array(self::OBJ_NAME => $params), 'POST');
         if ((!is_object($response)) || ($this->client->getDebug()->lastResponseCode != 201)) {
             throw new ResponseException(__METHOD__);
         }
         $this->client->setSideload(null);
+
         return $response;
     }
 
@@ -90,20 +98,22 @@ class Automations extends ClientAbstract {
      *
      * @return mixed
      */
-    public function update(array $params) {
-        if($this->lastId != null) {
+    public function update(array $params)
+    {
+        if ($this->lastId != null) {
             $params['id'] = $this->lastId;
             $this->lastId = null;
         }
-        if(!$this->hasKeys($params, array('id'))) {
+        if (!$this->hasKeys($params, array('id'))) {
             throw new MissingParametersException(__METHOD__, array('id'));
         }
-        $endPoint = Http::prepare('automations/'.$params['id'].'.json');
+        $endPoint = Http::prepare('automations/' . $params['id'] . '.json');
         $response = Http::send($this->client, $endPoint, array(self::OBJ_NAME => $params), 'PUT');
         if ((!is_object($response)) || ($this->client->getDebug()->lastResponseCode != 200)) {
             throw new ResponseException(__METHOD__);
         }
         $this->client->setSideload(null);
+
         return $response;
     }
 
@@ -118,21 +128,23 @@ class Automations extends ClientAbstract {
      *
      * @return bool
      */
-    public function delete(array $params = array()) {
-        if($this->lastId != null) {
+    public function delete(array $params = array())
+    {
+        if ($this->lastId != null) {
             $params['id'] = $this->lastId;
             $this->lastId = null;
         }
-        if(!$this->hasKeys($params, array('id'))) {
+        if (!$this->hasKeys($params, array('id'))) {
             throw new MissingParametersException(__METHOD__, array('id'));
         }
         $id = $params['id'];
-        $endPoint = Http::prepare('automations/'.$id.'.json');
+        $endPoint = Http::prepare('automations/' . $id . '.json');
         $response = Http::send($this->client, $endPoint, null, 'DELETE');
         if ($this->client->getDebug()->lastResponseCode != 200) {
             throw new ResponseException(__METHOD__);
         }
         $this->client->setSideload(null);
+
         return true;
     }
 

--- a/src/Zendesk/API/Categories.php
+++ b/src/Zendesk/API/Categories.php
@@ -6,7 +6,8 @@ namespace Zendesk\API;
  * The Categories class exposes category information
  * @package Zendesk\API
  */
-class Categories extends ClientAbstract {
+class Categories extends ClientAbstract
+{
 
     const OBJ_NAME = 'category';
     const OBJ_NAME_PLURAL = 'categories';
@@ -21,13 +22,15 @@ class Categories extends ClientAbstract {
      *
      * @return mixed
      */
-    public function findAll(array $params = array()) {
+    public function findAll(array $params = array())
+    {
         $endPoint = Http::prepare('categories.json', null, $params);
         $response = Http::send($this->client, $endPoint);
         if ((!is_object($response)) || ($this->client->getDebug()->lastResponseCode != 200)) {
             throw new ResponseException(__METHOD__);
         }
         $this->client->setSideload(null);
+
         return $response;
     }
 
@@ -42,20 +45,22 @@ class Categories extends ClientAbstract {
      *
      * @return mixed
      */
-    public function find(array $params = array()) {
-        if($this->lastId != null) {
+    public function find(array $params = array())
+    {
+        if ($this->lastId != null) {
             $params['id'] = $this->lastId;
             $this->lastId = null;
         }
-        if(!$this->hasKeys($params, array('id'))) {
+        if (!$this->hasKeys($params, array('id'))) {
             throw new MissingParametersException(__METHOD__, array('id'));
         }
-        $endPoint = Http::prepare('categories/'.$params['id'].'.json');
+        $endPoint = Http::prepare('categories/' . $params['id'] . '.json');
         $response = Http::send($this->client, $endPoint);
         if ((!is_object($response)) || ($this->client->getDebug()->lastResponseCode != 200)) {
             throw new ResponseException(__METHOD__);
         }
         $this->client->setSideload(null);
+
         return $response;
     }
 
@@ -69,13 +74,15 @@ class Categories extends ClientAbstract {
      *
      * @return mixed
      */
-    public function create(array $params) {
+    public function create(array $params)
+    {
         $endPoint = Http::prepare('categories.json');
         $response = Http::send($this->client, $endPoint, array(self::OBJ_NAME => $params), 'POST');
         if ((!is_object($response)) || ($this->client->getDebug()->lastResponseCode != 201)) {
             throw new ResponseException(__METHOD__);
         }
         $this->client->setSideload(null);
+
         return $response;
     }
 
@@ -90,22 +97,24 @@ class Categories extends ClientAbstract {
      *
      * @return mixed
      */
-    public function update(array $params) {
-        if($this->lastId != null) {
+    public function update(array $params)
+    {
+        if ($this->lastId != null) {
             $params['id'] = $this->lastId;
             $this->lastId = null;
         }
-        if(!$this->hasKeys($params, array('id'))) {
+        if (!$this->hasKeys($params, array('id'))) {
             throw new MissingParametersException(__METHOD__, array('id'));
         }
         $id = $params['id'];
         unset($params['id']);
-        $endPoint = Http::prepare('categories/'.$id.'.json');
+        $endPoint = Http::prepare('categories/' . $id . '.json');
         $response = Http::send($this->client, $endPoint, array(self::OBJ_NAME => $params), 'PUT');
         if ((!is_object($response)) || ($this->client->getDebug()->lastResponseCode != 200)) {
             throw new ResponseException(__METHOD__);
         }
         $this->client->setSideload(null);
+
         return $response;
     }
 
@@ -120,20 +129,22 @@ class Categories extends ClientAbstract {
      *
      * @return bool
      */
-    public function delete(array $params = array()) {
-        if($this->lastId != null) {
+    public function delete(array $params = array())
+    {
+        if ($this->lastId != null) {
             $params['id'] = $this->lastId;
             $this->lastId = null;
         }
-        if(!$this->hasKeys($params, array('id'))) {
+        if (!$this->hasKeys($params, array('id'))) {
             throw new MissingParametersException(__METHOD__, array('id'));
         }
-        $endPoint = Http::prepare('categories/'.$params['id'].'.json');
+        $endPoint = Http::prepare('categories/' . $params['id'] . '.json');
         $response = Http::send($this->client, $endPoint, null, 'DELETE');
         if ($this->client->getDebug()->lastResponseCode != 200) {
             throw new ResponseException(__METHOD__);
         }
         $this->client->setSideload(null);
+
         return true;
     }
 

--- a/src/Zendesk/API/Client.php
+++ b/src/Zendesk/API/Client.php
@@ -2,10 +2,10 @@
 
 namespace Zendesk\API;
 
-/*
- * Dead simple autoloader:
- * spl_autoload_register(function($c){@include 'src/'.preg_replace('#\\\|_(?!.+\\\)#','/',$c).'.php';});
- */
+    /*
+     * Dead simple autoloader:
+     * spl_autoload_register(function($c){@include 'src/'.preg_replace('#\\\|_(?!.+\\\)#','/',$c).'.php';});
+     */
 
 /**
  * Client class, base level access
@@ -50,7 +50,8 @@ namespace Zendesk\API;
  * @method Locales locales()
  * @method PushNotificationDevices push_notification_devices()
  */
-class Client {
+class Client
+{
 
     /**
      * @var string
@@ -238,10 +239,11 @@ class Client {
      * @param string $subdomain
      * @param string $username
      */
-    public function __construct($subdomain, $username) {
+    public function __construct($subdomain, $username)
+    {
         $this->subdomain = $subdomain;
         $this->username = $username;
-        $this->apiUrl = 'https://'.$subdomain.'.zendesk.com/api/'.$this->apiVer.'/';
+        $this->apiUrl = 'https://' . $subdomain . '.zendesk.com/api/' . $this->apiVer . '/';
         $this->debug = new Debug();
         $this->tickets = new Tickets($this);
         $this->ticketFields = new TicketFields($this);
@@ -288,20 +290,24 @@ class Client {
      * @param string $method
      * @param string $value
      */
-    public function setAuth($method, $value) {
-        switch($method) {
-            case 'password':    $this->password = $value;
-                                $this->token = '';
-                                $this->oAuthToken = '';
-                                break;
-            case 'token':        $this->password = '';
-                                $this->token = $value;
-                                $this->oAuthToken = '';
-                                break;
-            case 'oauth_token':    $this->password = '';
-                                $this->token = '';
-                                $this->oAuthToken = $value;
-                                break;
+    public function setAuth($method, $value)
+    {
+        switch ($method) {
+            case 'password':
+                $this->password = $value;
+                $this->token = '';
+                $this->oAuthToken = '';
+                break;
+            case 'token':
+                $this->password = '';
+                $this->token = $value;
+                $this->oAuthToken = '';
+                break;
+            case 'oauth_token':
+                $this->password = '';
+                $this->token = '';
+                $this->oAuthToken = $value;
+                break;
         }
     }
 
@@ -310,7 +316,8 @@ class Client {
      *
      * @return string
      */
-    public function getSubdomain() {
+    public function getSubdomain()
+    {
         return $this->subdomain;
     }
 
@@ -319,7 +326,8 @@ class Client {
      *
      * @return string
      */
-    public function getApiUrl() {
+    public function getApiUrl()
+    {
         return $this->apiUrl;
     }
 
@@ -328,7 +336,8 @@ class Client {
      *
      * @return string
      */
-    public function getAuthType() {
+    public function getAuthType()
+    {
         return ($this->oAuthToken ? 'oauth_token' : ($this->token ? 'token' : 'password'));
     }
 
@@ -337,8 +346,9 @@ class Client {
      *
      * @return string
      */
-    public function getAuthText() {
-        return ($this->oAuthToken ? $this->oAuthToken : $this->username.($this->token ? '/token:'.$this->token : ':'.$this->password));
+    public function getAuthText()
+    {
+        return ($this->oAuthToken ? $this->oAuthToken : $this->username . ($this->token ? '/token:' . $this->token : ':' . $this->password));
     }
 
     /**
@@ -349,7 +359,8 @@ class Client {
      * @param string $lastResponseHeaders
      * @param mixed $lastResponseError
      */
-    public function setDebug($lastRequestHeaders, $lastResponseCode, $lastResponseHeaders, $lastResponseError) {
+    public function setDebug($lastRequestHeaders, $lastResponseCode, $lastResponseHeaders, $lastResponseError)
+    {
         $this->debug->lastRequestHeaders = $lastRequestHeaders;
         $this->debug->lastResponseCode = $lastResponseCode;
         $this->debug->lastResponseHeaders = $lastResponseHeaders;
@@ -361,7 +372,8 @@ class Client {
      *
      * @return Debug
      */
-    public function getDebug() {
+    public function getDebug()
+    {
         return $this->debug;
     }
 
@@ -372,8 +384,10 @@ class Client {
      *
      * @return Client
      */
-    public function setSideload(array $fields = null) {
+    public function setSideload(array $fields = null)
+    {
         $this->sideload = $fields;
+
         return $this;
     }
 
@@ -384,7 +398,8 @@ class Client {
      *
      * @return array|null
      */
-    public function getSideload(array $params = null) {
+    public function getSideload(array $params = null)
+    {
         return ((isset($params['sideload'])) && (is_array($params['sideload'])) ? $params['sideload'] : $this->sideload);
     }
 
@@ -398,15 +413,16 @@ class Client {
      *
      * @throws CustomException
      */
-    public function __call($name, $arguments) {
-        if(isset($this->$name)) {
+    public function __call($name, $arguments)
+    {
+        if (isset($this->$name)) {
             return ((isset($arguments[0])) && ($arguments[0] != null) ? $this->$name->setLastId($arguments[0]) : $this->$name);
         }
-        $namePlural = $name.'s'; // try pluralize
-        if(isset($this->$namePlural)) {
+        $namePlural = $name . 's'; // try pluralize
+        if (isset($this->$namePlural)) {
             return $this->$namePlural->setLastId($arguments[0]);
         } else {
-            throw new CustomException("No method called $name available in ".__CLASS__);
+            throw new CustomException("No method called $name available in " . __CLASS__);
         }
     }
 
@@ -419,28 +435,40 @@ class Client {
      *
      * @return $this
      */
-    public function category($id) { return $this->categories->setLastId($id); }
+    public function category($id)
+    {
+        return $this->categories->setLastId($id);
+    }
 
     /**
      * @param int|null $id
      *
      * @return ActivityStream
      */
-    public function activities($id = null) { return ($id != null ? $this->activityStream()->setLastId($id) : $this->activityStream()); }
+    public function activities($id = null)
+    {
+        return ($id != null ? $this->activityStream()->setLastId($id) : $this->activityStream());
+    }
 
     /**
      * @param int $id
      *
      * @return ActivityStream
      */
-    public function activity($id) { return $this->activityStream()->setLastId($id); }
+    public function activity($id)
+    {
+        return $this->activityStream()->setLastId($id);
+    }
 
     /**
      * @param int $id
      *
      * @return JobStatuses
      */
-    public function jobStatus($id) { return $this->jobStatuses()->setLastId($id); }
+    public function jobStatus($id)
+    {
+        return $this->jobStatuses()->setLastId($id);
+    }
 
     /**
      * @param array $params
@@ -450,7 +478,10 @@ class Client {
      *
      * @return mixed
      */
-    public function search(array $params) { return $this->search->performSearch($params); }
+    public function search(array $params)
+    {
+        return $this->search->performSearch($params);
+    }
 
     /**
      * @param array $params
@@ -460,6 +491,9 @@ class Client {
      *
      * @return mixed
      */
-    public function anonymousSearch(array $params) { return $this->search->anonymousSearch($params); }
+    public function anonymousSearch(array $params)
+    {
+        return $this->search->anonymousSearch($params);
+    }
 
 }

--- a/src/Zendesk/API/ClientAbstract.php
+++ b/src/Zendesk/API/ClientAbstract.php
@@ -21,7 +21,8 @@ abstract class ClientAbstract
     /**
      * @param Client $client
      */
-     public function __construct(Client $client) {
+    public function __construct(Client $client)
+    {
         $this->client = $client;
     }
 
@@ -32,8 +33,10 @@ abstract class ClientAbstract
      *
      * @return $this
      */
-    public function setLastId($id) {
+    public function setLastId($id)
+    {
         $this->lastId = $id;
+
         return $this;
     }
 
@@ -42,7 +45,8 @@ abstract class ClientAbstract
      *
      * @return int
      */
-    public function getLastId() {
+    public function getLastId()
+    {
         return $this->lastId;
     }
 
@@ -54,12 +58,14 @@ abstract class ClientAbstract
      *
      * @return bool
      */
-    public function hasKeys(array $params, array $mandatory) {
-        for($i = 0; $i < count($mandatory); $i++) {
-            if(!array_key_exists($mandatory[$i], $params)) {
+    public function hasKeys(array $params, array $mandatory)
+    {
+        for ($i = 0; $i < count($mandatory); $i++) {
+            if (!array_key_exists($mandatory[$i], $params)) {
                 return false;
             }
         }
+
         return true;
     }
 
@@ -71,12 +77,14 @@ abstract class ClientAbstract
      *
      * @return bool
      */
-    public function hasAnyKey(array $params, array $mandatory) {
-        for($i = 0; $i < count($mandatory); $i++) {
-            if(array_key_exists($mandatory[$i], $params)) {
+    public function hasAnyKey(array $params, array $mandatory)
+    {
+        for ($i = 0; $i < count($mandatory); $i++) {
+            if (array_key_exists($mandatory[$i], $params)) {
                 return true;
             }
         }
+
         return false;
     }
 
@@ -87,8 +95,10 @@ abstract class ClientAbstract
      *
      * @return $this
      */
-    public function sideload(array $fields = array()) {
+    public function sideload(array $fields = array())
+    {
         $this->client->setSideload($fields);
+
         return $this;
     }
 

--- a/src/Zendesk/API/CurlRequest.php
+++ b/src/Zendesk/API/CurlRequest.php
@@ -5,70 +5,87 @@ namespace Zendesk\API;
  * Curl mock functions
  * @package Zendesk\API
  */
-class CurlRequest {
+class CurlRequest
+{
     protected $handle = null;
 
-    public function __construct($url = NULL) {
+    public function __construct($url = null)
+    {
         $this->handle = curl_init($url);
     }
 
-    public function close() {
+    public function close()
+    {
         return curl_close($this->handle);
     }
 
-    public function copy_handle() {
+    public function copy_handle()
+    {
         return curl_copy_handle($this->handle);
     }
 
-    public function errno() {
+    public function errno()
+    {
         return curl_errno($this->handle);
     }
 
-    public function error() {
+    public function error()
+    {
         return curl_error($this->handle);
     }
 
-    public function escape($str) {
+    public function escape($str)
+    {
         return curl_escape($this->handle, $str);
     }
 
-    public function exec() {
+    public function exec()
+    {
         return curl_exec($this->handle);
     }
 
-    public function file_create($filename, $mimetype = NULL, $postname = NULL) {
+    public function file_create($filename, $mimetype = null, $postname = null)
+    {
         return curl_file_create($filename, $mimetype, $postname);
     }
 
-    public function getinfo($opt = 0) {
+    public function getinfo($opt = 0)
+    {
         return curl_getinfo($this->handle, $opt);
     }
 
-    public function pause($bitmask) {
+    public function pause($bitmask)
+    {
         return curl_pause($this->handle, $bitmask);
     }
 
-    public function reset() {
+    public function reset()
+    {
         return curl_reset($this->handle);
     }
 
-    public function setopt_array($options) {
+    public function setopt_array($options)
+    {
         return curl_setopt_array($this->handle, $options);
     }
 
-    public function setopt($option, $value) {
+    public function setopt($option, $value)
+    {
         return curl_setopt($this->handle, $option, $value);
     }
 
-    public function strerror($errornum ) {
+    public function strerror($errornum)
+    {
         return curl_strerror($errornum);
     }
 
-    public function unescape($str) {
+    public function unescape($str)
+    {
         return curl_unescape($this->handle, $str);
     }
 
-    public function version($age = CURLVERSION_NOW) {
+    public function version($age = CURLVERSION_NOW)
+    {
         return curl_version($age);
     }
 }

--- a/src/Zendesk/API/CustomException.php
+++ b/src/Zendesk/API/CustomException.php
@@ -6,14 +6,16 @@ namespace Zendesk\API;
  * CustomException extends the Exception class with simplified messaging
  * @package Zendesk\API
  */
-class CustomException extends \Exception {
+class CustomException extends \Exception
+{
 
     /**
-     * @param string     $message
-     * @param int        $code
+     * @param string $message
+     * @param int $code
      * @param \Exception $previous
      */
-    public function __construct($message, $code = 0, \Exception $previous = null) {
+    public function __construct($message, $code = 0, \Exception $previous = null)
+    {
         parent::__construct($message, $code, $previous);
     }
 

--- a/src/Zendesk/API/CustomRoles.php
+++ b/src/Zendesk/API/CustomRoles.php
@@ -6,7 +6,8 @@ namespace Zendesk\API;
  * The CustomRoles class exposes access to custom roles
  * @package Zendesk\API
  */
-class CustomRoles extends ClientAbstract {
+class CustomRoles extends ClientAbstract
+{
 
     const OBJ_NAME = 'custom_role';
     const OBJ_NAME_PLURAL = 'custom_roles';
@@ -21,13 +22,15 @@ class CustomRoles extends ClientAbstract {
      *
      * @return mixed
      */
-    public function findAll(array $params = array()) {
+    public function findAll(array $params = array())
+    {
         $endPoint = Http::prepare('custom_roles.json', null, $params);
         $response = Http::send($this->client, $endPoint);
         if ((!is_object($response)) || ($this->client->getDebug()->lastResponseCode != 200)) {
             throw new ResponseException(__METHOD__);
         }
         $this->client->setSideload(null);
+
         return $response;
     }
 

--- a/src/Zendesk/API/Debug.php
+++ b/src/Zendesk/API/Debug.php
@@ -6,7 +6,8 @@ namespace Zendesk\API;
  * Debug helper class
  * @package Zendesk\API
  */
-class Debug {
+class Debug
+{
 
     /**
      * @var mixed
@@ -24,21 +25,21 @@ class Debug {
      * @var mixed
      */
     public $lastResponseError;
-    
+
     /**
-     * @return string 
+     * @return string
      */
     public function __toString()
     {
-    	$lastError = $this->lastResponseError;
-    	if (! is_string($lastError)) {
-    		$lastError = json_encode($lastError);
-    	} 
-    	$output = 'LastResponseCode: ' . $this->lastResponseCode
-    		. ', LastResponseError: ' . $lastError 
-    		. ', LastResponseHeaders: ' . $this->lastResponseHeaders
-    		. ', LastRequestHeaders: ' . $this->lastRequestHeaders;
-    	
-    	return $output;
+        $lastError = $this->lastResponseError;
+        if (!is_string($lastError)) {
+            $lastError = json_encode($lastError);
+        }
+        $output = 'LastResponseCode: ' . $this->lastResponseCode
+            . ', LastResponseError: ' . $lastError
+            . ', LastResponseHeaders: ' . $this->lastResponseHeaders
+            . ', LastRequestHeaders: ' . $this->lastRequestHeaders;
+
+        return $output;
     }
 }

--- a/src/Zendesk/API/DynamicContent.php
+++ b/src/Zendesk/API/DynamicContent.php
@@ -6,7 +6,8 @@ namespace Zendesk\API;
  * The DynamicContent class exposes methods seen at https://developer.zendesk.com/rest_api/docs/core/dynamic_content
  * @package Zendesk\API
  */
-class DynamicContent extends ClientAbstract {
+class DynamicContent extends ClientAbstract
+{
 
     const OBJ_NAME = 'item';
     const OBJ_NAME_PLURAL = 'items';
@@ -21,13 +22,15 @@ class DynamicContent extends ClientAbstract {
      *
      * @return mixed
      */
-    public function findAll(array $params = array()) {
+    public function findAll(array $params = array())
+    {
         $endPoint = Http::prepare('dynamic_content/items.json', null, $params);
         $response = Http::send($this->client, $endPoint);
         if ((!is_object($response)) || ($this->client->getDebug()->lastResponseCode != 200)) {
             throw new ResponseException(__METHOD__);
         }
         $this->client->setSideload(null);
+
         return $response;
     }
 
@@ -41,13 +44,15 @@ class DynamicContent extends ClientAbstract {
      *
      * @return mixed
      */
-    public function create(array $params) {
+    public function create(array $params)
+    {
         $endPoint = Http::prepare('dynamic_content/items.json');
         $response = Http::send($this->client, $endPoint, array(self::OBJ_NAME => $params), 'POST');
         if ((!is_object($response)) || ($this->client->getDebug()->lastResponseCode != 201)) {
             throw new ResponseException(__METHOD__);
         }
         $this->client->setSideload(null);
+
         return $response;
     }
 
@@ -62,21 +67,23 @@ class DynamicContent extends ClientAbstract {
      *
      * @return bool
      */
-    public function delete(array $params = array()) {
-        if($this->lastId != null) {
+    public function delete(array $params = array())
+    {
+        if ($this->lastId != null) {
             $params['id'] = $this->lastId;
             $this->lastId = null;
         }
-        if(!$this->hasKeys($params, array('id'))) {
+        if (!$this->hasKeys($params, array('id'))) {
             throw new MissingParametersException(__METHOD__, array('id'));
         }
         $id = $params['id'];
-        $endPoint = Http::prepare('dynamic_content/items/'.$id.'.json');
+        $endPoint = Http::prepare('dynamic_content/items/' . $id . '.json');
         $response = Http::send($this->client, $endPoint, null, 'DELETE');
         if ($this->client->getDebug()->lastResponseCode != 200) {
             throw new ResponseException(__METHOD__);
         }
         $this->client->setSideload(null);
+
         return true;
     }
 

--- a/src/Zendesk/API/ForumSubscriptions.php
+++ b/src/Zendesk/API/ForumSubscriptions.php
@@ -6,7 +6,8 @@ namespace Zendesk\API;
  * The ForumSubscriptions class exposes forum information
  * @package Zendesk\API
  */
-class ForumSubscriptions extends ClientAbstract {
+class ForumSubscriptions extends ClientAbstract
+{
 
     const OBJ_NAME = 'forum_subscription';
     const OBJ_NAME_PLURAL = 'forum_subscriptions';
@@ -21,17 +22,20 @@ class ForumSubscriptions extends ClientAbstract {
      *
      * @return mixed
      */
-    public function findAll(array $params = array()) {
-        if($this->client->forums()->getLastId() != null) {
+    public function findAll(array $params = array())
+    {
+        if ($this->client->forums()->getLastId() != null) {
             $params['forum_id'] = $this->client->forums()->getLastId();
             $this->client->forums()->setLastId(null);
         }
-        $endPoint = Http::prepare((isset($params['forum_id']) ? 'forum/'.$params['forum_id'].'/subscriptions.json' : 'forum_subscriptions.json'), null, $params);
+        $endPoint = Http::prepare((isset($params['forum_id']) ? 'forum/' . $params['forum_id'] . '/subscriptions.json' : 'forum_subscriptions.json'),
+            null, $params);
         $response = Http::send($this->client, $endPoint);
         if ((!is_object($response)) || ($this->client->getDebug()->lastResponseCode != 200)) {
             throw new ResponseException(__METHOD__);
         }
         $this->client->setSideload(null);
+
         return $response;
     }
 
@@ -46,20 +50,22 @@ class ForumSubscriptions extends ClientAbstract {
      *
      * @return mixed
      */
-    public function find(array $params = array()) {
-        if($this->lastId != null) {
+    public function find(array $params = array())
+    {
+        if ($this->lastId != null) {
             $params['id'] = $this->lastId;
             $this->lastId = null;
         }
-        if(!$this->hasKeys($params, array('id'))) {
+        if (!$this->hasKeys($params, array('id'))) {
             throw new MissingParametersException(__METHOD__, array('id'));
         }
-        $endPoint = Http::prepare('forum_subscriptions/'.$params['id'].'.json');
+        $endPoint = Http::prepare('forum_subscriptions/' . $params['id'] . '.json');
         $response = Http::send($this->client, $endPoint);
         if ((!is_object($response)) || ($this->client->getDebug()->lastResponseCode != 200)) {
             throw new ResponseException(__METHOD__);
         }
         $this->client->setSideload(null);
+
         return $response;
     }
 
@@ -74,16 +80,17 @@ class ForumSubscriptions extends ClientAbstract {
      *
      * @return mixed
      */
-    public function create(array $params) {
-        if($this->client->users()->getLastId() != null) {
+    public function create(array $params)
+    {
+        if ($this->client->users()->getLastId() != null) {
             $params['user_id'] = $this->client->users()->getLastId();
             $this->client->users()->setLastId(null);
         }
-        if($this->client->forums()->getLastId() != null) {
+        if ($this->client->forums()->getLastId() != null) {
             $params['forum_id'] = $this->client->forums()->getLastId();
             $this->client->forums()->setLastId(null);
         }
-        if(!$this->hasKeys($params, array('user_id', 'forum_id'))) {
+        if (!$this->hasKeys($params, array('user_id', 'forum_id'))) {
             throw new MissingParametersException(__METHOD__, array('user_id', 'forum_id'));
         }
         $endPoint = Http::prepare('forum_subscriptions.json');
@@ -92,6 +99,7 @@ class ForumSubscriptions extends ClientAbstract {
             throw new ResponseException(__METHOD__);
         }
         $this->client->setSideload(null);
+
         return $response;
     }
 
@@ -106,20 +114,22 @@ class ForumSubscriptions extends ClientAbstract {
      *
      * @return bool
      */
-    public function delete(array $params = array()) {
-        if($this->lastId != null) {
+    public function delete(array $params = array())
+    {
+        if ($this->lastId != null) {
             $params['id'] = $this->lastId;
             $this->lastId = null;
         }
-        if(!$this->hasKeys($params, array('id'))) {
+        if (!$this->hasKeys($params, array('id'))) {
             throw new MissingParametersException(__METHOD__, array('id'));
         }
-        $endPoint = Http::prepare('forum_subscriptions/'.$params['id'].'.json');
+        $endPoint = Http::prepare('forum_subscriptions/' . $params['id'] . '.json');
         $response = Http::send($this->client, $endPoint, null, 'DELETE');
         if ($this->client->getDebug()->lastResponseCode != 200) {
             throw new ResponseException(__METHOD__);
         }
         $this->client->setSideload(null);
+
         return true;
     }
 

--- a/src/Zendesk/API/Forums.php
+++ b/src/Zendesk/API/Forums.php
@@ -6,7 +6,8 @@ namespace Zendesk\API;
  * The Forums class exposes forum information
  * @package Zendesk\API
  */
-class Forums extends ClientAbstract {
+class Forums extends ClientAbstract
+{
 
     const OBJ_NAME = 'forum';
     const OBJ_NAME_PLURAL = 'forums';
@@ -19,7 +20,8 @@ class Forums extends ClientAbstract {
     /**
      * @param Client $client
      */
-    public function __construct(Client $client) {
+    public function __construct(Client $client)
+    {
         parent::__construct($client);
         $this->subscriptions = new ForumSubscriptions($client);
     }
@@ -34,13 +36,16 @@ class Forums extends ClientAbstract {
      *
      * @return mixed
      */
-    public function findAll(array $params = array()) {
-        $endPoint = Http::prepare((isset($params['category_id']) ? 'categories/'.$params['category_id'].'/forums.json' : 'forums.json'), null, $params);
+    public function findAll(array $params = array())
+    {
+        $endPoint = Http::prepare((isset($params['category_id']) ? 'categories/' . $params['category_id'] . '/forums.json' : 'forums.json'),
+            null, $params);
         $response = Http::send($this->client, $endPoint);
         if ((!is_object($response)) || ($this->client->getDebug()->lastResponseCode != 200)) {
             throw new ResponseException(__METHOD__);
         }
         $this->client->setSideload(null);
+
         return $response;
     }
 
@@ -55,20 +60,22 @@ class Forums extends ClientAbstract {
      *
      * @return mixed
      */
-    public function find(array $params = array()) {
-        if($this->lastId != null) {
+    public function find(array $params = array())
+    {
+        if ($this->lastId != null) {
             $params['id'] = $this->lastId;
             $this->lastId = null;
         }
-        if(!$this->hasKeys($params, array('id'))) {
+        if (!$this->hasKeys($params, array('id'))) {
             throw new MissingParametersException(__METHOD__, array('id'));
         }
-        $endPoint = Http::prepare('forums/'.$params['id'].'.json');
+        $endPoint = Http::prepare('forums/' . $params['id'] . '.json');
         $response = Http::send($this->client, $endPoint);
         if ((!is_object($response)) || ($this->client->getDebug()->lastResponseCode != 200)) {
             throw new ResponseException(__METHOD__);
         }
         $this->client->setSideload(null);
+
         return $response;
     }
 
@@ -82,13 +89,15 @@ class Forums extends ClientAbstract {
      *
      * @return mixed
      */
-    public function create(array $params) {
+    public function create(array $params)
+    {
         $endPoint = Http::prepare('forums.json');
         $response = Http::send($this->client, $endPoint, array(self::OBJ_NAME => $params), 'POST');
         if ((!is_object($response)) || ($this->client->getDebug()->lastResponseCode != 201)) {
             throw new ResponseException(__METHOD__);
         }
         $this->client->setSideload(null);
+
         return $response;
     }
 
@@ -103,22 +112,24 @@ class Forums extends ClientAbstract {
      *
      * @return mixed
      */
-    public function update(array $params) {
-        if($this->lastId != null) {
+    public function update(array $params)
+    {
+        if ($this->lastId != null) {
             $params['id'] = $this->lastId;
             $this->lastId = null;
         }
-        if(!$this->hasKeys($params, array('id'))) {
+        if (!$this->hasKeys($params, array('id'))) {
             throw new MissingParametersException(__METHOD__, array('id'));
         }
         $id = $params['id'];
         unset($params['id']);
-        $endPoint = Http::prepare('forums/'.$id.'.json');
+        $endPoint = Http::prepare('forums/' . $id . '.json');
         $response = Http::send($this->client, $endPoint, array(self::OBJ_NAME => $params), 'PUT');
         if ((!is_object($response)) || ($this->client->getDebug()->lastResponseCode != 200)) {
             throw new ResponseException(__METHOD__);
         }
         $this->client->setSideload(null);
+
         return $response;
     }
 
@@ -133,20 +144,22 @@ class Forums extends ClientAbstract {
      *
      * @return bool
      */
-    public function delete(array $params = array()) {
-        if($this->lastId != null) {
+    public function delete(array $params = array())
+    {
+        if ($this->lastId != null) {
             $params['id'] = $this->lastId;
             $this->lastId = null;
         }
-        if(!$this->hasKeys($params, array('id'))) {
+        if (!$this->hasKeys($params, array('id'))) {
             throw new MissingParametersException(__METHOD__, array('id'));
         }
-        $endPoint = Http::prepare('forums/'.$params['id'].'.json');
+        $endPoint = Http::prepare('forums/' . $params['id'] . '.json');
         $response = Http::send($this->client, $endPoint, null, 'DELETE');
         if ($this->client->getDebug()->lastResponseCode != 200) {
             throw new ResponseException(__METHOD__);
         }
         $this->client->setSideload(null);
+
         return true;
     }
 
@@ -160,12 +173,18 @@ class Forums extends ClientAbstract {
      *
      * @return ForumSubscriptions
      */
-    public function subscriptions($id = null) { return ($id != null ? $this->subscriptions->setLastId($id) : $this->subscriptions); }
+    public function subscriptions($id = null)
+    {
+        return ($id != null ? $this->subscriptions->setLastId($id) : $this->subscriptions);
+    }
 
     /**
      * @param int $id
      *
      * @return ForumSubscriptions
      */
-    public function subscription($id) { return $this->subscriptions->setLastId($id); }
+    public function subscription($id)
+    {
+        return $this->subscriptions->setLastId($id);
+    }
 }

--- a/src/Zendesk/API/GroupMemberships.php
+++ b/src/Zendesk/API/GroupMemberships.php
@@ -6,7 +6,8 @@ namespace Zendesk\API;
  * The GroupMemberships class exposes group membership information
  * @package Zendesk\API
  */
-class GroupMemberships extends ClientAbstract {
+class GroupMemberships extends ClientAbstract
+{
 
     const OBJ_NAME = 'group_membership';
     const OBJ_NAME_PLURAL = 'group_memberships';
@@ -21,25 +22,28 @@ class GroupMemberships extends ClientAbstract {
      *
      * @return mixed
      */
-    public function findAll(array $params = array()) {
-        if($this->client->users()->getLastId() != null) {
+    public function findAll(array $params = array())
+    {
+        if ($this->client->users()->getLastId() != null) {
             $params['user_id'] = $this->client->users()->getLastId();
             $this->client->users()->setLastId(null);
         }
-        if($this->client->groups()->getLastId() != null) {
+        if ($this->client->groups()->getLastId() != null) {
             $params['group_id'] = $this->client->groups()->getLastId();
             $this->client->groups()->setLastId(null);
         }
         $endPoint = Http::prepare(
-                (isset($params['assignable']) ? (isset($params['group_id']) ? 'groups/'.$params['group_id'].'/memberships/assignable.json' : 'group_memberships/assignable.json') :
-                (isset($params['user_id']) ? 'users/'.$params['user_id'].'/group_memberships.json' :
-                (isset($params['group_id']) ? 'groups/'.$params['group_id'].'/memberships.json' : 'group_memberships.json'))), $this->client->getSideload($params), $params
-            );
+            (isset($params['assignable']) ? (isset($params['group_id']) ? 'groups/' . $params['group_id'] . '/memberships/assignable.json' : 'group_memberships/assignable.json') :
+                (isset($params['user_id']) ? 'users/' . $params['user_id'] . '/group_memberships.json' :
+                    (isset($params['group_id']) ? 'groups/' . $params['group_id'] . '/memberships.json' : 'group_memberships.json'))),
+            $this->client->getSideload($params), $params
+        );
         $response = Http::send($this->client, $endPoint);
         if ((!is_object($response)) || ($this->client->getDebug()->lastResponseCode != 200)) {
             throw new ResponseException(__METHOD__);
         }
         $this->client->setSideload(null);
+
         return $response;
     }
 
@@ -54,24 +58,27 @@ class GroupMemberships extends ClientAbstract {
      *
      * @return mixed
      */
-    public function find(array $params = array()) {
-        if($this->client->users()->getLastId() != null) {
+    public function find(array $params = array())
+    {
+        if ($this->client->users()->getLastId() != null) {
             $params['user_id'] = $this->client->users()->getLastId();
             $this->client->users()->setLastId(null);
         }
-        if($this->lastId != null) {
+        if ($this->lastId != null) {
             $params['id'] = $this->lastId;
             $this->lastId = null;
         }
-        if(!$this->hasKeys($params, array('id'))) {
+        if (!$this->hasKeys($params, array('id'))) {
             throw new MissingParametersException(__METHOD__, array('id'));
         }
-        $endPoint = Http::prepare((isset($params['user_id']) ? 'users/'.$params['user_id'].'/group_memberships/'.$params['id'].'.json' : 'group_memberships/'.$params['id'].'.json'), $this->client->getSideload($params));
+        $endPoint = Http::prepare((isset($params['user_id']) ? 'users/' . $params['user_id'] . '/group_memberships/' . $params['id'] . '.json' : 'group_memberships/' . $params['id'] . '.json'),
+            $this->client->getSideload($params));
         $response = Http::send($this->client, $endPoint);
         if ((!is_object($response)) || ($this->client->getDebug()->lastResponseCode != 200)) {
             throw new ResponseException(__METHOD__);
         }
         $this->client->setSideload(null);
+
         return $response;
     }
 
@@ -86,24 +93,26 @@ class GroupMemberships extends ClientAbstract {
      *
      * @return mixed
      */
-    public function create(array $params) {
-        if($this->client->users()->getLastId() != null) {
+    public function create(array $params)
+    {
+        if ($this->client->users()->getLastId() != null) {
             $params['user_id'] = $this->client->users()->getLastId();
             $this->client->users()->setLastId(null);
         }
-        if($this->client->groups()->getLastId() != null) {
+        if ($this->client->groups()->getLastId() != null) {
             $params['group_id'] = $this->client->groups()->getLastId();
             $this->client->groups()->setLastId(null);
         }
-        if(!$this->hasKeys($params, array('user_id', 'group_id'))) {
+        if (!$this->hasKeys($params, array('user_id', 'group_id'))) {
             throw new MissingParametersException(__METHOD__, array('user_id', 'group_id'));
         }
-        $endPoint = Http::prepare((isset($params['user_id']) ? 'users/'.$params['user_id'].'/group_memberships.json' : 'group_memberships.json'));
-        $response = Http::send($this->client, $endPoint, array (self::OBJ_NAME => $params), 'POST');
+        $endPoint = Http::prepare((isset($params['user_id']) ? 'users/' . $params['user_id'] . '/group_memberships.json' : 'group_memberships.json'));
+        $response = Http::send($this->client, $endPoint, array(self::OBJ_NAME => $params), 'POST');
         if ((!is_object($response)) || ($this->client->getDebug()->lastResponseCode != 201)) {
             throw new ResponseException(__METHOD__);
         }
         $this->client->setSideload(null);
+
         return $response;
     }
 
@@ -118,24 +127,26 @@ class GroupMemberships extends ClientAbstract {
      *
      * @return bool
      */
-    public function delete(array $params = array()) {
-        if($this->client->users()->getLastId() != null) {
+    public function delete(array $params = array())
+    {
+        if ($this->client->users()->getLastId() != null) {
             $params['user_id'] = $this->client->users()->getLastId();
             $this->client->users()->setLastId(null);
         }
-        if($this->lastId != null) {
+        if ($this->lastId != null) {
             $params['id'] = $this->lastId;
             $this->lastId = null;
         }
-        if(!$this->hasKeys($params, array('id'))) {
+        if (!$this->hasKeys($params, array('id'))) {
             throw new MissingParametersException(__METHOD__, array('id'));
         }
-        $endPoint = Http::prepare((isset($params['user_id']) ? 'users/'.$params['user_id'].'/group_memberships/'.$params['id'].'.json' : 'group_memberships/'.$params['id'].'.json'));
+        $endPoint = Http::prepare((isset($params['user_id']) ? 'users/' . $params['user_id'] . '/group_memberships/' . $params['id'] . '.json' : 'group_memberships/' . $params['id'] . '.json'));
         $response = Http::send($this->client, $endPoint, null, 'DELETE');
         if ($this->client->getDebug()->lastResponseCode != 200) {
             throw new ResponseException(__METHOD__);
         }
         $this->client->setSideload(null);
+
         return true;
     }
 
@@ -150,24 +161,26 @@ class GroupMemberships extends ClientAbstract {
      *
      * @return mixed
      */
-    public function makeDefault(array $params = array()) {
-        if($this->client->users()->getLastId() != null) {
+    public function makeDefault(array $params = array())
+    {
+        if ($this->client->users()->getLastId() != null) {
             $params['user_id'] = $this->client->users()->getLastId();
             $this->client->users()->setLastId(null);
         }
-        if($this->lastId != null) {
+        if ($this->lastId != null) {
             $params['id'] = $this->lastId;
             $this->lastId = null;
         }
-        if(!$this->hasKeys($params, array('user_id', 'id'))) {
+        if (!$this->hasKeys($params, array('user_id', 'id'))) {
             throw new MissingParametersException(__METHOD__, array('user_id', 'id'));
         }
-        $endPoint = Http::prepare('users/'.$params['user_id'].'/group_memberships/'.$params['id'].'/make_default.json');
+        $endPoint = Http::prepare('users/' . $params['user_id'] . '/group_memberships/' . $params['id'] . '/make_default.json');
         $response = Http::send($this->client, $endPoint, null, 'PUT');
         if ((!is_object($response)) || ($this->client->getDebug()->lastResponseCode != 200)) {
             throw new ResponseException(__METHOD__);
         }
         $this->client->setSideload(null);
+
         return $response;
     }
 

--- a/src/Zendesk/API/Groups.php
+++ b/src/Zendesk/API/Groups.php
@@ -6,7 +6,8 @@ namespace Zendesk\API;
  * The Groups class exposes ticket group information
  * @package Zendesk\API
  */
-class Groups extends ClientAbstract {
+class Groups extends ClientAbstract
+{
 
     const OBJ_NAME = 'group';
     const OBJ_NAME_PLURAL = 'groups';
@@ -21,20 +22,23 @@ class Groups extends ClientAbstract {
      *
      * @return mixed
      */
-    public function findAll(array $params = array()) {
-        if($this->client->users()->getLastId() != null) {
+    public function findAll(array $params = array())
+    {
+        if ($this->client->users()->getLastId() != null) {
             $params['user_id'] = $this->client->users()->getLastId();
             $this->client->users()->setLastId(null);
         }
         $endPoint = Http::prepare(
-                (isset($params['user_id']) ? 'users/'.$params['user_id'].'/groups.json' :
-                (isset($params['assignable']) ? 'groups/assignable.json' : 'groups.json')), $this->client->getSideload($params), $params
+            (isset($params['user_id']) ? 'users/' . $params['user_id'] . '/groups.json' :
+                (isset($params['assignable']) ? 'groups/assignable.json' : 'groups.json')),
+            $this->client->getSideload($params), $params
         );
         $response = Http::send($this->client, $endPoint);
         if ((!is_object($response)) || ($this->client->getDebug()->lastResponseCode != 200)) {
             throw new ResponseException(__METHOD__);
         }
         $this->client->setSideload(null);
+
         return $response;
     }
 
@@ -49,20 +53,22 @@ class Groups extends ClientAbstract {
      *
      * @return mixed
      */
-    public function find(array $params = array()) {
-        if($this->lastId != null) {
+    public function find(array $params = array())
+    {
+        if ($this->lastId != null) {
             $params['id'] = $this->lastId;
             $this->lastId = null;
         }
-        if(!$this->hasKeys($params, array('id'))) {
+        if (!$this->hasKeys($params, array('id'))) {
             throw new MissingParametersException(__METHOD__, array('id'));
         }
-        $endPoint = Http::prepare('groups/'.$params['id'].'.json', $this->client->getSideload($params));
+        $endPoint = Http::prepare('groups/' . $params['id'] . '.json', $this->client->getSideload($params));
         $response = Http::send($this->client, $endPoint);
         if ((!is_object($response)) || ($this->client->getDebug()->lastResponseCode != 200)) {
             throw new ResponseException(__METHOD__);
         }
         $this->client->setSideload(null);
+
         return $response;
     }
 
@@ -76,13 +82,15 @@ class Groups extends ClientAbstract {
      *
      * @return mixed
      */
-    public function create(array $params) {
+    public function create(array $params)
+    {
         $endPoint = Http::prepare('groups.json');
         $response = Http::send($this->client, $endPoint, array(self::OBJ_NAME => $params), 'POST');
         if ((!is_object($response)) || ($this->client->getDebug()->lastResponseCode != 201)) {
             throw new ResponseException(__METHOD__);
         }
         $this->client->setSideload(null);
+
         return $response;
     }
 
@@ -97,22 +105,24 @@ class Groups extends ClientAbstract {
      *
      * @return mixed
      */
-    public function update(array $params) {
-        if($this->lastId != null) {
+    public function update(array $params)
+    {
+        if ($this->lastId != null) {
             $params['id'] = $this->lastId;
             $this->lastId = null;
         }
-        if(!$this->hasKeys($params, array('id'))) {
+        if (!$this->hasKeys($params, array('id'))) {
             throw new MissingParametersException(__METHOD__, array('id'));
         }
         $id = $params['id'];
         unset($params['id']);
-        $endPoint = Http::prepare('groups/'.$id.'.json');
+        $endPoint = Http::prepare('groups/' . $id . '.json');
         $response = Http::send($this->client, $endPoint, array(self::OBJ_NAME => $params), 'PUT');
         if ((!is_object($response)) || ($this->client->getDebug()->lastResponseCode != 200)) {
             throw new ResponseException(__METHOD__);
         }
         $this->client->setSideload(null);
+
         return $response;
     }
 
@@ -127,20 +137,22 @@ class Groups extends ClientAbstract {
      *
      * @return bool
      */
-    public function delete(array $params = array()) {
-        if($this->lastId != null) {
+    public function delete(array $params = array())
+    {
+        if ($this->lastId != null) {
             $params['id'] = $this->lastId;
             $this->lastId = null;
         }
-        if(!$this->hasKeys($params, array('id'))) {
+        if (!$this->hasKeys($params, array('id'))) {
             throw new MissingParametersException(__METHOD__, array('id'));
         }
-        $endPoint = Http::prepare('groups/'.$params['id'].'.json');
+        $endPoint = Http::prepare('groups/' . $params['id'] . '.json');
         $response = Http::send($this->client, $endPoint, null, 'DELETE');
         if ($this->client->getDebug()->lastResponseCode != 200) {
             throw new ResponseException(__METHOD__);
         }
         $this->client->setSideload(null);
+
         return true;
     }
 
@@ -149,13 +161,19 @@ class Groups extends ClientAbstract {
      *
      * @return GroupMemberships
      */
-    public function members($id = null) { return ($id != null ? $this->client->groupMemberships()->setLastId($id) : $this->client->groupMemberships()); }
+    public function members($id = null)
+    {
+        return ($id != null ? $this->client->groupMemberships()->setLastId($id) : $this->client->groupMemberships());
+    }
 
     /**
      * @param int $id
      *
      * @return GroupMemberships
      */
-    public function member($id) { return $this->client->groupMemberships()->setLastId($id); }
+    public function member($id)
+    {
+        return $this->client->groupMemberships()->setLastId($id);
+    }
 
 }

--- a/src/Zendesk/API/JobStatuses.php
+++ b/src/Zendesk/API/JobStatuses.php
@@ -6,7 +6,8 @@ namespace Zendesk\API;
  * The JobStatuses class exposes information about the status of a job
  * @package Zendesk\API
  */
-class JobStatuses extends ClientAbstract {
+class JobStatuses extends ClientAbstract
+{
 
     /**
      * Show a specific job status
@@ -19,20 +20,22 @@ class JobStatuses extends ClientAbstract {
      *
      * @return mixed
      */
-    public function find(array $params = array()) {
-        if($this->lastId != null) {
+    public function find(array $params = array())
+    {
+        if ($this->lastId != null) {
             $params['id'] = $this->lastId;
             $this->lastId = null;
         }
-        if(!$this->hasKeys($params, array('id'))) {
+        if (!$this->hasKeys($params, array('id'))) {
             throw new MissingParametersException(__METHOD__, array('id'));
         }
-        $endPoint = Http::prepare('job_statuses/'.$params['id'].'.json');
+        $endPoint = Http::prepare('job_statuses/' . $params['id'] . '.json');
         $response = Http::send($this->client, $endPoint);
         if ((!is_object($response)) || ($this->client->getDebug()->lastResponseCode != 200)) {
             throw new ResponseException(__METHOD__);
         }
         $this->client->setSideload(null);
+
         return $response;
     }
 

--- a/src/Zendesk/API/Locales.php
+++ b/src/Zendesk/API/Locales.php
@@ -6,7 +6,8 @@ namespace Zendesk\API;
  * The Locales class exposes view management methods
  * @package Zendesk\API
  */
-class Locales extends ClientAbstract {
+class Locales extends ClientAbstract
+{
 
     const OBJ_NAME = 'locale';
     const OBJ_NAME_PLURAL = 'locales';
@@ -21,15 +22,17 @@ class Locales extends ClientAbstract {
      *
      * @return mixed
      */
-    public function findAll(array $params = array()) {
+    public function findAll(array $params = array())
+    {
         $endPoint = Http::prepare(
-                (isset($params['current']) ? 'locales/current.json' :
+            (isset($params['current']) ? 'locales/current.json' :
                 (isset($params['agent']) ? 'locales/agent.json' : 'locales.json')), null, $params);
         $response = Http::send($this->client, $endPoint);
         if ((!is_object($response)) || ($this->client->getDebug()->lastResponseCode != 200)) {
             throw new ResponseException(__METHOD__);
         }
         $this->client->setSideload(null);
+
         return $response;
     }
 
@@ -44,20 +47,22 @@ class Locales extends ClientAbstract {
      *
      * @return mixed
      */
-    public function find(array $params = array()) {
-        if($this->lastId != null) {
+    public function find(array $params = array())
+    {
+        if ($this->lastId != null) {
             $params['id'] = $this->lastId;
             $this->lastId = null;
         }
-        if(!$this->hasKeys($params, array('id'))) {
+        if (!$this->hasKeys($params, array('id'))) {
             throw new MissingParametersException(__METHOD__, array('id'));
         }
-        $endPoint = Http::prepare('locales/'.$params['id'].'.json');
+        $endPoint = Http::prepare('locales/' . $params['id'] . '.json');
         $response = Http::send($this->client, $endPoint);
         if ((!is_object($response)) || ($this->client->getDebug()->lastResponseCode != 200)) {
             throw new ResponseException(__METHOD__);
         }
         $this->client->setSideload(null);
+
         return $response;
     }
 
@@ -72,16 +77,19 @@ class Locales extends ClientAbstract {
      *
      * @return mixed
      */
-    public function detectBest(array $params) {
-        if(!$this->hasKeys($params, array('available_locales'))) {
+    public function detectBest(array $params)
+    {
+        if (!$this->hasKeys($params, array('available_locales'))) {
             throw new MissingParametersException(__METHOD__, array('available_locales'));
         }
         $endPoint = Http::prepare('locales/detect_best_locale.json', null, $params);
-        $response = Http::send($this->client, $endPoint, array('available_locales' => $params['available_locales']), 'GET');
+        $response = Http::send($this->client, $endPoint, array('available_locales' => $params['available_locales']),
+            'GET');
         if ((!is_object($response)) || ($this->client->getDebug()->lastResponseCode != 200)) {
             throw new ResponseException(__METHOD__);
         }
         $this->client->setSideload(null);
+
         return $response;
     }
 
@@ -95,13 +103,19 @@ class Locales extends ClientAbstract {
      *
      * @return mixed
      */
-    public function agent() { return $this->findAll(array('agent' => true)); }
+    public function agent()
+    {
+        return $this->findAll(array('agent' => true));
+    }
 
     /**
      * @throws ResponseException
      *
      * @return mixed
      */
-    public function current() { return $this->findAll(array('current' => true)); }
+    public function current()
+    {
+        return $this->findAll(array('current' => true));
+    }
 
 }

--- a/src/Zendesk/API/Macros.php
+++ b/src/Zendesk/API/Macros.php
@@ -6,7 +6,8 @@ namespace Zendesk\API;
  * The Macros class exposes methods seen at http://developer.zendesk.com/documentation/rest_api/macros.html
  * @package Zendesk\API
  */
-class Macros extends ClientAbstract {
+class Macros extends ClientAbstract
+{
 
     const OBJ_NAME = 'macro';
     const OBJ_NAME_PLURAL = 'macros';
@@ -21,13 +22,15 @@ class Macros extends ClientAbstract {
      *
      * @return mixed
      */
-    public function findAll(array $params = array()) {
+    public function findAll(array $params = array())
+    {
         $endPoint = Http::prepare((isset($params['active']) ? 'macros/active.json' : 'macros.json'), null, $params);
         $response = Http::send($this->client, $endPoint);
         if ((!is_object($response)) || ($this->client->getDebug()->lastResponseCode != 200)) {
             throw new ResponseException(__METHOD__);
         }
         $this->client->setSideload(null);
+
         return $response;
     }
 
@@ -42,20 +45,22 @@ class Macros extends ClientAbstract {
      *
      * @return mixed
      */
-    public function find(array $params = array()) {
-        if($this->lastId != null) {
+    public function find(array $params = array())
+    {
+        if ($this->lastId != null) {
             $params['id'] = $this->lastId;
             $this->lastId = null;
         }
-        if(!$this->hasKeys($params, array('id'))) {
+        if (!$this->hasKeys($params, array('id'))) {
             throw new MissingParametersException(__METHOD__, array('id'));
         }
-        $endPoint = Http::prepare('macros/'.$params['id'].'.json');
+        $endPoint = Http::prepare('macros/' . $params['id'] . '.json');
         $response = Http::send($this->client, $endPoint);
         if ((!is_object($response)) || ($this->client->getDebug()->lastResponseCode != 200)) {
             throw new ResponseException(__METHOD__);
         }
         $this->client->setSideload(null);
+
         return $response;
     }
 
@@ -69,13 +74,15 @@ class Macros extends ClientAbstract {
      *
      * @return mixed
      */
-    public function create(array $params) {
+    public function create(array $params)
+    {
         $endPoint = Http::prepare('macros.json');
         $response = Http::send($this->client, $endPoint, array(self::OBJ_NAME => $params), 'POST');
         if ((!is_object($response)) || ($this->client->getDebug()->lastResponseCode != 201)) {
             throw new ResponseException(__METHOD__);
         }
         $this->client->setSideload(null);
+
         return $response;
     }
 
@@ -90,20 +97,22 @@ class Macros extends ClientAbstract {
      *
      * @return mixed
      */
-    public function update(array $params) {
-        if($this->lastId != null) {
+    public function update(array $params)
+    {
+        if ($this->lastId != null) {
             $params['id'] = $this->lastId;
             $this->lastId = null;
         }
-        if(!$this->hasKeys($params, array('id'))) {
+        if (!$this->hasKeys($params, array('id'))) {
             throw new MissingParametersException(__METHOD__, array('id'));
         }
-        $endPoint = Http::prepare('macros/'.$params['id'].'.json');
+        $endPoint = Http::prepare('macros/' . $params['id'] . '.json');
         $response = Http::send($this->client, $endPoint, array(self::OBJ_NAME => $params), 'PUT');
         if ((!is_object($response)) || ($this->client->getDebug()->lastResponseCode != 200)) {
             throw new ResponseException(__METHOD__);
         }
         $this->client->setSideload(null);
+
         return $response;
     }
 
@@ -118,21 +127,23 @@ class Macros extends ClientAbstract {
      *
      * @return bool
      */
-    public function delete(array $params = array()) {
-        if($this->lastId != null) {
+    public function delete(array $params = array())
+    {
+        if ($this->lastId != null) {
             $params['id'] = $this->lastId;
             $this->lastId = null;
         }
-        if(!$this->hasKeys($params, array('id'))) {
+        if (!$this->hasKeys($params, array('id'))) {
             throw new MissingParametersException(__METHOD__, array('id'));
         }
         $id = $params['id'];
-        $endPoint = Http::prepare('macros/'.$id.'.json');
+        $endPoint = Http::prepare('macros/' . $id . '.json');
         $response = Http::send($this->client, $endPoint, null, 'DELETE');
         if ($this->client->getDebug()->lastResponseCode != 200) {
             throw new ResponseException(__METHOD__);
         }
         $this->client->setSideload(null);
+
         return true;
     }
 
@@ -147,24 +158,26 @@ class Macros extends ClientAbstract {
      *
      * @return mixed
      */
-    public function apply(array $params = array()) {
-        if($this->client->tickets()->getLastId() != null) {
+    public function apply(array $params = array())
+    {
+        if ($this->client->tickets()->getLastId() != null) {
             $params['ticket_id'] = $this->client->tickets()->getLastId();
             $this->client->tickets()->setLastId(null);
         }
-        if($this->lastId != null) {
+        if ($this->lastId != null) {
             $params['id'] = $this->lastId;
             $this->lastId = null;
         }
-        if(!$this->hasKeys($params, array('id'))) {
+        if (!$this->hasKeys($params, array('id'))) {
             throw new MissingParametersException(__METHOD__, array('id'));
         }
-        $endPoint = Http::prepare((isset($params['ticket_id']) ? 'tickets/'.$params['ticket_id'].'/macros/'.$params['id'].'/apply.json' : 'macros/'.$params['id'].'/apply.json'));
+        $endPoint = Http::prepare((isset($params['ticket_id']) ? 'tickets/' . $params['ticket_id'] . '/macros/' . $params['id'] . '/apply.json' : 'macros/' . $params['id'] . '/apply.json'));
         $response = Http::send($this->client, $endPoint);
         if ((!is_object($response)) || ($this->client->getDebug()->lastResponseCode != 200)) {
             throw new ResponseException(__METHOD__);
         }
         $this->client->setSideload(null);
+
         return $response;
     }
 

--- a/src/Zendesk/API/MissingParametersException.php
+++ b/src/Zendesk/API/MissingParametersException.php
@@ -6,16 +6,19 @@ namespace Zendesk\API;
  * MissingParametersException extends the Exception class with simplified messaging
  * @package Zendesk\API
  */
-class MissingParametersException extends \Exception {
+class MissingParametersException extends \Exception
+{
 
     /**
-     * @param string     $method
-     * @param array      $params
-     * @param int        $code
+     * @param string $method
+     * @param array $params
+     * @param int $code
      * @param \Exception $previous
      */
-    public function __construct($method, array $params, $code = 0, \Exception $previous = null) {
-        parent::__construct('Missing parameters: \''.implode("', '", $params).'\' must be supplied for '.$method, $code, $previous);
+    public function __construct($method, array $params, $code = 0, \Exception $previous = null)
+    {
+        parent::__construct('Missing parameters: \'' . implode("', '", $params) . '\' must be supplied for ' . $method,
+            $code, $previous);
     }
 
 }

--- a/src/Zendesk/API/OAuthClients.php
+++ b/src/Zendesk/API/OAuthClients.php
@@ -6,7 +6,8 @@ namespace Zendesk\API;
  * The OAuthClients class exposes methods seen at http://developer.zendesk.com/documentation/rest_api/oauth_clients.html
  * @package Zendesk\API
  */
-class OAuthClients extends ClientAbstract {
+class OAuthClients extends ClientAbstract
+{
 
     const OBJ_NAME = 'client';
     const OBJ_NAME_PLURAL = 'clients';
@@ -21,13 +22,16 @@ class OAuthClients extends ClientAbstract {
      *
      * @return mixed
      */
-    public function findAll(array $params = array()) {
-        $endPoint = Http::prepare((isset($params['me']) ? 'users/me/oauth/clients.json' : 'oauth/clients.json'), null, $params);
+    public function findAll(array $params = array())
+    {
+        $endPoint = Http::prepare((isset($params['me']) ? 'users/me/oauth/clients.json' : 'oauth/clients.json'), null,
+            $params);
         $response = Http::send($this->client, $endPoint);
         if ((!is_object($response)) || ($this->client->getDebug()->lastResponseCode != 200)) {
             throw new ResponseException(__METHOD__);
         }
         $this->client->setSideload(null);
+
         return $response;
     }
 
@@ -42,20 +46,22 @@ class OAuthClients extends ClientAbstract {
      *
      * @return mixed
      */
-    public function find(array $params = array()) {
-        if($this->lastId != null) {
+    public function find(array $params = array())
+    {
+        if ($this->lastId != null) {
             $params['id'] = $this->lastId;
             $this->lastId = null;
         }
-        if(!$this->hasKeys($params, array('id'))) {
+        if (!$this->hasKeys($params, array('id'))) {
             throw new MissingParametersException(__METHOD__, array('id'));
         }
-        $endPoint = Http::prepare('oauth/clients/'.$params['id'].'.json');
+        $endPoint = Http::prepare('oauth/clients/' . $params['id'] . '.json');
         $response = Http::send($this->client, $endPoint);
         if ((!is_object($response)) || ($this->client->getDebug()->lastResponseCode != 200)) {
             throw new ResponseException(__METHOD__);
         }
         $this->client->setSideload(null);
+
         return $response;
     }
 
@@ -69,13 +75,15 @@ class OAuthClients extends ClientAbstract {
      *
      * @return mixed
      */
-    public function create(array $params) {
+    public function create(array $params)
+    {
         $endPoint = Http::prepare('oauth/clients.json');
         $response = Http::send($this->client, $endPoint, array(self::OBJ_NAME => $params), 'POST');
         if ((!is_object($response)) || ($this->client->getDebug()->lastResponseCode != 201)) {
             throw new ResponseException(__METHOD__);
         }
         $this->client->setSideload(null);
+
         return $response;
     }
 
@@ -90,22 +98,24 @@ class OAuthClients extends ClientAbstract {
      *
      * @return mixed
      */
-    public function update(array $params) {
-        if($this->lastId != null) {
+    public function update(array $params)
+    {
+        if ($this->lastId != null) {
             $params['id'] = $this->lastId;
             $this->lastId = null;
         }
-        if(!$this->hasKeys($params, array('id'))) {
+        if (!$this->hasKeys($params, array('id'))) {
             throw new MissingParametersException(__METHOD__, array('id'));
         }
         $id = $params['id'];
         unset($params['id']);
-        $endPoint = Http::prepare('oauth/clients/'.$id.'.json');
+        $endPoint = Http::prepare('oauth/clients/' . $id . '.json');
         $response = Http::send($this->client, $endPoint, array(self::OBJ_NAME => $params), 'PUT');
         if ((!is_object($response)) || ($this->client->getDebug()->lastResponseCode != 200)) {
             throw new ResponseException(__METHOD__);
         }
         $this->client->setSideload(null);
+
         return $response;
     }
 
@@ -120,21 +130,23 @@ class OAuthClients extends ClientAbstract {
      *
      * @return bool
      */
-    public function delete(array $params = array()) {
-        if($this->lastId != null) {
+    public function delete(array $params = array())
+    {
+        if ($this->lastId != null) {
             $params['id'] = $this->lastId;
             $this->lastId = null;
         }
-        if(!$this->hasKeys($params, array('id'))) {
+        if (!$this->hasKeys($params, array('id'))) {
             throw new MissingParametersException(__METHOD__, array('id'));
         }
         $id = $params['id'];
-        $endPoint = Http::prepare('oauth/clients/'.$id.'.json');
+        $endPoint = Http::prepare('oauth/clients/' . $id . '.json');
         $response = Http::send($this->client, $endPoint, null, 'DELETE');
         if ($this->client->getDebug()->lastResponseCode != 200) {
             throw new ResponseException(__METHOD__);
         }
         $this->client->setSideload(null);
+
         return true;
     }
 

--- a/src/Zendesk/API/OAuthTokens.php
+++ b/src/Zendesk/API/OAuthTokens.php
@@ -6,7 +6,8 @@ namespace Zendesk\API;
  * The OAuthTokens class exposes methods seen at http://developer.zendesk.com/documentation/rest_api/oauth_clients.html
  * @package Zendesk\API
  */
-class OAuthTokens extends ClientAbstract {
+class OAuthTokens extends ClientAbstract
+{
 
     const OBJ_NAME = 'token';
     const OBJ_NAME_PLURAL = 'tokens';
@@ -21,13 +22,15 @@ class OAuthTokens extends ClientAbstract {
      *
      * @return mixed
      */
-    public function findAll(array $params = array()) {
+    public function findAll(array $params = array())
+    {
         $endPoint = Http::prepare('oauth/tokens.json', null, $params);
         $response = Http::send($this->client, $endPoint);
         if ((!is_object($response)) || ($this->client->getDebug()->lastResponseCode != 200)) {
             throw new ResponseException(__METHOD__);
         }
         $this->client->setSideload(null);
+
         return $response;
     }
 
@@ -41,17 +44,19 @@ class OAuthTokens extends ClientAbstract {
      *
      * @return mixed
      */
-    public function find(array $params = array()) {
-        if($this->lastId != null) {
+    public function find(array $params = array())
+    {
+        if ($this->lastId != null) {
             $params['id'] = $this->lastId;
             $this->lastId = null;
         }
-        $endPoint = Http::prepare('oauth/tokens/'.(isset($params['id']) ? $params['id'] : 'current').'.json');
+        $endPoint = Http::prepare('oauth/tokens/' . (isset($params['id']) ? $params['id'] : 'current') . '.json');
         $response = Http::send($this->client, $endPoint);
         if ((!is_object($response)) || ($this->client->getDebug()->lastResponseCode != 200)) {
             throw new ResponseException(__METHOD__);
         }
         $this->client->setSideload(null);
+
         return $response;
     }
 
@@ -66,21 +71,23 @@ class OAuthTokens extends ClientAbstract {
      *
      * @return bool
      */
-    public function revoke(array $params = array()) {
-        if($this->lastId != null) {
+    public function revoke(array $params = array())
+    {
+        if ($this->lastId != null) {
             $params['id'] = $this->lastId;
             $this->lastId = null;
         }
-        if(!$this->hasKeys($params, array('id'))) {
+        if (!$this->hasKeys($params, array('id'))) {
             throw new MissingParametersException(__METHOD__, array('id'));
         }
         $id = $params['id'];
-        $endPoint = Http::prepare('oauth/tokens/'.$id.'.json');
+        $endPoint = Http::prepare('oauth/tokens/' . $id . '.json');
         $response = Http::send($this->client, $endPoint, null, 'DELETE');
         if ($this->client->getDebug()->lastResponseCode != 200) {
             throw new ResponseException(__METHOD__);
         }
         $this->client->setSideload(null);
+
         return true;
     }
 

--- a/src/Zendesk/API/OrganizationFields.php
+++ b/src/Zendesk/API/OrganizationFields.php
@@ -6,7 +6,8 @@ namespace Zendesk\API;
  * The OrganizationFields class exposes methods as detailed on http://developer.zendesk.com/documentation/rest_api/organization_fields.html
  * @package Zendesk\API
  */
-class OrganizationFields extends ClientAbstract {
+class OrganizationFields extends ClientAbstract
+{
 
     const OBJ_NAME = 'organization_field';
     const OBJ_NAME_PLURAL = 'organization_fields';
@@ -21,13 +22,15 @@ class OrganizationFields extends ClientAbstract {
      *
      * @return mixed
      */
-    public function findAll(array $params = array()) {
+    public function findAll(array $params = array())
+    {
         $endPoint = Http::prepare('organization_fields.json', null, $params);
         $response = Http::send($this->client, $endPoint);
         if ((!is_object($response)) || ($this->client->getDebug()->lastResponseCode != 200)) {
             throw new ResponseException(__METHOD__);
         }
         $this->client->setSideload(null);
+
         return $response;
     }
 
@@ -42,20 +45,22 @@ class OrganizationFields extends ClientAbstract {
      *
      * @return mixed
      */
-    public function find(array $params = array()) {
-        if($this->lastId != null) {
+    public function find(array $params = array())
+    {
+        if ($this->lastId != null) {
             $params['id'] = $this->lastId;
             $this->lastId = null;
         }
-        if(!$this->hasKeys($params, array('id'))) {
+        if (!$this->hasKeys($params, array('id'))) {
             throw new MissingParametersException(__METHOD__, array('id'));
         }
-        $endPoint = Http::prepare('organization_fields/'.$params['id'].'.json');
+        $endPoint = Http::prepare('organization_fields/' . $params['id'] . '.json');
         $response = Http::send($this->client, $endPoint);
         if ((!is_object($response)) || ($this->client->getDebug()->lastResponseCode != 200)) {
             throw new ResponseException(__METHOD__);
         }
         $this->client->setSideload(null);
+
         return $response;
     }
 
@@ -69,13 +74,15 @@ class OrganizationFields extends ClientAbstract {
      *
      * @return mixed
      */
-    public function create(array $params) {
+    public function create(array $params)
+    {
         $endPoint = Http::prepare('organization_fields.json');
         $response = Http::send($this->client, $endPoint, array(self::OBJ_NAME => $params), 'POST');
         if ((!is_object($response)) || ($this->client->getDebug()->lastResponseCode != 201)) {
             throw new ResponseException(__METHOD__);
         }
         $this->client->setSideload(null);
+
         return $response;
     }
 
@@ -90,22 +97,24 @@ class OrganizationFields extends ClientAbstract {
      *
      * @return mixed
      */
-    public function update(array $params) {
-        if($this->lastId != null) {
+    public function update(array $params)
+    {
+        if ($this->lastId != null) {
             $params['id'] = $this->lastId;
             $this->lastId = null;
         }
-        if(!$this->hasKeys($params, array('id'))) {
+        if (!$this->hasKeys($params, array('id'))) {
             throw new MissingParametersException(__METHOD__, array('id'));
         }
         $id = $params['id'];
         unset($params['id']);
-        $endPoint = Http::prepare('organization_fields/'.$id.'.json');
+        $endPoint = Http::prepare('organization_fields/' . $id . '.json');
         $response = Http::send($this->client, $endPoint, array(self::OBJ_NAME => $params), 'PUT');
         if ((!is_object($response)) || ($this->client->getDebug()->lastResponseCode != 200)) {
             throw new ResponseException(__METHOD__);
         }
         $this->client->setSideload(null);
+
         return $response;
     }
 
@@ -120,21 +129,23 @@ class OrganizationFields extends ClientAbstract {
      *
      * @return bool
      */
-    public function delete(array $params = array()) {
-        if($this->lastId != null) {
+    public function delete(array $params = array())
+    {
+        if ($this->lastId != null) {
             $params['id'] = $this->lastId;
             $this->lastId = null;
         }
-        if(!$this->hasKeys($params, array('id'))) {
+        if (!$this->hasKeys($params, array('id'))) {
             throw new MissingParametersException(__METHOD__, array('id'));
         }
         $id = $params['id'];
-        $endPoint = Http::prepare('organization_fields/'.$id.'.json');
+        $endPoint = Http::prepare('organization_fields/' . $id . '.json');
         $response = Http::send($this->client, $endPoint, null, 'DELETE');
         if ($this->client->getDebug()->lastResponseCode != 200) {
             throw new ResponseException(__METHOD__);
         }
         $this->client->setSideload(null);
+
         return true;
     }
 
@@ -149,16 +160,19 @@ class OrganizationFields extends ClientAbstract {
      *
      * @return mixed
      */
-    public function reorder(array $params) {
-        if(!$this->hasKeys($params, array('organization_field_ids'))) {
+    public function reorder(array $params)
+    {
+        if (!$this->hasKeys($params, array('organization_field_ids'))) {
             throw new MissingParametersException(__METHOD__, array('organization_field_ids'));
         }
         $endPoint = Http::prepare('organization_fields/reorder.json');
-        $response = Http::send($this->client, $endPoint, array('organization_field_ids' => $params['organization_field_ids']), 'PUT');
+        $response = Http::send($this->client, $endPoint,
+            array('organization_field_ids' => $params['organization_field_ids']), 'PUT');
         if ($this->client->getDebug()->lastResponseCode != 200) {
             throw new ResponseException(__METHOD__);
         }
         $this->client->setSideload(null);
+
         return $response;
     }
 

--- a/src/Zendesk/API/Organizations.php
+++ b/src/Zendesk/API/Organizations.php
@@ -6,7 +6,8 @@ namespace Zendesk\API;
  * The Organizations class exposes methods as detailed on http://developer.zendesk.com/documentation/rest_api/organizations.html
  * @package Zendesk\API
  */
-class Organizations extends ClientAbstract {
+class Organizations extends ClientAbstract
+{
 
     const OBJ_NAME = 'organization';
     const OBJ_NAME_PLURAL = 'organizations';
@@ -21,17 +22,20 @@ class Organizations extends ClientAbstract {
      *
      * @return mixed
      */
-    public function findAll(array $params = array()) {
-        if($this->client->users()->getLastId() != null) {
+    public function findAll(array $params = array())
+    {
+        if ($this->client->users()->getLastId() != null) {
             $params['user_id'] = $this->client->users()->getLastId();
             $this->client->users()->setLastId(null);
         }
-        $endPoint = Http::prepare((isset($params['user_id']) ? 'users/'.$params['user_id'].'/organizations.json' : 'organizations.json'), $this->client->getSideload($params), $params);
+        $endPoint = Http::prepare((isset($params['user_id']) ? 'users/' . $params['user_id'] . '/organizations.json' : 'organizations.json'),
+            $this->client->getSideload($params), $params);
         $response = Http::send($this->client, $endPoint);
         if ((!is_object($response)) || ($this->client->getDebug()->lastResponseCode != 200)) {
             throw new ResponseException(__METHOD__);
         }
         $this->client->setSideload(null);
+
         return $response;
     }
 
@@ -46,20 +50,22 @@ class Organizations extends ClientAbstract {
      *
      * @return mixed
      */
-    public function find(array $params = array()) {
-        if($this->lastId != null) {
+    public function find(array $params = array())
+    {
+        if ($this->lastId != null) {
             $params['id'] = $this->lastId;
             $this->lastId = null;
         }
-        if(!$this->hasKeys($params, array('id'))) {
+        if (!$this->hasKeys($params, array('id'))) {
             throw new MissingParametersException(__METHOD__, array('id'));
         }
-        $endPoint = Http::prepare('organizations/'.$params['id'].'.json', $this->client->getSideload($params));
+        $endPoint = Http::prepare('organizations/' . $params['id'] . '.json', $this->client->getSideload($params));
         $response = Http::send($this->client, $endPoint);
         if ((!is_object($response)) || ($this->client->getDebug()->lastResponseCode != 200)) {
             throw new ResponseException(__METHOD__);
         }
         $this->client->setSideload(null);
+
         return $response;
     }
 
@@ -73,13 +79,15 @@ class Organizations extends ClientAbstract {
      *
      * @return mixed
      */
-    public function create(array $params) {
+    public function create(array $params)
+    {
         $endPoint = Http::prepare('organizations.json');
         $response = Http::send($this->client, $endPoint, array(self::OBJ_NAME => $params), 'POST');
         if ((!is_object($response)) || ($this->client->getDebug()->lastResponseCode != 201)) {
             throw new ResponseException(__METHOD__);
         }
         $this->client->setSideload(null);
+
         return $response;
     }
 
@@ -93,13 +101,15 @@ class Organizations extends ClientAbstract {
      *
      * @return mixed
      */
-    public function createMany(array $params) {
+    public function createMany(array $params)
+    {
         $endPoint = Http::prepare('organizations/create_many.json');
         $response = Http::send($this->client, $endPoint, array(self::OBJ_NAME_PLURAL => $params), 'POST');
         if ((!is_object($response)) || ($this->client->getDebug()->lastResponseCode != 200)) {
             throw new ResponseException(__METHOD__);
         }
         $this->client->setSideload(null);
+
         return $response;
     }
 
@@ -114,22 +124,24 @@ class Organizations extends ClientAbstract {
      *
      * @return mixed
      */
-    public function update(array $params) {
-        if($this->lastId != null) {
+    public function update(array $params)
+    {
+        if ($this->lastId != null) {
             $params['id'] = $this->lastId;
             $this->lastId = null;
         }
-        if(!$this->hasKeys($params, array('id'))) {
+        if (!$this->hasKeys($params, array('id'))) {
             throw new MissingParametersException(__METHOD__, array('id'));
         }
         $id = $params['id'];
         unset($params['id']);
-        $endPoint = Http::prepare('organizations/'.$id.'.json');
-        $response = Http::send($this->client, $endPoint, array (self::OBJ_NAME => $params), 'PUT');
+        $endPoint = Http::prepare('organizations/' . $id . '.json');
+        $response = Http::send($this->client, $endPoint, array(self::OBJ_NAME => $params), 'PUT');
         if ((!is_object($response)) || ($this->client->getDebug()->lastResponseCode != 200)) {
             throw new ResponseException(__METHOD__);
         }
         $this->client->setSideload(null);
+
         return $response;
     }
 
@@ -144,21 +156,23 @@ class Organizations extends ClientAbstract {
      *
      * @return bool
      */
-    public function delete(array $params = array()) {
-        if($this->lastId != null) {
+    public function delete(array $params = array())
+    {
+        if ($this->lastId != null) {
             $params['id'] = $this->lastId;
             $this->lastId = null;
         }
-        if(!$this->hasKeys($params, array('id'))) {
+        if (!$this->hasKeys($params, array('id'))) {
             throw new MissingParametersException(__METHOD__, array('id'));
         }
         $id = $params['id'];
-        $endPoint = Http::prepare('organizations/'.$id.'.json');
+        $endPoint = Http::prepare('organizations/' . $id . '.json');
         $response = Http::send($this->client, $endPoint, null, 'DELETE');
         if ($this->client->getDebug()->lastResponseCode != 200) {
             throw new ResponseException(__METHOD__);
         }
         $this->client->setSideload(null);
+
         return true;
     }
 
@@ -173,8 +187,9 @@ class Organizations extends ClientAbstract {
      *
      * @return mixed
      */
-    public function autocomplete(array $params = array()) {
-        if(!$this->hasKeys($params, array('name'))) {
+    public function autocomplete(array $params = array())
+    {
+        if (!$this->hasKeys($params, array('name'))) {
             throw new MissingParametersException(__METHOD__, array('name'));
         }
         $endPoint = Http::prepare('organizations/autocomplete.json');
@@ -183,6 +198,7 @@ class Organizations extends ClientAbstract {
             throw new ResponseException(__METHOD__);
         }
         $this->client->setSideload(null);
+
         return $response;
     }
 
@@ -197,20 +213,23 @@ class Organizations extends ClientAbstract {
      *
      * @return mixed
      */
-    public function related(array $params = array()) {
-        if($this->lastId != null) {
+    public function related(array $params = array())
+    {
+        if ($this->lastId != null) {
             $params['id'] = $this->lastId;
             $this->lastId = null;
         }
-        if(!$this->hasKeys($params, array('id'))) {
+        if (!$this->hasKeys($params, array('id'))) {
             throw new MissingParametersException(__METHOD__, array('id'));
         }
-        $endPoint = Http::prepare('organizations/'.$params['id'].'/related.json', $this->client->getSideload($params), $params);
+        $endPoint = Http::prepare('organizations/' . $params['id'] . '/related.json',
+            $this->client->getSideload($params), $params);
         $response = Http::send($this->client, $endPoint);
         if ((!is_object($response)) || ($this->client->getDebug()->lastResponseCode != 200)) {
             throw new ResponseException(__METHOD__);
         }
         $this->client->setSideload(null);
+
         return $response;
     }
 
@@ -225,8 +244,9 @@ class Organizations extends ClientAbstract {
      *
      * @return mixed
      */
-    public function search(array $params) {
-        if(!$this->hasKeys($params, array('external_id'))) {
+    public function search(array $params)
+    {
+        if (!$this->hasKeys($params, array('external_id'))) {
             throw new MissingParametersException(__METHOD__, array('external_id'));
         }
         $endPoint = Http::prepare('organizations/search.json', $this->client->getSideload($params), $params);
@@ -235,6 +255,7 @@ class Organizations extends ClientAbstract {
             throw new ResponseException(__METHOD__);
         }
         $this->client->setSideload(null);
+
         return $response;
     }
 
@@ -248,27 +269,39 @@ class Organizations extends ClientAbstract {
      *
      * @return Tickets
      */
-    public function tickets($id = null) { return ($id != null ? $this->client->tickets()->setLastId($id) : $this->client->tickets()); }
+    public function tickets($id = null)
+    {
+        return ($id != null ? $this->client->tickets()->setLastId($id) : $this->client->tickets());
+    }
 
     /**
      * @param int $id
      *
      * @return Tickets
      */
-    public function ticket($id) { return $this->client->tickets()->setLastId($id); }
+    public function ticket($id)
+    {
+        return $this->client->tickets()->setLastId($id);
+    }
 
     /**
      * @param int|null $id
      *
      * @return Tags
      */
-    public function tags($id = null) { return ($id != null ? $this->client->tags()->setLastId($id) : $this->client->tags()); }
+    public function tags($id = null)
+    {
+        return ($id != null ? $this->client->tags()->setLastId($id) : $this->client->tags());
+    }
 
     /**
      * @param int $id
      *
      * @return Tags
      */
-    public function tag($id) { return $this->client->tags()->setLastId($id); }
+    public function tag($id)
+    {
+        return $this->client->tags()->setLastId($id);
+    }
 
 }

--- a/src/Zendesk/API/PushNotificationDevices.php
+++ b/src/Zendesk/API/PushNotificationDevices.php
@@ -7,12 +7,14 @@ namespace Zendesk\API;
  * @package Zendesk\API
  *
  */
-class PushNotificationDevices extends ClientAbstract {
+class PushNotificationDevices extends ClientAbstract
+{
 
     /**
      * @param Client $client
      */
-    public function __construct(Client $client) {
+    public function __construct(Client $client)
+    {
         parent::__construct($client);
     }
 
@@ -27,13 +29,15 @@ class PushNotificationDevices extends ClientAbstract {
      *
      * @return bool
      */
-    public function delete(array $devices = array()) {
+    public function delete(array $devices = array())
+    {
         $endPoint = Http::prepare('push_notification_devices/destroy_many.json');
         $response = Http::send($this->client, $endPoint, array("push_notification_devices" => $devices), 'POST');
         if ($this->client->getDebug()->lastResponseCode != 200) {
             throw new ResponseException(__METHOD__);
         }
         $this->client->setSideload(null);
+
         return true;
     }
 }

--- a/src/Zendesk/API/RequestComments.php
+++ b/src/Zendesk/API/RequestComments.php
@@ -8,7 +8,8 @@ namespace Zendesk\API;
  *
  * @package Zendesk\API
  */
-class RequestComments extends ClientAbstract {
+class RequestComments extends ClientAbstract
+{
 
     const OBJ_NAME = 'comment';
     const OBJ_NAME_PLURAL = 'comments';
@@ -24,20 +25,22 @@ class RequestComments extends ClientAbstract {
      *
      * @return mixed
      */
-    public function findAll(array $params = array()) {
-        if($this->client->requests()->getLastId() != null) {
+    public function findAll(array $params = array())
+    {
+        if ($this->client->requests()->getLastId() != null) {
             $params['request_id'] = $this->client->requests()->getLastId();
             $this->client->requests()->setLastId(null);
         }
-        if(!$this->hasKeys($params, array('request_id'))) {
+        if (!$this->hasKeys($params, array('request_id'))) {
             throw new MissingParametersException(__METHOD__, array('request_id'));
         }
-        $endPoint = Http::prepare('requests/'.$params['request_id'].'/comments.json', null, $params);
+        $endPoint = Http::prepare('requests/' . $params['request_id'] . '/comments.json', null, $params);
         $response = Http::send($this->client, $endPoint);
         if ((!is_object($response)) || ($this->client->getDebug()->lastResponseCode != 200)) {
             throw new ResponseException(__METHOD__);
         }
         $this->client->setSideload(null);
+
         return $response;
     }
 
@@ -52,24 +55,26 @@ class RequestComments extends ClientAbstract {
      *
      * @return mixed
      */
-    public function find(array $params = array()) {
-        if($this->client->requests()->getLastId() != null) {
+    public function find(array $params = array())
+    {
+        if ($this->client->requests()->getLastId() != null) {
             $params['request_id'] = $this->client->requests()->getLastId();
             $this->client->requests()->setLastId(null);
         }
-        if($this->lastId != null) {
+        if ($this->lastId != null) {
             $params['id'] = $this->lastId;
             $this->lastId = null;
         }
-        if(!$this->hasKeys($params, array('id', 'request_id'))) {
+        if (!$this->hasKeys($params, array('id', 'request_id'))) {
             throw new MissingParametersException(__METHOD__, array('id', 'request_id'));
         }
-        $endPoint = Http::prepare('requests/'.$params['request_id'].'/comments/'.$params['id'].'.json');
+        $endPoint = Http::prepare('requests/' . $params['request_id'] . '/comments/' . $params['id'] . '.json');
         $response = Http::send($this->client, $endPoint);
         if ((!is_object($response)) || ($this->client->getDebug()->lastResponseCode != 200)) {
             throw new ResponseException(__METHOD__);
         }
         $this->client->setSideload(null);
+
         return $response;
     }
 

--- a/src/Zendesk/API/Requests.php
+++ b/src/Zendesk/API/Requests.php
@@ -6,7 +6,8 @@ namespace Zendesk\API;
  * The Requests class exposes request management methods
  * Note: you must authenticate as a user!
  */
-class Requests extends ClientAbstract {
+class Requests extends ClientAbstract
+{
 
     const OBJ_NAME = 'request';
     const OBJ_NAME_PLURAL = 'requests';
@@ -19,7 +20,8 @@ class Requests extends ClientAbstract {
     /**
      * @param Client $client
      */
-    public function __construct(Client $client) {
+    public function __construct(Client $client)
+    {
         parent::__construct($client);
         $this->comments = new RequestComments($client);
     }
@@ -34,19 +36,22 @@ class Requests extends ClientAbstract {
      *
      * @return mixed
      */
-    public function findAll(array $params = array()) {
+    public function findAll(array $params = array())
+    {
         $endPoint = Http::prepare(
-                (isset($params['organization_id']) ? 'organizations/'.$params['organization_id'].'/requests' :
-                (isset($params['user_id']) ? 'users/'.$params['user_id'].'/requests' :
-                (isset($params['ccd']) ? 'requests/ccd' :
-                (isset($params['solved']) ? 'requests/solved' :
-                (isset($params['open']) ? 'requests/open' : 'requests'))))
-            ).'.json'.(isset($params['status']) ? '?status='.$params['status'] : ''), $this->client->getSideload($params), $params);
+            (isset($params['organization_id']) ? 'organizations/' . $params['organization_id'] . '/requests' :
+                (isset($params['user_id']) ? 'users/' . $params['user_id'] . '/requests' :
+                    (isset($params['ccd']) ? 'requests/ccd' :
+                        (isset($params['solved']) ? 'requests/solved' :
+                            (isset($params['open']) ? 'requests/open' : 'requests'))))
+            ) . '.json' . (isset($params['status']) ? '?status=' . $params['status'] : ''),
+            $this->client->getSideload($params), $params);
         $response = Http::send($this->client, $endPoint);
         if ((!is_object($response)) || ($this->client->getDebug()->lastResponseCode != 200)) {
             throw new ResponseException(__METHOD__);
         }
         $this->client->setSideload(null);
+
         return $response;
     }
 
@@ -61,20 +66,22 @@ class Requests extends ClientAbstract {
      *
      * @return mixed
      */
-    public function find(array $params = array()) {
-        if($this->lastId != null) {
+    public function find(array $params = array())
+    {
+        if ($this->lastId != null) {
             $params['id'] = $this->lastId;
             $this->lastId = null;
         }
-        if(!$this->hasKeys($params, array('id'))) {
+        if (!$this->hasKeys($params, array('id'))) {
             throw new MissingParametersException(__METHOD__, array('id'));
         }
-        $endPoint = Http::prepare('requests/'.$params['id'].'.json', $this->client->getSideload($params));
+        $endPoint = Http::prepare('requests/' . $params['id'] . '.json', $this->client->getSideload($params));
         $response = Http::send($this->client, $endPoint);
         if ((!is_object($response)) || ($this->client->getDebug()->lastResponseCode != 200)) {
             throw new ResponseException(__METHOD__);
         }
         $this->client->setSideload(null);
+
         return $response;
     }
 
@@ -88,13 +95,15 @@ class Requests extends ClientAbstract {
      *
      * @return mixed
      */
-    public function create(array $params) {
+    public function create(array $params)
+    {
         $endPoint = Http::prepare('requests.json');
-        $response = Http::send($this->client, $endPoint, array (self::OBJ_NAME => $params), 'POST');
+        $response = Http::send($this->client, $endPoint, array(self::OBJ_NAME => $params), 'POST');
         if ((!is_object($response)) || ($this->client->getDebug()->lastResponseCode != 201)) {
             throw new ResponseException(__METHOD__);
         }
         $this->client->setSideload(null);
+
         return $response;
     }
 
@@ -109,22 +118,24 @@ class Requests extends ClientAbstract {
      *
      * @return mixed
      */
-    public function update(array $params) {
-        if($this->lastId != null) {
+    public function update(array $params)
+    {
+        if ($this->lastId != null) {
             $params['id'] = $this->lastId;
             $this->lastId = null;
         }
-        if(!$this->hasKeys($params, array('id'))) {
+        if (!$this->hasKeys($params, array('id'))) {
             throw new MissingParametersException(__METHOD__, array('id'));
         }
         $id = $params['id'];
         unset($params['id']);
-        $endPoint = Http::prepare('requests/'.$id.'.json');
-        $response = Http::send($this->client, $endPoint, array (self::OBJ_NAME => $params), 'PUT');
+        $endPoint = Http::prepare('requests/' . $id . '.json');
+        $response = Http::send($this->client, $endPoint, array(self::OBJ_NAME => $params), 'PUT');
         if ((!is_object($response)) || ($this->client->getDebug()->lastResponseCode != 200)) {
             throw new ResponseException(__METHOD__);
         }
         $this->client->setSideload(null);
+
         return $response;
     }
 
@@ -137,14 +148,20 @@ class Requests extends ClientAbstract {
      * @param int|null $id
      * @return RequestComments
      */
-    public function comments($id = null) { return ($id != null ? $this->comments->setLastId($id) : $this->comments); }
+    public function comments($id = null)
+    {
+        return ($id != null ? $this->comments->setLastId($id) : $this->comments);
+    }
 
     /**
      * @param int $id
      *
      * @return $this
      */
-    public function comment($id) { return $this->comments->setLastId($id); }
+    public function comment($id)
+    {
+        return $this->comments->setLastId($id);
+    }
 
     /**
      * @param array $params
@@ -153,7 +170,12 @@ class Requests extends ClientAbstract {
      *
      * @return mixed
      */
-    public function open(array $params = array()) { $params['open'] = true; return $this->findAll($params); }
+    public function open(array $params = array())
+    {
+        $params['open'] = true;
+
+        return $this->findAll($params);
+    }
 
     /**
      * @param array $params
@@ -162,7 +184,12 @@ class Requests extends ClientAbstract {
      *
      * @return mixed
      */
-    public function solved(array $params = array()) { $params['solved'] = true; return $this->findAll($params); }
+    public function solved(array $params = array())
+    {
+        $params['solved'] = true;
+
+        return $this->findAll($params);
+    }
 
     /**
      * @param array $params
@@ -171,6 +198,11 @@ class Requests extends ClientAbstract {
      *
      * @return mixed
      */
-    public function ccd(array $params = array()) { $params['ccd'] = true; return $this->findAll($params); }
+    public function ccd(array $params = array())
+    {
+        $params['ccd'] = true;
+
+        return $this->findAll($params);
+    }
 
 }

--- a/src/Zendesk/API/ResponseException.php
+++ b/src/Zendesk/API/ResponseException.php
@@ -6,16 +6,19 @@ namespace Zendesk\API;
  * ResponseException extends the Exception class with simplified messaging
  * @package Zendesk\API
  */
-class ResponseException extends \Exception {
+class ResponseException extends \Exception
+{
 
     /**
-     * @param string     $method
-     * @param string     $detail
-     * @param int        $code
+     * @param string $method
+     * @param string $detail
+     * @param int $code
      * @param \Exception $previous
      */
-        public function __construct($method, $detail = '', $code = 0, \Exception $previous = null) {
-        parent::__construct('Response to '.$method.' is not valid. Call $client->getDebug() for details'.$detail, $code, $previous);
+    public function __construct($method, $detail = '', $code = 0, \Exception $previous = null)
+    {
+        parent::__construct('Response to ' . $method . ' is not valid. Call $client->getDebug() for details' . $detail,
+            $code, $previous);
     }
 
 }

--- a/src/Zendesk/API/SatisfactionRatings.php
+++ b/src/Zendesk/API/SatisfactionRatings.php
@@ -6,7 +6,8 @@ namespace Zendesk\API;
  * The SatisfactionRatings class exposes methods as detailed on http://developer.zendesk.com/documentation/rest_api/satisfaction_ratings.html
  * @package Zendesk\API
  */
-class SatisfactionRatings extends ClientAbstract {
+class SatisfactionRatings extends ClientAbstract
+{
 
     const OBJ_NAME = 'satisfaction_rating';
     const OBJ_NAME_PLURAL = 'satisfaction_ratings';
@@ -21,8 +22,9 @@ class SatisfactionRatings extends ClientAbstract {
      *
      * @return mixed
      */
-    public function findAll(array $params = array()) {
-        if($this->client->tickets()->getLastId() != null) {
+    public function findAll(array $params = array())
+    {
+        if ($this->client->tickets()->getLastId() != null) {
             $params['ticket_id'] = $this->client->tickets()->getLastId();
             $this->client->tickets()->setLastId(null);
         }
@@ -37,6 +39,7 @@ class SatisfactionRatings extends ClientAbstract {
             throw new ResponseException(__METHOD__);
         }
         $this->client->setSideload(null);
+
         return $response;
     }
 
@@ -51,20 +54,22 @@ class SatisfactionRatings extends ClientAbstract {
      *
      * @return mixed
      */
-    public function find(array $params = array()) {
-        if($this->lastId != null) {
+    public function find(array $params = array())
+    {
+        if ($this->lastId != null) {
             $params['id'] = $this->lastId;
             $this->lastId = null;
         }
-        if(!$this->hasKeys($params, array('id'))) {
+        if (!$this->hasKeys($params, array('id'))) {
             throw new MissingParametersException(__METHOD__, array('id'));
         }
-        $endPoint = Http::prepare('satisfaction_ratings/'.$params['id'].'.json');
+        $endPoint = Http::prepare('satisfaction_ratings/' . $params['id'] . '.json');
         $response = Http::send($this->client, $endPoint);
         if ((!is_object($response)) || ($this->client->getDebug()->lastResponseCode != 200)) {
             throw new ResponseException(__METHOD__);
         }
         $this->client->setSideload(null);
+
         return $response;
     }
 
@@ -78,17 +83,20 @@ class SatisfactionRatings extends ClientAbstract {
      *
      * @return mixed
      */
-    public function create(array $params) {
-        if($this->client->tickets()->getLastId() != null) {
+    public function create(array $params)
+    {
+        if ($this->client->tickets()->getLastId() != null) {
             $params['ticket_id'] = $this->client->tickets()->getLastId();
             $this->client->tickets()->setLastId(null);
         }
-        $endPoint = Http::prepare('tickets/'.$params['ticket_id'].'/satisfaction_rating.json');
+        $endPoint = Http::prepare('tickets/' . $params['ticket_id'] . '/satisfaction_rating.json');
         $response = Http::send($this->client, $endPoint, array(self::OBJ_NAME => $params), 'POST');
         if ((!is_object($response)) || ($this->client->getDebug()->lastResponseCode != 200)) {
-            throw new ResponseException(__METHOD__, ($this->client->getDebug()->lastResponseCode == 403 ? ' (hint: you need to authenticate as a verified end user for this method)' : ''));
+            throw new ResponseException(__METHOD__,
+                ($this->client->getDebug()->lastResponseCode == 403 ? ' (hint: you need to authenticate as a verified end user for this method)' : ''));
         }
         $this->client->setSideload(null);
+
         return $response;
     }
 

--- a/src/Zendesk/API/Search.php
+++ b/src/Zendesk/API/Search.php
@@ -6,7 +6,8 @@ namespace Zendesk\API;
  * The Search class exposes methods defined in http://developer.zendesk.com/documentation/rest_api/search.html
  * @package Zendesk\API
  */
-class Search extends ClientAbstract {
+class Search extends ClientAbstract
+{
 
     /**
      * Perform a search
@@ -19,16 +20,18 @@ class Search extends ClientAbstract {
      *
      * @return mixed
      */
-    public function performSearch(array $params) {
-        if(!$this->hasKeys($params, array('query'))) {
+    public function performSearch(array $params)
+    {
+        if (!$this->hasKeys($params, array('query'))) {
             throw new MissingParametersException(__METHOD__, array('query'));
         }
         $endPoint = Http::prepare('search.json', null, $params);
-        $response = Http::send($this->client, $endPoint, $params, 'GET', 'application/json', FALSE);
+        $response = Http::send($this->client, $endPoint, $params, 'GET', 'application/json', false);
         if ((!is_object($response)) || ($this->client->getDebug()->lastResponseCode != 200)) {
             throw new ResponseException(__METHOD__);
         }
         $this->client->setSideload(null);
+
         return $response;
     }
 
@@ -43,8 +46,9 @@ class Search extends ClientAbstract {
      *
      * @return mixed
      */
-    public function anonymousSearch(array $params) {
-        if(!$this->hasKeys($params, array('query'))) {
+    public function anonymousSearch(array $params)
+    {
+        if (!$this->hasKeys($params, array('query'))) {
             throw new MissingParametersException(__METHOD__, array('query'));
         }
         $endPoint = Http::prepare('portal/search.json', null, $params);
@@ -53,6 +57,7 @@ class Search extends ClientAbstract {
             throw new ResponseException(__METHOD__);
         }
         $this->client->setSideload(null);
+
         return $response;
     }
 

--- a/src/Zendesk/API/Settings.php
+++ b/src/Zendesk/API/Settings.php
@@ -6,7 +6,8 @@ namespace Zendesk\API;
  * The Settings class exposes methods for retrieving settings parameters
  * @package Zendesk\API
  */
-class Settings extends ClientAbstract {
+class Settings extends ClientAbstract
+{
 
     const OBJ_NAME = 'settings';
     const OBJ_NAME_PLURAL = 'settings';
@@ -21,13 +22,15 @@ class Settings extends ClientAbstract {
      *
      * @return mixed
      */
-    public function findAll(array $params = array ()) {
+    public function findAll(array $params = array())
+    {
         $endPoint = Http::prepare('account/settings.json', null, $params);
         $response = Http::send($this->client, $endPoint);
         if ((!is_object($response)) || ($this->client->getDebug()->lastResponseCode != 200)) {
             throw new ResponseException(__METHOD__);
         }
         $this->client->setSideload(null);
+
         return $response;
     }
 
@@ -41,13 +44,15 @@ class Settings extends ClientAbstract {
      *
      * @return mixed
      */
-    public function update(array $params) {
+    public function update(array $params)
+    {
         $endPoint = Http::prepare('account/settings.json');
         $response = Http::send($this->client, $endPoint, array(self::OBJ_NAME => $params), 'PUT');
         if ((!is_object($response)) || ($this->client->getDebug()->lastResponseCode != 200)) {
             throw new ResponseException(__METHOD__);
         }
         $this->client->setSideload(null);
+
         return $response;
     }
 

--- a/src/Zendesk/API/SharingAgreements.php
+++ b/src/Zendesk/API/SharingAgreements.php
@@ -6,7 +6,8 @@ namespace Zendesk\API;
  * The SharingAgreements class exposes methods as detailed at http://developer.zendesk.com/documentation/rest_api/sharing_agreements.html
  * @package Zendesk\API
  */
-class SharingAgreements extends ClientAbstract {
+class SharingAgreements extends ClientAbstract
+{
 
     const OBJ_NAME = 'sharing_agreement';
     const OBJ_NAME_PLURAL = 'sharing_agreements';
@@ -21,13 +22,15 @@ class SharingAgreements extends ClientAbstract {
      *
      * @return mixed
      */
-    public function findAll(array $params = array ()) {
+    public function findAll(array $params = array())
+    {
         $endPoint = Http::prepare('sharing_agreements.json', null, $params);
         $response = Http::send($this->client, $endPoint);
         if ((!is_object($response)) || ($this->client->getDebug()->lastResponseCode != 200)) {
             throw new ResponseException(__METHOD__);
         }
         $this->client->setSideload(null);
+
         return $response;
     }
 

--- a/src/Zendesk/API/SuspendedTickets.php
+++ b/src/Zendesk/API/SuspendedTickets.php
@@ -6,7 +6,8 @@ namespace Zendesk\API;
  * The SuspendedTickets class exposes methods as detailed on http://developer.zendesk.com/documentation/rest_api/suspended_tickets.html
  * @package Zendesk\API
  */
-class SuspendedTickets extends ClientAbstract {
+class SuspendedTickets extends ClientAbstract
+{
 
     const OBJ_NAME = 'suspended_ticket';
     const OBJ_NAME_PLURAL = 'suspended_tickets';
@@ -21,13 +22,15 @@ class SuspendedTickets extends ClientAbstract {
      *
      * @return mixed
      */
-    public function findAll(array $params = array()) {
+    public function findAll(array $params = array())
+    {
         $endPoint = Http::prepare('suspended_tickets.json', null, $params);
         $response = Http::send($this->client, $endPoint);
         if ((!is_object($response)) || ($this->client->getDebug()->lastResponseCode != 200)) {
             throw new ResponseException(__METHOD__);
         }
         $this->client->setSideload(null);
+
         return $response;
     }
 
@@ -42,20 +45,22 @@ class SuspendedTickets extends ClientAbstract {
      *
      * @return mixed
      */
-    public function find(array $params = array()) {
-        if($this->lastId != null) {
+    public function find(array $params = array())
+    {
+        if ($this->lastId != null) {
             $params['id'] = $this->lastId;
             $this->lastId = null;
         }
-        if(!$this->hasKeys($params, array('id'))) {
+        if (!$this->hasKeys($params, array('id'))) {
             throw new MissingParametersException(__METHOD__, array('id'));
         }
-        $endPoint = Http::prepare('suspended_tickets/'.$params['id'].'.json');
+        $endPoint = Http::prepare('suspended_tickets/' . $params['id'] . '.json');
         $response = Http::send($this->client, $endPoint);
         if ((!is_object($response)) || ($this->client->getDebug()->lastResponseCode != 200)) {
             throw new ResponseException(__METHOD__);
         }
         $this->client->setSideload(null);
+
         return $response;
     }
 
@@ -70,21 +75,24 @@ class SuspendedTickets extends ClientAbstract {
      *
      * @return mixed
      */
-    public function recover(array $params = array()) {
-        if($this->lastId != null) {
+    public function recover(array $params = array())
+    {
+        if ($this->lastId != null) {
             $params['id'] = $this->lastId;
             $this->lastId = null;
         }
-        if(!$this->hasKeys($params, array('id'))) {
+        if (!$this->hasKeys($params, array('id'))) {
             throw new MissingParametersException(__METHOD__, array('id'));
         }
         $id = $params['id'];
-        $endPoint = Http::prepare((is_array($id) ? 'suspended_tickets/recover_many.json?ids='.implode(',', $id) : 'suspended_tickets/'.$id.'/recover.json'));
+        $endPoint = Http::prepare((is_array($id) ? 'suspended_tickets/recover_many.json?ids=' . implode(',',
+                $id) : 'suspended_tickets/' . $id . '/recover.json'));
         $response = Http::send($this->client, $endPoint, array(self::OBJ_NAME => $params), 'PUT');
         if ((!is_object($response)) || ($this->client->getDebug()->lastResponseCode != 200)) {
             throw new ResponseException(__METHOD__);
         }
         $this->client->setSideload(null);
+
         return $response;
     }
 
@@ -99,21 +107,24 @@ class SuspendedTickets extends ClientAbstract {
      *
      * @return bool
      */
-    public function delete(array $params = array()) {
-        if($this->lastId != null) {
+    public function delete(array $params = array())
+    {
+        if ($this->lastId != null) {
             $params['id'] = $this->lastId;
             $this->lastId = null;
         }
-        if(!$this->hasKeys($params, array('id'))) {
+        if (!$this->hasKeys($params, array('id'))) {
             throw new MissingParametersException(__METHOD__, array('id'));
         }
         $id = $params['id'];
-        $endPoint = Http::prepare((is_array($id) ? 'suspended_tickets/destroy_many.json?ids='.implode(',', $id) : 'suspended_tickets/'.$id.'.json'));
+        $endPoint = Http::prepare((is_array($id) ? 'suspended_tickets/destroy_many.json?ids=' . implode(',',
+                $id) : 'suspended_tickets/' . $id . '.json'));
         $response = Http::send($this->client, $endPoint, null, 'DELETE');
         if ($this->client->getDebug()->lastResponseCode != 200) {
             throw new ResponseException(__METHOD__);
         }
         $this->client->setSideload(null);
+
         return true;
     }
 

--- a/src/Zendesk/API/Tags.php
+++ b/src/Zendesk/API/Tags.php
@@ -6,7 +6,8 @@ namespace Zendesk\API;
  * The Tags class exposes methods as detailed on http://developer.zendesk.com/documentation/rest_api/tags.html
  * @package Zendesk\API
  */
-class Tags extends ClientAbstract {
+class Tags extends ClientAbstract
+{
 
     const OBJ_NAME = 'tags';
     const OBJ_NAME_PLURAL = 'tags';
@@ -21,13 +22,15 @@ class Tags extends ClientAbstract {
      *
      * @return mixed
      */
-    public function findAll(array $params = array()) {
+    public function findAll(array $params = array())
+    {
         $endPoint = Http::prepare('tags.json', null, $params);
         $response = Http::send($this->client, $endPoint);
         if ((!is_object($response)) || ($this->client->getDebug()->lastResponseCode != 200)) {
             throw new ResponseException(__METHOD__);
         }
         $this->client->setSideload(null);
+
         return $response;
     }
 
@@ -42,32 +45,34 @@ class Tags extends ClientAbstract {
      *
      * @return mixed
      */
-    public function find(array $params = array()) {
-        if($this->client->tickets()->getLastId() != null) {
+    public function find(array $params = array())
+    {
+        if ($this->client->tickets()->getLastId() != null) {
             $params['ticket_id'] = $this->client->tickets()->getLastId();
             $this->client->tickets()->setLastId(null);
         }
-        if($this->client->topics()->getLastId() != null) {
+        if ($this->client->topics()->getLastId() != null) {
             $params['topic_id'] = $this->client->topics()->getLastId();
             $this->client->topics()->setLastId(null);
         }
-        if($this->client->organizations()->getLastId() != null) {
+        if ($this->client->organizations()->getLastId() != null) {
             $params['organization_id'] = $this->client->organizations()->getLastId();
             $this->client->organizations()->setLastId(null);
         }
-        if(!$this->hasAnyKey($params, array('ticket_id', 'topic_id', 'organization_id'))) {
+        if (!$this->hasAnyKey($params, array('ticket_id', 'topic_id', 'organization_id'))) {
             throw new MissingParametersException(__METHOD__, array('ticket_id', 'topic_id', 'organization_id'));
         }
         $endPoint = Http::prepare(
-                (isset($params['ticket_id']) ? 'tickets/'.$params['ticket_id'].'/tags.json' :
-                (isset($params['topic_id']) ? 'topics/'.$params['topic_id'].'/tags.json' :
-                (isset($params['organization_id']) ? 'organizations/'.$params['organization_id'].'/tags.json' : '')))
-            );
+            (isset($params['ticket_id']) ? 'tickets/' . $params['ticket_id'] . '/tags.json' :
+                (isset($params['topic_id']) ? 'topics/' . $params['topic_id'] . '/tags.json' :
+                    (isset($params['organization_id']) ? 'organizations/' . $params['organization_id'] . '/tags.json' : '')))
+        );
         $response = Http::send($this->client, $endPoint);
         if ((!is_object($response)) || ($this->client->getDebug()->lastResponseCode != 200)) {
             throw new ResponseException(__METHOD__);
         }
         $this->client->setSideload(null);
+
         return $response;
     }
 
@@ -82,35 +87,37 @@ class Tags extends ClientAbstract {
      *
      * @return mixed
      */
-    public function create(array $params) {
-        if($this->client->tickets()->getLastId() != null) {
+    public function create(array $params)
+    {
+        if ($this->client->tickets()->getLastId() != null) {
             $params['ticket_id'] = $this->client->tickets()->getLastId();
             $this->client->tickets()->setLastId(null);
         }
-        if($this->client->topics()->getLastId() != null) {
+        if ($this->client->topics()->getLastId() != null) {
             $params['topic_id'] = $this->client->topics()->getLastId();
             $this->client->topics()->setLastId(null);
         }
-        if($this->client->organizations()->getLastId() != null) {
+        if ($this->client->organizations()->getLastId() != null) {
             $params['organization_id'] = $this->client->organizations()->getLastId();
             $this->client->organizations()->setLastId(null);
         }
-        if(!$this->hasAnyKey($params, array('ticket_id', 'topic_id', 'organization_id'))) {
+        if (!$this->hasAnyKey($params, array('ticket_id', 'topic_id', 'organization_id'))) {
             throw new MissingParametersException(__METHOD__, array('ticket_id', 'topic_id', 'organization_id'));
         }
-        if(!$this->hasKeys($params, array('tags'))) {
+        if (!$this->hasKeys($params, array('tags'))) {
             throw new MissingParametersException(__METHOD__, array('tags'));
         }
         $endPoint = Http::prepare(
-                (isset($params['ticket_id']) ? 'tickets/'.$params['ticket_id'].'/tags.json' :
-                (isset($params['topic_id']) ? 'topics/'.$params['topic_id'].'/tags.json' :
-                (isset($params['organization_id']) ? 'organizations/'.$params['organization_id'].'/tags.json' : '')))
-            );
+            (isset($params['ticket_id']) ? 'tickets/' . $params['ticket_id'] . '/tags.json' :
+                (isset($params['topic_id']) ? 'topics/' . $params['topic_id'] . '/tags.json' :
+                    (isset($params['organization_id']) ? 'organizations/' . $params['organization_id'] . '/tags.json' : '')))
+        );
         $response = Http::send($this->client, $endPoint, array(self::OBJ_NAME => $params['tags']), 'POST');
         if ((!is_object($response)) || ($this->client->getDebug()->lastResponseCode != 201)) {
             throw new ResponseException(__METHOD__);
         }
         $this->client->setSideload(null);
+
         return $response;
     }
 
@@ -125,35 +132,37 @@ class Tags extends ClientAbstract {
      *
      * @return mixed
      */
-    public function update(array $params) {
-        if($this->client->tickets()->getLastId() != null) {
+    public function update(array $params)
+    {
+        if ($this->client->tickets()->getLastId() != null) {
             $params['ticket_id'] = $this->client->tickets()->getLastId();
             $this->client->tickets()->setLastId(null);
         }
-        if($this->client->topics()->getLastId() != null) {
+        if ($this->client->topics()->getLastId() != null) {
             $params['topic_id'] = $this->client->topics()->getLastId();
             $this->client->topics()->setLastId(null);
         }
-        if($this->client->organizations()->getLastId() != null) {
+        if ($this->client->organizations()->getLastId() != null) {
             $params['organization_id'] = $this->client->organizations()->getLastId();
             $this->client->organizations()->setLastId(null);
         }
-        if(!$this->hasAnyKey($params, array('ticket_id', 'topic_id', 'organization_id'))) {
+        if (!$this->hasAnyKey($params, array('ticket_id', 'topic_id', 'organization_id'))) {
             throw new MissingParametersException(__METHOD__, array('ticket_id', 'topic_id', 'organization_id'));
         }
-        if(!$this->hasKeys($params, array('tags'))) {
+        if (!$this->hasKeys($params, array('tags'))) {
             throw new MissingParametersException(__METHOD__, array('tags'));
         }
         $endPoint = Http::prepare(
-                (isset($params['ticket_id']) ? 'tickets/'.$params['ticket_id'].'/tags.json' :
-                (isset($params['topic_id']) ? 'topics/'.$params['topic_id'].'/tags.json' :
-                (isset($params['organization_id']) ? 'organizations/'.$params['organization_id'].'/tags.json' : '')))
-            );
+            (isset($params['ticket_id']) ? 'tickets/' . $params['ticket_id'] . '/tags.json' :
+                (isset($params['topic_id']) ? 'topics/' . $params['topic_id'] . '/tags.json' :
+                    (isset($params['organization_id']) ? 'organizations/' . $params['organization_id'] . '/tags.json' : '')))
+        );
         $response = Http::send($this->client, $endPoint, array(self::OBJ_NAME => $params['tags']), 'PUT');
         if ((!is_object($response)) || ($this->client->getDebug()->lastResponseCode != 200)) {
             throw new ResponseException(__METHOD__);
         }
         $this->client->setSideload(null);
+
         return $response;
     }
 
@@ -168,35 +177,37 @@ class Tags extends ClientAbstract {
      *
      * @return mixed
      */
-    public function delete(array $params) {
-        if($this->client->tickets()->getLastId() != null) {
+    public function delete(array $params)
+    {
+        if ($this->client->tickets()->getLastId() != null) {
             $params['ticket_id'] = $this->client->tickets()->getLastId();
             $this->client->tickets()->setLastId(null);
         }
-        if($this->client->topics()->getLastId() != null) {
+        if ($this->client->topics()->getLastId() != null) {
             $params['topic_id'] = $this->client->topics()->getLastId();
             $this->client->topics()->setLastId(null);
         }
-        if($this->client->organizations()->getLastId() != null) {
+        if ($this->client->organizations()->getLastId() != null) {
             $params['organization_id'] = $this->client->organizations()->getLastId();
             $this->client->organizations()->setLastId(null);
         }
-        if(!$this->hasKeys($params, array('tags'))) {
+        if (!$this->hasKeys($params, array('tags'))) {
             throw new MissingParametersException(__METHOD__, array('tags'));
         }
-        if(!$this->hasAnyKey($params, array('ticket_id', 'topic_id', 'organization_id'))) {
+        if (!$this->hasAnyKey($params, array('ticket_id', 'topic_id', 'organization_id'))) {
             throw new MissingParametersException(__METHOD__, array('ticket_id', 'topic_id', 'organization_id'));
         }
         $endPoint = Http::prepare(
-                (isset($params['ticket_id']) ? 'tickets/'.$params['ticket_id'].'/tags.json' :
-                (isset($params['topic_id']) ? 'topics/'.$params['topic_id'].'/tags.json' :
-                (isset($params['organization_id']) ? 'organizations/'.$params['organization_id'].'/tags.json' : '')))
-            );
+            (isset($params['ticket_id']) ? 'tickets/' . $params['ticket_id'] . '/tags.json' :
+                (isset($params['topic_id']) ? 'topics/' . $params['topic_id'] . '/tags.json' :
+                    (isset($params['organization_id']) ? 'organizations/' . $params['organization_id'] . '/tags.json' : '')))
+        );
         $response = Http::send($this->client, $endPoint, array(self::OBJ_NAME => $params['tags']), 'DELETE');
         if ($this->client->getDebug()->lastResponseCode != 200) {
             throw new ResponseException(__METHOD__);
         }
         $this->client->setSideload(null);
+
         return $response;
     }
 
@@ -212,7 +223,10 @@ class Tags extends ClientAbstract {
      *
      * @return mixed
      */
-    public function show(array $params = array()) { return $this->findAll($params); }
+    public function show(array $params = array())
+    {
+        return $this->findAll($params);
+    }
 
     /**
      * @param array $params
@@ -222,7 +236,10 @@ class Tags extends ClientAbstract {
      *
      * @return mixed
      */
-    public function set(array $params) { return $this->create($params); }
+    public function set(array $params)
+    {
+        return $this->create($params);
+    }
 
     /**
      * @param array $params
@@ -232,7 +249,10 @@ class Tags extends ClientAbstract {
      *
      * @return mixed
      */
-    public function add(array $params) { return $this->update($params); }
+    public function add(array $params)
+    {
+        return $this->update($params);
+    }
 
     /**
      * @param array $params
@@ -242,6 +262,9 @@ class Tags extends ClientAbstract {
      *
      * @return mixed
      */
-    public function remove(array $params) { return $this->delete($params); }
+    public function remove(array $params)
+    {
+        return $this->delete($params);
+    }
 
 }

--- a/src/Zendesk/API/Targets.php
+++ b/src/Zendesk/API/Targets.php
@@ -6,7 +6,8 @@ namespace Zendesk\API;
  * The Targets class exposes methods as detailed on http://developer.zendesk.com/documentation/rest_api/targets.html
  * @package Zendesk\API
  */
-class Targets extends ClientAbstract {
+class Targets extends ClientAbstract
+{
 
     const OBJ_NAME = 'target';
     const OBJ_NAME_PLURAL = 'targets';
@@ -21,13 +22,15 @@ class Targets extends ClientAbstract {
      *
      * @return mixed
      */
-    public function findAll(array $params = array()) {
+    public function findAll(array $params = array())
+    {
         $endPoint = Http::prepare('targets.json', null, $params);
         $response = Http::send($this->client, $endPoint);
         if ((!is_object($response)) || ($this->client->getDebug()->lastResponseCode != 200)) {
             throw new ResponseException(__METHOD__);
         }
         $this->client->setSideload(null);
+
         return $response;
     }
 
@@ -42,20 +45,22 @@ class Targets extends ClientAbstract {
      *
      * @return mixed
      */
-    public function find(array $params = array()) {
-        if($this->lastId != null) {
+    public function find(array $params = array())
+    {
+        if ($this->lastId != null) {
             $params['id'] = $this->lastId;
             $this->lastId = null;
         }
-        if(!$this->hasKeys($params, array('id'))) {
+        if (!$this->hasKeys($params, array('id'))) {
             throw new MissingParametersException(__METHOD__, array('id'));
         }
-        $endPoint = Http::prepare('targets/'.$params['id'].'.json');
+        $endPoint = Http::prepare('targets/' . $params['id'] . '.json');
         $response = Http::send($this->client, $endPoint);
         if ((!is_object($response)) || ($this->client->getDebug()->lastResponseCode != 200)) {
             throw new ResponseException(__METHOD__);
         }
         $this->client->setSideload(null);
+
         return $response;
     }
 
@@ -69,13 +74,15 @@ class Targets extends ClientAbstract {
      *
      * @return mixed
      */
-    public function create(array $params) {
+    public function create(array $params)
+    {
         $endPoint = Http::prepare('targets.json');
         $response = Http::send($this->client, $endPoint, array(self::OBJ_NAME => $params), 'POST');
         if ((!is_object($response)) || ($this->client->getDebug()->lastResponseCode != 201)) {
             throw new ResponseException(__METHOD__);
         }
         $this->client->setSideload(null);
+
         return $response;
     }
 
@@ -90,20 +97,22 @@ class Targets extends ClientAbstract {
      *
      * @return mixed
      */
-    public function update(array $params) {
-        if($this->lastId != null) {
+    public function update(array $params)
+    {
+        if ($this->lastId != null) {
             $params['id'] = $this->lastId;
             $this->lastId = null;
         }
-        if(!$this->hasKeys($params, array('id'))) {
+        if (!$this->hasKeys($params, array('id'))) {
             throw new MissingParametersException(__METHOD__, array('id'));
         }
-        $endPoint = Http::prepare('targets/'.$params['id'].'.json');
+        $endPoint = Http::prepare('targets/' . $params['id'] . '.json');
         $response = Http::send($this->client, $endPoint, array(self::OBJ_NAME => $params), 'PUT');
         if ((!is_object($response)) || ($this->client->getDebug()->lastResponseCode != 200)) {
             throw new ResponseException(__METHOD__);
         }
         $this->client->setSideload(null);
+
         return $response;
     }
 
@@ -118,20 +127,22 @@ class Targets extends ClientAbstract {
      *
      * @return bool
      */
-    public function delete(array $params = array()) {
-        if($this->lastId != null) {
+    public function delete(array $params = array())
+    {
+        if ($this->lastId != null) {
             $params['id'] = $this->lastId;
             $this->lastId = null;
         }
-        if(!$this->hasKeys($params, array('id'))) {
+        if (!$this->hasKeys($params, array('id'))) {
             throw new MissingParametersException(__METHOD__, array('id'));
         }
-        $endPoint = Http::prepare('targets/'.$params['id'].'.json');
+        $endPoint = Http::prepare('targets/' . $params['id'] . '.json');
         $response = Http::send($this->client, $endPoint, null, 'DELETE');
         if ($this->client->getDebug()->lastResponseCode != 200) {
             throw new ResponseException(__METHOD__);
         }
         $this->client->setSideload(null);
+
         return true;
     }
 

--- a/src/Zendesk/API/TicketAudits.php
+++ b/src/Zendesk/API/TicketAudits.php
@@ -6,7 +6,8 @@ namespace Zendesk\API;
  * The TicketAudits class exposes read only audit methods
  * @package Zendesk\API
  */
-class TicketAudits extends ClientAbstract {
+class TicketAudits extends ClientAbstract
+{
 
     const OBJ_NAME = 'audit';
     const OBJ_NAME_PLURAL = 'audits';
@@ -22,20 +23,23 @@ class TicketAudits extends ClientAbstract {
      *
      * @return mixed
      */
-    public function findAll(array $params = array()) {
-        if($this->client->tickets()->getLastId() != null) {
+    public function findAll(array $params = array())
+    {
+        if ($this->client->tickets()->getLastId() != null) {
             $params['ticket_id'] = $this->client->tickets()->getLastId();
             $this->client->tickets()->setLastId(null);
         }
-        if(!$this->hasKeys($params, array('ticket_id'))) {
+        if (!$this->hasKeys($params, array('ticket_id'))) {
             throw new MissingParametersException(__METHOD__, array('ticket_id'));
         }
-        $endPoint = Http::prepare('tickets/'.$params['ticket_id'].'/audits.json', $this->client->getSideload($params), $params);
+        $endPoint = Http::prepare('tickets/' . $params['ticket_id'] . '/audits.json',
+            $this->client->getSideload($params), $params);
         $response = Http::send($this->client, $endPoint);
         if ((!is_object($response)) || ($this->client->getDebug()->lastResponseCode != 200)) {
             throw new ResponseException(__METHOD__);
         }
         $this->client->setSideload(null);
+
         return $response;
     }
 
@@ -50,24 +54,27 @@ class TicketAudits extends ClientAbstract {
      *
      * @return mixed
      */
-    public function find(array $params = array()) {
-        if($this->client->tickets()->getLastId() != null) {
+    public function find(array $params = array())
+    {
+        if ($this->client->tickets()->getLastId() != null) {
             $params['ticket_id'] = $this->client->tickets()->getLastId();
             $this->client->tickets()->setLastId(null);
         }
-        if($this->lastId != null) {
+        if ($this->lastId != null) {
             $params['id'] = $this->lastId;
             $this->lastId = null;
         }
-        if(!$this->hasKeys($params, array('id', 'ticket_id'))) {
+        if (!$this->hasKeys($params, array('id', 'ticket_id'))) {
             throw new MissingParametersException(__METHOD__, array('id', 'ticket_id'));
         }
-        $endPoint = Http::prepare('tickets/'.$params['ticket_id'].'/audits/'.$params['id'].'.json', $this->client->getSideload($params));
+        $endPoint = Http::prepare('tickets/' . $params['ticket_id'] . '/audits/' . $params['id'] . '.json',
+            $this->client->getSideload($params));
         $response = Http::send($this->client, $endPoint);
         if ((!is_object($response)) || ($this->client->getDebug()->lastResponseCode != 200)) {
             throw new ResponseException(__METHOD__);
         }
         $this->client->setSideload(null);
+
         return $response;
     }
 
@@ -82,24 +89,26 @@ class TicketAudits extends ClientAbstract {
      *
      * @return mixed
      */
-    public function markAsTrusted(array $params = array()) {
-        if($this->client->tickets()->getLastId() != null) {
+    public function markAsTrusted(array $params = array())
+    {
+        if ($this->client->tickets()->getLastId() != null) {
             $params['ticket_id'] = $this->client->tickets()->getLastId();
             $this->client->tickets()->setLastId(null);
         }
-        if($this->lastId != null) {
+        if ($this->lastId != null) {
             $params['id'] = $this->lastId;
             $this->lastId = null;
         }
-        if(!$this->hasKeys($params, array('id', 'ticket_id'))) {
+        if (!$this->hasKeys($params, array('id', 'ticket_id'))) {
             throw new MissingParametersException(__METHOD__, array('id', 'ticket_id'));
         }
-        $endPoint = Http::prepare('tickets/'.$params['ticket_id'].'/audits/'.$params['id'].'/trust.json');
+        $endPoint = Http::prepare('tickets/' . $params['ticket_id'] . '/audits/' . $params['id'] . '/trust.json');
         $response = Http::send($this->client, $endPoint, null, 'PUT');
         if ($this->client->getDebug()->lastResponseCode != 200) {
             throw new ResponseException(__METHOD__);
         }
         $this->client->setSideload(null);
+
         return $response;
     }
 

--- a/src/Zendesk/API/TicketComments.php
+++ b/src/Zendesk/API/TicketComments.php
@@ -6,7 +6,8 @@ namespace Zendesk\API;
  * The TicketComments class exposes comment methods for tickets
  * @package Zendesk\API
  */
-class TicketComments extends ClientAbstract {
+class TicketComments extends ClientAbstract
+{
 
     const OBJ_NAME = 'comment';
     const OBJ_NAME_PLURAL = 'comments';
@@ -22,20 +23,22 @@ class TicketComments extends ClientAbstract {
      *
      * @return mixed
      */
-    public function findAll(array $params = array()) {
-        if($this->client->tickets()->getLastId() != null) {
+    public function findAll(array $params = array())
+    {
+        if ($this->client->tickets()->getLastId() != null) {
             $params['ticket_id'] = $this->client->tickets()->getLastId();
             $this->client->tickets()->setLastId(null);
         }
-        if(!$this->hasKeys($params, array('ticket_id'))) {
+        if (!$this->hasKeys($params, array('ticket_id'))) {
             throw new MissingParametersException(__METHOD__, array('ticket_id'));
         }
-        $endPoint = Http::prepare('tickets/'.$params['ticket_id'].'/comments.json', null, $params);
+        $endPoint = Http::prepare('tickets/' . $params['ticket_id'] . '/comments.json', null, $params);
         $response = Http::send($this->client, $endPoint);
         if ((!is_object($response)) || ($this->client->getDebug()->lastResponseCode != 200)) {
             throw new ResponseException(__METHOD__);
         }
         $this->client->setSideload(null);
+
         return $response;
     }
 
@@ -50,24 +53,26 @@ class TicketComments extends ClientAbstract {
      *
      * @return mixed
      */
-    public function makePrivate(array $params = array()) {
-        if($this->client->tickets()->getLastId() != null) {
+    public function makePrivate(array $params = array())
+    {
+        if ($this->client->tickets()->getLastId() != null) {
             $params['ticket_id'] = $this->client->tickets()->getLastId();
             $this->client->tickets()->setLastId(null);
         }
-        if($this->lastId != null) {
+        if ($this->lastId != null) {
             $params['id'] = $this->lastId;
             $this->lastId = null;
         }
-        if(!$this->hasKeys($params, array('id', 'ticket_id'))) {
+        if (!$this->hasKeys($params, array('id', 'ticket_id'))) {
             throw new MissingParametersException(__METHOD__, array('id', 'ticket_id'));
         }
-        $endPoint = Http::prepare('tickets/'.$params['ticket_id'].'/comments/'.$params['id'].'/make_private.json');
+        $endPoint = Http::prepare('tickets/' . $params['ticket_id'] . '/comments/' . $params['id'] . '/make_private.json');
         $response = Http::send($this->client, $endPoint, null, 'PUT');
         if ($this->client->getDebug()->lastResponseCode != 200) {
             throw new ResponseException(__METHOD__, ' (hint: you can\'t make a private ticket private again)');
         }
         $this->client->setSideload(null);
+
         return $response;
     }
 
@@ -81,8 +86,9 @@ class TicketComments extends ClientAbstract {
      *
      * @throws CustomException
      */
-    public function find(array $params = array()) {
-        throw new CustomException('Method '.__METHOD__.' does not exist. Try $client->ticket(ticket_id)->comments()->findAll() instead.');
+    public function find(array $params = array())
+    {
+        throw new CustomException('Method ' . __METHOD__ . ' does not exist. Try $client->ticket(ticket_id)->comments()->findAll() instead.');
     }
 
 }

--- a/src/Zendesk/API/TicketFields.php
+++ b/src/Zendesk/API/TicketFields.php
@@ -6,7 +6,8 @@ namespace Zendesk\API;
  * The TicketFields class exposes field management methods for tickets
  * @package Zendesk\API
  */
-class TicketFields extends ClientAbstract {
+class TicketFields extends ClientAbstract
+{
 
     const OBJ_NAME = 'ticket_field';
     const OBJ_NAME_PLURAL = 'ticket_fields';
@@ -21,13 +22,15 @@ class TicketFields extends ClientAbstract {
      *
      * @return mixed
      */
-    public function findAll(array $params = array()) {
+    public function findAll(array $params = array())
+    {
         $endPoint = Http::prepare('ticket_fields.json', null, $params);
         $response = Http::send($this->client, $endPoint);
         if ((!is_object($response)) || ($this->client->getDebug()->lastResponseCode != 200)) {
             throw new ResponseException(__METHOD__);
         }
         $this->client->setSideload(null);
+
         return $response;
     }
 
@@ -42,20 +45,22 @@ class TicketFields extends ClientAbstract {
      *
      * @return mixed
      */
-    public function find(array $params = array()) {
-        if($this->lastId != null) {
+    public function find(array $params = array())
+    {
+        if ($this->lastId != null) {
             $params['id'] = $this->lastId;
             $this->lastId = null;
         }
-        if(!$this->hasKeys($params, array('id'))) {
+        if (!$this->hasKeys($params, array('id'))) {
             throw new MissingParametersException(__METHOD__, array('id'));
         }
-        $endPoint = Http::prepare('ticket_fields/'.$params['id'].'.json');
+        $endPoint = Http::prepare('ticket_fields/' . $params['id'] . '.json');
         $response = Http::send($this->client, $endPoint);
         if ((!is_object($response)) || ($this->client->getDebug()->lastResponseCode != 200)) {
             throw new ResponseException(__METHOD__);
         }
         $this->client->setSideload(null);
+
         return $response;
     }
 
@@ -69,13 +74,15 @@ class TicketFields extends ClientAbstract {
      *
      * @return mixed
      */
-    public function create(array $params) {
+    public function create(array $params)
+    {
         $endPoint = Http::prepare('ticket_fields.json');
         $response = Http::send($this->client, $endPoint, array(self::OBJ_NAME => $params), 'POST');
         if ((!is_object($response)) || ($this->client->getDebug()->lastResponseCode != 201)) {
             throw new ResponseException(__METHOD__);
         }
         $this->client->setSideload(null);
+
         return $response;
     }
 
@@ -90,22 +97,24 @@ class TicketFields extends ClientAbstract {
      *
      * @return mixed
      */
-    public function update(array $params) {
-        if($this->lastId != null) {
+    public function update(array $params)
+    {
+        if ($this->lastId != null) {
             $params['id'] = $this->lastId;
             $this->lastId = null;
         }
-        if(!$this->hasKeys($params, array('id'))) {
+        if (!$this->hasKeys($params, array('id'))) {
             throw new MissingParametersException(__METHOD__, array('id'));
         }
         $id = $params['id'];
         unset($params['id']);
-        $endPoint = Http::prepare('ticket_fields/'.$id.'.json');
+        $endPoint = Http::prepare('ticket_fields/' . $id . '.json');
         $response = Http::send($this->client, $endPoint, array(self::OBJ_NAME => $params), 'PUT');
         if ((!is_object($response)) || ($this->client->getDebug()->lastResponseCode != 200)) {
             throw new ResponseException(__METHOD__);
         }
         $this->client->setSideload(null);
+
         return $response;
     }
 
@@ -120,21 +129,23 @@ class TicketFields extends ClientAbstract {
      *
      * @return bool
      */
-    public function delete(array $params = array()) {
-        if($this->lastId != null) {
+    public function delete(array $params = array())
+    {
+        if ($this->lastId != null) {
             $params['id'] = $this->lastId;
             $this->lastId = null;
         }
-        if(!$this->hasKeys($params, array('id'))) {
+        if (!$this->hasKeys($params, array('id'))) {
             throw new MissingParametersException(__METHOD__, array('id'));
         }
         $id = $params['id'];
-        $endPoint = Http::prepare('ticket_fields/'.$id.'.json');
+        $endPoint = Http::prepare('ticket_fields/' . $id . '.json');
         $response = Http::send($this->client, $endPoint, null, 'DELETE');
         if ($this->client->getDebug()->lastResponseCode != 200) {
             throw new ResponseException(__METHOD__);
         }
         $this->client->setSideload(null);
+
         return true;
     }
 

--- a/src/Zendesk/API/TicketForms.php
+++ b/src/Zendesk/API/TicketForms.php
@@ -6,7 +6,8 @@ namespace Zendesk\API;
  * The TicketForms class exposes form management methods for tickets
  * @package Zendesk\API
  */
-class TicketForms extends ClientAbstract {
+class TicketForms extends ClientAbstract
+{
 
     const OBJ_NAME = 'ticket_form';
     const OBJ_NAME_PLURAL = 'ticket_forms';
@@ -21,13 +22,15 @@ class TicketForms extends ClientAbstract {
      *
      * @return mixed
      */
-    public function findAll(array $params = array()) {
+    public function findAll(array $params = array())
+    {
         $endPoint = Http::prepare('ticket_forms.json', null, $params);
         $response = Http::send($this->client, $endPoint);
         if ((!is_object($response)) || ($this->client->getDebug()->lastResponseCode != 200)) {
             throw new ResponseException(__METHOD__);
         }
         $this->client->setSideload(null);
+
         return $response;
     }
 
@@ -42,20 +45,22 @@ class TicketForms extends ClientAbstract {
      *
      * @return mixed
      */
-    public function find(array $params = array()) {
-        if($this->lastId != null) {
+    public function find(array $params = array())
+    {
+        if ($this->lastId != null) {
             $params['id'] = $this->lastId;
             $this->lastId = null;
         }
-        if(!$this->hasKeys($params, array('id'))) {
+        if (!$this->hasKeys($params, array('id'))) {
             throw new MissingParametersException(__METHOD__, array('id'));
         }
-        $endPoint = Http::prepare('ticket_forms/'.$params['id'].'.json');
+        $endPoint = Http::prepare('ticket_forms/' . $params['id'] . '.json');
         $response = Http::send($this->client, $endPoint);
         if ((!is_object($response)) || ($this->client->getDebug()->lastResponseCode != 200)) {
             throw new ResponseException(__METHOD__);
         }
         $this->client->setSideload(null);
+
         return $response;
     }
 
@@ -69,13 +74,15 @@ class TicketForms extends ClientAbstract {
      *
      * @return mixed
      */
-    public function create(array $params) {
+    public function create(array $params)
+    {
         $endPoint = Http::prepare('ticket_forms.json');
         $response = Http::send($this->client, $endPoint, array(self::OBJ_NAME => $params), 'POST');
         if ((!is_object($response)) || ($this->client->getDebug()->lastResponseCode != 201)) {
             throw new ResponseException(__METHOD__);
         }
         $this->client->setSideload(null);
+
         return $response;
     }
 
@@ -90,22 +97,24 @@ class TicketForms extends ClientAbstract {
      *
      * @return mixed
      */
-    public function update(array $params) {
-        if($this->lastId != null) {
+    public function update(array $params)
+    {
+        if ($this->lastId != null) {
             $params['id'] = $this->lastId;
             $this->lastId = null;
         }
-        if(!$this->hasKeys($params, array('id'))) {
+        if (!$this->hasKeys($params, array('id'))) {
             throw new MissingParametersException(__METHOD__, array('id'));
         }
         $id = $params['id'];
         unset($params['id']);
-        $endPoint = Http::prepare('ticket_forms/'.$id.'.json');
+        $endPoint = Http::prepare('ticket_forms/' . $id . '.json');
         $response = Http::send($this->client, $endPoint, array(self::OBJ_NAME => $params), 'PUT');
         if ((!is_object($response)) || ($this->client->getDebug()->lastResponseCode != 200)) {
             throw new ResponseException(__METHOD__);
         }
         $this->client->setSideload(null);
+
         return $response;
     }
 
@@ -120,21 +129,24 @@ class TicketForms extends ClientAbstract {
      *
      * @return bool
      */
-    public function delete(array $params = array()) {
-        if($this->lastId != null) {
+    public function delete(array $params = array())
+    {
+        if ($this->lastId != null) {
             $params['id'] = $this->lastId;
             $this->lastId = null;
         }
-        if(!$this->hasKeys($params, array('id'))) {
+        if (!$this->hasKeys($params, array('id'))) {
             throw new MissingParametersException(__METHOD__, array('id'));
         }
         $id = $params['id'];
-        $endPoint = Http::prepare('ticket_forms/'.$id.'.json');
+        $endPoint = Http::prepare('ticket_forms/' . $id . '.json');
         $response = Http::send($this->client, $endPoint, null, 'DELETE');
         if ($this->client->getDebug()->lastResponseCode != 200) {
-            throw new ResponseException(__METHOD__, ($this->client->getDebug()->lastResponseCode == 422 ? ' (hint: you may need to run $client->ticketForm(id)->deactivate to deactivate the ticket form first)' : ''));
+            throw new ResponseException(__METHOD__,
+                ($this->client->getDebug()->lastResponseCode == 422 ? ' (hint: you may need to run $client->ticketForm(id)->deactivate to deactivate the ticket form first)' : ''));
         }
         $this->client->setSideload(null);
+
         return true;
     }
 
@@ -148,13 +160,15 @@ class TicketForms extends ClientAbstract {
      *
      * @return bool
      */
-    function reorder(array $params) {
+    function reorder(array $params)
+    {
         $endPoint = Http::prepare('ticket_forms/reorder.json');
         $response = Http::send($this->client, $endPoint, array('ticket_form_ids' => $params), 'PUT');
         if ($this->client->getDebug()->lastResponseCode != 200) {
             throw new ResponseException(__METHOD__);
         }
         $this->client->setSideload(null);
+
         return true;
     }
 
@@ -169,21 +183,23 @@ class TicketForms extends ClientAbstract {
      *
      * @return mixed
      */
-    function cloneForm(array $params = array()) {
-        if($this->lastId != null) {
+    function cloneForm(array $params = array())
+    {
+        if ($this->lastId != null) {
             $params['id'] = $this->lastId;
             $this->lastId = null;
         }
-        if(!$this->hasKeys($params, array('id'))) {
+        if (!$this->hasKeys($params, array('id'))) {
             throw new MissingParametersException(__METHOD__, array('id'));
         }
         $id = $params['id'];
-        $endPoint = Http::prepare('ticket_forms/'.$id.'/clone.json');
+        $endPoint = Http::prepare('ticket_forms/' . $id . '/clone.json');
         $response = Http::send($this->client, $endPoint, null, 'POST');
         if ($this->client->getDebug()->lastResponseCode != 201) {
             throw new ResponseException(__METHOD__);
         }
         $this->client->setSideload(null);
+
         return $response;
     }
 
@@ -197,8 +213,10 @@ class TicketForms extends ClientAbstract {
      *
      * @return mixed
      */
-    function deactivate(array $params = array()) {
+    function deactivate(array $params = array())
+    {
         $params['active'] = false;
+
         return $this->update($params);
     }
 

--- a/src/Zendesk/API/TicketImport.php
+++ b/src/Zendesk/API/TicketImport.php
@@ -6,7 +6,8 @@ namespace Zendesk\API;
  * The TicketImport class exposes import methods for tickets
  * @package Zendesk\API
  */
-class TicketImport extends ClientAbstract {
+class TicketImport extends ClientAbstract
+{
 
     const OBJ_NAME = 'ticket';
     const OBJ_NAME_PLURAL = 'tickets';
@@ -21,13 +22,15 @@ class TicketImport extends ClientAbstract {
      *
      * @return mixed
      */
-    public function import(array $params) {
+    public function import(array $params)
+    {
         $endPoint = Http::prepare('imports/tickets.json');
-        $response = Http::send($this->client, $endPoint, array (self::OBJ_NAME => $params), 'POST');
+        $response = Http::send($this->client, $endPoint, array(self::OBJ_NAME => $params), 'POST');
         if ((!is_object($response)) || ($this->client->getDebug()->lastResponseCode != 201)) {
             throw new ResponseException(__METHOD__);
         }
         $this->client->setSideload(null);
+
         return $response;
     }
 

--- a/src/Zendesk/API/TicketMetrics.php
+++ b/src/Zendesk/API/TicketMetrics.php
@@ -6,7 +6,8 @@ namespace Zendesk\API;
  * The TicketMetrics class exposes metrics methods for tickets
  * @package Zendesk\API
  */
-class TicketMetrics extends ClientAbstract {
+class TicketMetrics extends ClientAbstract
+{
 
     const OBJ_NAME = 'ticket_metric';
     const OBJ_NAME_PLURAL = 'ticket_metrics';
@@ -21,17 +22,20 @@ class TicketMetrics extends ClientAbstract {
      *
      * @return mixed
      */
-    public function findAll(array $params = array()) {
-        if($this->client->tickets()->getLastId() != null) {
+    public function findAll(array $params = array())
+    {
+        if ($this->client->tickets()->getLastId() != null) {
             $params['ticket_id'] = $this->client->tickets()->getLastId();
             $this->client->tickets()->setLastId(null);
         }
-        $endPoint = Http::prepare((isset($params['ticket_id']) ? 'tickets/'.$params['ticket_id'].'/metrics.json' : 'ticket_metrics.json'), null, $params);
+        $endPoint = Http::prepare((isset($params['ticket_id']) ? 'tickets/' . $params['ticket_id'] . '/metrics.json' : 'ticket_metrics.json'),
+            null, $params);
         $response = Http::send($this->client, $endPoint);
         if ((!is_object($response)) || ($this->client->getDebug()->lastResponseCode != 200)) {
             throw new ResponseException(__METHOD__);
         }
         $this->client->setSideload(null);
+
         return $response;
     }
 
@@ -46,24 +50,26 @@ class TicketMetrics extends ClientAbstract {
      *
      * @return mixed
      */
-    public function find(array $params = array()) {
-        if($this->client->tickets()->getLastId() != null) {
+    public function find(array $params = array())
+    {
+        if ($this->client->tickets()->getLastId() != null) {
             $params['ticket_id'] = $this->client->tickets()->getLastId();
             $this->client->tickets()->setLastId(null);
         }
-        if($this->lastId != null) {
+        if ($this->lastId != null) {
             $params['id'] = $this->lastId;
             $this->lastId = null;
         }
-        if(!$this->hasAnyKey($params, array('id', 'ticket_id'))) {
+        if (!$this->hasAnyKey($params, array('id', 'ticket_id'))) {
             throw new MissingParametersException(__METHOD__, array('id', 'ticket_id'));
         }
-        $endPoint = Http::prepare((isset($params['ticket_id']) ? 'tickets/'.$params['ticket_id'].'/metrics.json' : 'ticket_metrics/'.$params['id'].'.json'));
+        $endPoint = Http::prepare((isset($params['ticket_id']) ? 'tickets/' . $params['ticket_id'] . '/metrics.json' : 'ticket_metrics/' . $params['id'] . '.json'));
         $response = Http::send($this->client, $endPoint);
         if ((!is_object($response)) || ($this->client->getDebug()->lastResponseCode != 200)) {
             throw new ResponseException(__METHOD__);
         }
         $this->client->setSideload(null);
+
         return $response;
     }
 

--- a/src/Zendesk/API/Tickets.php
+++ b/src/Zendesk/API/Tickets.php
@@ -11,7 +11,8 @@ namespace Zendesk\API;
  * @method TicketMetrics metrics()
  * @method SatisfactionRatings satisfactionRatings()
  */
-class Tickets extends ClientAbstract {
+class Tickets extends ClientAbstract
+{
 
     const OBJ_NAME = 'ticket';
     const OBJ_NAME_PLURAL = 'tickets';
@@ -48,7 +49,8 @@ class Tickets extends ClientAbstract {
     /**
      * @param Client $client
      */
-    public function __construct(Client $client) {
+    public function __construct(Client $client)
+    {
         parent::__construct($client);
         $this->audits = new TicketAudits($client);
         $this->comments = new TicketComments($client);
@@ -67,29 +69,31 @@ class Tickets extends ClientAbstract {
      *
      * @return mixed
      */
-    public function findAll(array $params = array ()) {
-        if($this->client->organizations()->getLastId() != null) {
+    public function findAll(array $params = array())
+    {
+        if ($this->client->organizations()->getLastId() != null) {
             $params['organization_id'] = $this->client->organizations()->getLastId();
             $this->client->organizations()->setLastId(null);
         }
-        if($this->client->users()->getLastId() != null) {
+        if ($this->client->users()->getLastId() != null) {
             $params['user_id'] = $this->client->users()->getLastId();
             $this->client->users()->setLastId(null);
         }
         $queryParams = array();
-        if(isset($params['external_id'])) {
+        if (isset($params['external_id'])) {
             $queryParams['external_id'] = $params['external_id'];
         }
         $endPoint = Http::prepare(
-                (isset($params['organization_id']) ? 'organizations/'.$params['organization_id'].'/tickets' :
-                (isset($params['user_id']) ? 'users/'.$params['user_id'].'/tickets/'.(isset($params['ccd']) ? 'ccd' : 'requested') :
-                (isset($params['recent']) ? 'tickets/recent' : 'tickets'))
-            ).'.json', $this->client->getSideload($params), $params);
+            (isset($params['organization_id']) ? 'organizations/' . $params['organization_id'] . '/tickets' :
+                (isset($params['user_id']) ? 'users/' . $params['user_id'] . '/tickets/' . (isset($params['ccd']) ? 'ccd' : 'requested') :
+                    (isset($params['recent']) ? 'tickets/recent' : 'tickets'))
+            ) . '.json', $this->client->getSideload($params), $params);
         $response = Http::send($this->client, $endPoint, $queryParams);
         if ((!is_object($response)) || ($this->client->getDebug()->lastResponseCode != 200)) {
             throw new ResponseException(__METHOD__);
         }
         $this->client->setSideload(null);
+
         return $response;
     }
 
@@ -104,20 +108,23 @@ class Tickets extends ClientAbstract {
      *
      * @return mixed
      */
-    public function find(array $params = array()) {
-        if($this->lastId != null) {
+    public function find(array $params = array())
+    {
+        if ($this->lastId != null) {
             $params['id'] = $this->lastId;
             $this->lastId = null;
         }
-        if(!$this->hasKeys($params, array('id'))) {
+        if (!$this->hasKeys($params, array('id'))) {
             throw new MissingParametersException(__METHOD__, array('id'));
         }
-        $endPoint = Http::prepare((is_array($params['id']) ? 'tickets/show_many.json?ids='.implode(',', $params['id']) : 'tickets/'.$params['id'].'.json'), $this->client->getSideload($params));
+        $endPoint = Http::prepare((is_array($params['id']) ? 'tickets/show_many.json?ids=' . implode(',',
+                $params['id']) : 'tickets/' . $params['id'] . '.json'), $this->client->getSideload($params));
         $response = Http::send($this->client, $endPoint);
         if ((!is_object($response)) || ($this->client->getDebug()->lastResponseCode != 200)) {
             throw new ResponseException(__METHOD__);
         }
         $this->client->setSideload(null);
+
         return $response;
     }
 
@@ -132,20 +139,23 @@ class Tickets extends ClientAbstract {
      *
      * @return mixed
      */
-    public function findTwicket(array $params = array()) {
-        if($this->lastId != null) {
+    public function findTwicket(array $params = array())
+    {
+        if ($this->lastId != null) {
             $params['id'] = $this->lastId;
             $this->lastId = null;
         }
-        if(!$this->hasKeys($params, array('id'))) {
+        if (!$this->hasKeys($params, array('id'))) {
             throw new MissingParametersException(__METHOD__, array('id'));
         }
-        $endPoint = Http::prepare('channels/twitter/tickets/'.$params['id'].'/statuses.json'.(is_array($params['comment_ids']) ? '?'.implode(',', $params['comment_ids']) : ''), $this->client->getSideload($params));
+        $endPoint = Http::prepare('channels/twitter/tickets/' . $params['id'] . '/statuses.json' . (is_array($params['comment_ids']) ? '?' . implode(',',
+                    $params['comment_ids']) : ''), $this->client->getSideload($params));
         $response = Http::send($this->client, $endPoint);
         if ((!is_object($response)) || ($this->client->getDebug()->lastResponseCode != 200)) {
             throw new ResponseException(__METHOD__);
         }
         $this->client->setSideload(null);
+
         return $response;
     }
 
@@ -159,17 +169,19 @@ class Tickets extends ClientAbstract {
      *
      * @return mixed
      */
-    public function create(array $params) {
-        if(count($this->lastAttachments)) {
+    public function create(array $params)
+    {
+        if (count($this->lastAttachments)) {
             $params['comment']['uploads'] = $this->lastAttachments;
             $this->lastAttachments = array();
         }
         $endPoint = Http::prepare('tickets.json');
-        $response = Http::send($this->client, $endPoint, array (self::OBJ_NAME => $params), 'POST');
+        $response = Http::send($this->client, $endPoint, array(self::OBJ_NAME => $params), 'POST');
         if ((!is_object($response)) || ($this->client->getDebug()->lastResponseCode != 201)) {
             throw new ResponseException(__METHOD__);
         }
         $this->client->setSideload(null);
+
         return $response;
     }
 
@@ -184,16 +196,20 @@ class Tickets extends ClientAbstract {
      *
      * @return mixed
      */
-    public function createFromTweet(array $params) {
-        if((!$params['twitter_status_message_id']) || (!$params['monitored_twitter_handle_id'])) {
-            throw new MissingParametersException(__METHOD__, array('twitter_status_message_id', 'monitored_twitter_handle_id'));
+    public function createFromTweet(array $params)
+    {
+        if ((!$params['twitter_status_message_id']) || (!$params['monitored_twitter_handle_id'])) {
+            throw new MissingParametersException(__METHOD__,
+                array('twitter_status_message_id', 'monitored_twitter_handle_id'));
         }
         $endPoint = Http::prepare('channels/twitter/tickets.json');
-        $response = Http::send($this->client, $endPoint, array (self::OBJ_NAME => $params), 'POST');
+        $response = Http::send($this->client, $endPoint, array(self::OBJ_NAME => $params), 'POST');
         if ((!is_object($response)) || ($this->client->getDebug()->lastResponseCode != 201)) {
-            throw new ResponseException(__METHOD__, ($this->client->getDebug()->lastResponseCode == 422 ? ' (hint: you can\'t create two tickets from the same tweet)' : ''));
+            throw new ResponseException(__METHOD__,
+                ($this->client->getDebug()->lastResponseCode == 422 ? ' (hint: you can\'t create two tickets from the same tweet)' : ''));
         }
         $this->client->setSideload(null);
+
         return $response;
     }
 
@@ -208,26 +224,30 @@ class Tickets extends ClientAbstract {
      *
      * @return mixed
      */
-    public function update(array $params) {
-        if($this->lastId != null) {
+    public function update(array $params)
+    {
+        if ($this->lastId != null) {
             $params['id'] = $this->lastId;
             $this->lastId = null;
         }
-        if(!$this->hasKeys($params, array('id'))) {
+        if (!$this->hasKeys($params, array('id'))) {
             throw new MissingParametersException(__METHOD__, array('id'));
         }
-        if(count($this->lastAttachments)) {
+        if (count($this->lastAttachments)) {
             $params['comment']['uploads'] = $this->lastAttachments;
             $this->lastAttachments = array();
         }
         $id = $params['id'];
         unset($params['id']);
-        $endPoint = Http::prepare((is_array($id) ? 'tickets/update_many.json?ids='.implode(',', $id) : 'tickets/'.$id.'.json'));
-        $response = Http::send($this->client, $endPoint, array (self::OBJ_NAME => $params), 'PUT');
+        $endPoint = Http::prepare((is_array($id) ? 'tickets/update_many.json?ids=' . implode(',',
+                $id) : 'tickets/' . $id . '.json'));
+        $response = Http::send($this->client, $endPoint, array(self::OBJ_NAME => $params), 'PUT');
         if ((!is_object($response)) || ($this->client->getDebug()->lastResponseCode != 200)) {
-            throw new ResponseException(__METHOD__, ($this->client->getDebug()->lastResponseCode == 422 ? ' (hint: you can\'t update a closed ticket)' : ''));
+            throw new ResponseException(__METHOD__,
+                ($this->client->getDebug()->lastResponseCode == 422 ? ' (hint: you can\'t update a closed ticket)' : ''));
         }
         $this->client->setSideload(null);
+
         return $response;
     }
 
@@ -242,22 +262,25 @@ class Tickets extends ClientAbstract {
      *
      * @return mixed
      */
-    public function markAsSpam(array $params = array()) {
-        if($this->lastId != null) {
+    public function markAsSpam(array $params = array())
+    {
+        if ($this->lastId != null) {
             $params['id'] = $this->lastId;
             $this->lastId = null;
         }
-        if(!$this->hasKeys($params, array('id'))) {
+        if (!$this->hasKeys($params, array('id'))) {
             throw new MissingParametersException(__METHOD__, array('id'));
         }
         $id = $params['id'];
-        $endPoint = Http::prepare('tickets/'.$id.'/mark_as_spam.json');
+        $endPoint = Http::prepare('tickets/' . $id . '/mark_as_spam.json');
         $response = Http::send($this->client, $endPoint, null, 'PUT');
         // Seems to be a bug in the service, it may respond with 422 even when it succeeds
         if ((!is_object($response)) || ($this->client->getDebug()->lastResponseCode != 200)) {
-            throw new ResponseException(__METHOD__, ($this->client->getDebug()->lastResponseCode == 422 ? ' (note: there\'s currently a bug in the service so this call may have succeeded; call tickets->find to see if it still exists.)' : ''));
+            throw new ResponseException(__METHOD__,
+                ($this->client->getDebug()->lastResponseCode == 422 ? ' (note: there\'s currently a bug in the service so this call may have succeeded; call tickets->find to see if it still exists.)' : ''));
         }
         $this->client->setSideload(null);
+
         return $response;
     }
 
@@ -272,21 +295,23 @@ class Tickets extends ClientAbstract {
      *
      * @return mixed
      */
-    public function related(array $params = array()) {
-        if($this->lastId != null) {
+    public function related(array $params = array())
+    {
+        if ($this->lastId != null) {
             $params['id'] = $this->lastId;
             $this->lastId = null;
         }
-        if(!$this->hasKeys($params, array('id'))) {
+        if (!$this->hasKeys($params, array('id'))) {
             throw new MissingParametersException(__METHOD__, array('id'));
         }
         $id = $params['id'];
-        $endPoint = Http::prepare('tickets/'.$id.'/related.json', $this->client->getSideload($params), $params);
+        $endPoint = Http::prepare('tickets/' . $id . '/related.json', $this->client->getSideload($params), $params);
         $response = Http::send($this->client, $endPoint);
         if ((!is_object($response)) || ($this->client->getDebug()->lastResponseCode != 200)) {
             throw new ResponseException(__METHOD__);
         }
         $this->client->setSideload(null);
+
         return $response;
     }
 
@@ -301,21 +326,24 @@ class Tickets extends ClientAbstract {
      *
      * @return bool
      */
-    public function delete(array $params = array()) {
-        if($this->lastId != null) {
+    public function delete(array $params = array())
+    {
+        if ($this->lastId != null) {
             $params['id'] = $this->lastId;
             $this->lastId = null;
         }
-        if(!$this->hasKeys($params, array('id'))) {
+        if (!$this->hasKeys($params, array('id'))) {
             throw new MissingParametersException(__METHOD__, array('id'));
         }
         $id = $params['id'];
-        $endPoint = Http::prepare((is_array($id) ? 'tickets/destroy_many.json?ids='.implode(',', $id) : 'tickets/'.$id.'.json'));
+        $endPoint = Http::prepare((is_array($id) ? 'tickets/destroy_many.json?ids=' . implode(',',
+                $id) : 'tickets/' . $id . '.json'));
         $response = Http::send($this->client, $endPoint, null, 'DELETE');
         if ($this->client->getDebug()->lastResponseCode != 200) {
             throw new ResponseException(__METHOD__);
         }
         $this->client->setSideload(null);
+
         return true;
     }
 
@@ -330,21 +358,24 @@ class Tickets extends ClientAbstract {
      *
      * @return mixed
      */
-    public function collaborators(array $params) {
-        if($this->lastId != null) {
+    public function collaborators(array $params)
+    {
+        if ($this->lastId != null) {
             $params['id'] = $this->lastId;
             $this->lastId = null;
         }
-        if(!$this->hasKeys($params, array('id'))) {
+        if (!$this->hasKeys($params, array('id'))) {
             throw new MissingParametersException(__METHOD__, array('id'));
         }
         $id = $params['id'];
-        $endPoint = Http::prepare('tickets/'.$id.'/collaborators.json', $this->client->getSideload($params), $params);
+        $endPoint = Http::prepare('tickets/' . $id . '/collaborators.json', $this->client->getSideload($params),
+            $params);
         $response = Http::send($this->client, $endPoint);
         if ((!is_object($response)) || ($this->client->getDebug()->lastResponseCode != 200)) {
             throw new ResponseException(__METHOD__);
         }
         $this->client->setSideload(null);
+
         return $response;
     }
 
@@ -359,24 +390,25 @@ class Tickets extends ClientAbstract {
      *
      * @return mixed
      */
-    public function incidents(array $params) {
-        if($this->lastId != null) {
+    public function incidents(array $params)
+    {
+        if ($this->lastId != null) {
             $params['id'] = $this->lastId;
             $this->lastId = null;
         }
-        if(!$this->hasKeys($params, array('id'))) {
+        if (!$this->hasKeys($params, array('id'))) {
             throw new MissingParametersException(__METHOD__, array('id'));
         }
         $id = $params['id'];
-        $endPoint = Http::prepare('tickets/'.$id.'/incidents.json', $this->client->getSideload($params), $params);
+        $endPoint = Http::prepare('tickets/' . $id . '/incidents.json', $this->client->getSideload($params), $params);
         $response = Http::send($this->client, $endPoint);
         if ((!is_object($response)) || ($this->client->getDebug()->lastResponseCode != 200)) {
             throw new ResponseException(__METHOD__);
         }
         $this->client->setSideload(null);
+
         return $response;
     }
-
 
 
     /**
@@ -390,13 +422,15 @@ class Tickets extends ClientAbstract {
      *
      * @return mixed
      */
-    public function problems(array $params) {
+    public function problems(array $params)
+    {
         $endPoint = Http::prepare('problems.json', $this->client->getSideload($params), $params);
         $response = Http::send($this->client, $endPoint);
         if ((!is_object($response)) || ($this->client->getDebug()->lastResponseCode != 200)) {
             throw new ResponseException(__METHOD__);
         }
         $this->client->setSideload(null);
+
         return $response;
     }
 
@@ -411,21 +445,23 @@ class Tickets extends ClientAbstract {
      *
      * @return mixed
      */
-    public function problemAutoComplete(array $params) {
-        if($this->lastId != null) {
+    public function problemAutoComplete(array $params)
+    {
+        if ($this->lastId != null) {
             $params['id'] = $this->lastId;
             $this->lastId = null;
         }
-        if(!$this->hasKeys($params, array('id', 'text'))) {
+        if (!$this->hasKeys($params, array('id', 'text'))) {
             throw new MissingParametersException(__METHOD__, array('id', 'text'));
         }
         $id = $params['id'];
-        $endPoint = Http::prepare('tickets/'.$id.'/problems/autocomplete.json');
+        $endPoint = Http::prepare('tickets/' . $id . '/problems/autocomplete.json');
         $response = Http::send($this->client, $endPoint, array('text' => $params['text']), 'POST');
         if ((!is_object($response)) || ($this->client->getDebug()->lastResponseCode != 200)) {
             throw new ResponseException(__METHOD__);
         }
         $this->client->setSideload(null);
+
         return $response;
     }
 
@@ -440,16 +476,18 @@ class Tickets extends ClientAbstract {
      *
      * @return mixed
      */
-    public function export(array $params) {
-        if(!$params['start_time']) {
+    public function export(array $params)
+    {
+        if (!$params['start_time']) {
             throw new MissingParametersException(__METHOD__, array('start_time'));
         }
-        $endPoint = Http::prepare('exports/tickets.json?start_time='.$params['start_time']);
+        $endPoint = Http::prepare('exports/tickets.json?start_time=' . $params['start_time']);
         $response = Http::send($this->client, $endPoint);
         if ((!is_object($response)) || ($this->client->getDebug()->lastResponseCode != 200)) {
             throw new ResponseException(__METHOD__);
         }
         $this->client->setSideload(null);
+
         return $response;
     }
 
@@ -464,16 +502,18 @@ class Tickets extends ClientAbstract {
      *
      * @return mixed
      */
-    public function exportSample(array $params) {
-        if(!$params['start_time']) {
+    public function exportSample(array $params)
+    {
+        if (!$params['start_time']) {
             throw new MissingParametersException(__METHOD__, array('start_time'));
         }
-        $endPoint = Http::prepare('exports/tickets/sample.json?start_time='.$params['start_time']);
+        $endPoint = Http::prepare('exports/tickets/sample.json?start_time=' . $params['start_time']);
         $response = Http::send($this->client, $endPoint);
         if ((!is_object($response)) || ($this->client->getDebug()->lastResponseCode != 200)) {
             throw new ResponseException(__METHOD__);
         }
         $this->client->setSideload(null);
+
         return $response;
     }
 
@@ -487,15 +527,16 @@ class Tickets extends ClientAbstract {
      *
      * @throws CustomException
      */
-    public function __call($name, $arguments) {
-        if(isset($this->$name)) {
+    public function __call($name, $arguments)
+    {
+        if (isset($this->$name)) {
             return ((isset($arguments[0])) && ($arguments[0] != null) ? $this->$name->setLastId($arguments[0]) : $this->$name);
         }
-        $namePlural = $name.'s'; // try pluralize
-        if(isset($this->$namePlural)) {
+        $namePlural = $name . 's'; // try pluralize
+        if (isset($this->$namePlural)) {
             return $this->$namePlural->setLastId($arguments[0]);
         } else {
-            throw new CustomException("No method called $name available in ".__CLASS__);
+            throw new CustomException("No method called $name available in " . __CLASS__);
         }
     }
 
@@ -509,14 +550,20 @@ class Tickets extends ClientAbstract {
      *
      * @return Tags
      */
-    public function tags($id = null) { return ($id != null ? $this->client->tags()->setLastId($id) : $this->client->tags()); }
+    public function tags($id = null)
+    {
+        return ($id != null ? $this->client->tags()->setLastId($id) : $this->client->tags());
+    }
 
     /**
      * @param $id
      *
      * @return Tags
      */
-    public function tag($id) { return $this->client->tags()->setLastId($id); }
+    public function tag($id)
+    {
+        return $this->client->tags()->setLastId($id);
+    }
 
     /**
      * @param array $params
@@ -525,7 +572,10 @@ class Tickets extends ClientAbstract {
      *
      * @return mixed
      */
-    public function import(array $params) { return $this->import->import($params); }
+    public function import(array $params)
+    {
+        return $this->import->import($params);
+    }
 
     /**
      * @param array $params
@@ -536,15 +586,17 @@ class Tickets extends ClientAbstract {
      *
      * @return Tickets
      */
-    public function attach(array $params = array()) {
-        if(!$this->hasKeys($params, array('file'))) {
+    public function attach(array $params = array())
+    {
+        if (!$this->hasKeys($params, array('file'))) {
             throw new MissingParametersException(__METHOD__, array('file'));
         }
         $upload = $this->client->attachments()->upload($params);
-        if((!is_object($upload->upload)) || (!$upload->upload->token)) {
+        if ((!is_object($upload->upload)) || (!$upload->upload->token)) {
             throw new ResponseException(__METHOD__);
         }
         $this->lastAttachments[] = $upload->upload->token;
+
         return $this;
     }
 

--- a/src/Zendesk/API/TopicComments.php
+++ b/src/Zendesk/API/TopicComments.php
@@ -6,7 +6,8 @@ namespace Zendesk\API;
  * The TopicComments class exposes topic commentary information
  * @package Zendesk\API
  */
-class TopicComments extends ClientAbstract {
+class TopicComments extends ClientAbstract
+{
 
     const OBJ_NAME = 'topic_comment';
     const OBJ_NAME_PLURAL = 'topic_comments';
@@ -22,27 +23,30 @@ class TopicComments extends ClientAbstract {
      *
      * @return mixed
      */
-    public function findAll(array $params = array()) {
-        if($this->client->topics()->getLastId() != null) {
+    public function findAll(array $params = array())
+    {
+        if ($this->client->topics()->getLastId() != null) {
             $params['topic_id'] = $this->client->topics()->getLastId();
             $this->client->topics()->setLastId(null);
         }
-        if($this->client->users()->getLastId() != null) {
+        if ($this->client->users()->getLastId() != null) {
             $params['user_id'] = $this->client->users()->getLastId();
             $this->client->users()->setLastId(null);
         }
-        if(!$this->hasAnyKey($params, array('topic_id', 'user_id'))) {
+        if (!$this->hasAnyKey($params, array('topic_id', 'user_id'))) {
             throw new MissingParametersException(__METHOD__, array('topic_id', 'user_id'));
         }
         $endPoint = Http::prepare(
-                (isset($params['topic_id']) ? 'topics/'.$params['topic_id'].'/comments.json' :
-                (isset($params['user_id']) ? 'users/'.$params['user_id'].'/topic_comments.json' : '')), $this->client->getSideload($params), $params
-            );
+            (isset($params['topic_id']) ? 'topics/' . $params['topic_id'] . '/comments.json' :
+                (isset($params['user_id']) ? 'users/' . $params['user_id'] . '/topic_comments.json' : '')),
+            $this->client->getSideload($params), $params
+        );
         $response = Http::send($this->client, $endPoint);
         if ((!is_object($response)) || ($this->client->getDebug()->lastResponseCode != 200)) {
             throw new ResponseException(__METHOD__);
         }
         $this->client->setSideload(null);
+
         return $response;
     }
 
@@ -57,31 +61,34 @@ class TopicComments extends ClientAbstract {
      *
      * @return mixed
      */
-    public function find(array $params = array()) {
-        if($this->client->topics()->getLastId() != null) {
+    public function find(array $params = array())
+    {
+        if ($this->client->topics()->getLastId() != null) {
             $params['topic_id'] = $this->client->topics()->getLastId();
             $this->client->topics()->setLastId(null);
         }
-        if($this->client->users()->getLastId() != null) {
+        if ($this->client->users()->getLastId() != null) {
             $params['user_id'] = $this->client->users()->getLastId();
             $this->client->users()->setLastId(null);
         }
-        if(!$this->hasAnyKey($params, array('topic_id', 'user_id'))) {
+        if (!$this->hasAnyKey($params, array('topic_id', 'user_id'))) {
             throw new MissingParametersException(__METHOD__, array('topic_id', 'user_id'));
         }
-        if($this->lastId != null) {
+        if ($this->lastId != null) {
             $params['id'] = $this->lastId;
             $this->lastId = null;
         }
-        if(!$this->hasKeys($params, array('id'))) {
+        if (!$this->hasKeys($params, array('id'))) {
             throw new MissingParametersException(__METHOD__, array('id'));
         }
-        $endPoint = Http::prepare((isset($params['topic_id']) ? 'topics/'.$params['topic_id'].'/comments/'.$params['id'].'.json' : 'users/'.$params['user_id'].'/topic_comments/'.$params['id'].'.json'), $this->client->getSideload($params));
+        $endPoint = Http::prepare((isset($params['topic_id']) ? 'topics/' . $params['topic_id'] . '/comments/' . $params['id'] . '.json' : 'users/' . $params['user_id'] . '/topic_comments/' . $params['id'] . '.json'),
+            $this->client->getSideload($params));
         $response = Http::send($this->client, $endPoint);
         if ((!is_object($response)) || ($this->client->getDebug()->lastResponseCode != 200)) {
             throw new ResponseException(__METHOD__);
         }
         $this->client->setSideload(null);
+
         return $response;
     }
 
@@ -96,20 +103,22 @@ class TopicComments extends ClientAbstract {
      *
      * @return mixed
      */
-    public function create(array $params) {
-        if($this->client->topics()->getLastId() != null) {
+    public function create(array $params)
+    {
+        if ($this->client->topics()->getLastId() != null) {
             $params['topic_id'] = $this->client->topics()->getLastId();
             $this->client->topics()->setLastId(null);
         }
-        if(!$this->hasKeys($params, array('topic_id'))) {
+        if (!$this->hasKeys($params, array('topic_id'))) {
             throw new MissingParametersException(__METHOD__, array('topic_id'));
         }
-        $endPoint = Http::prepare('topics/'.$params['topic_id'].'/comments.json');
-        $response = Http::send($this->client, $endPoint, array (self::OBJ_NAME => $params), 'POST');
+        $endPoint = Http::prepare('topics/' . $params['topic_id'] . '/comments.json');
+        $response = Http::send($this->client, $endPoint, array(self::OBJ_NAME => $params), 'POST');
         if ((!is_object($response)) || ($this->client->getDebug()->lastResponseCode != 201)) {
             throw new ResponseException(__METHOD__);
         }
         $this->client->setSideload(null);
+
         return $response;
     }
 
@@ -124,20 +133,22 @@ class TopicComments extends ClientAbstract {
      *
      * @return mixed
      */
-    public function import(array $params) {
-        if($this->client->topics()->getLastId() != null) {
+    public function import(array $params)
+    {
+        if ($this->client->topics()->getLastId() != null) {
             $params['topic_id'] = $this->client->topics()->getLastId();
             $this->client->topics()->setLastId(null);
         }
-        if(!$this->hasKeys($params, array('topic_id'))) {
+        if (!$this->hasKeys($params, array('topic_id'))) {
             throw new MissingParametersException(__METHOD__, array('topic_id'));
         }
-        $endPoint = Http::prepare('import/topics/'.$params['topic_id'].'/comments.json');
-        $response = Http::send($this->client, $endPoint, array (self::OBJ_NAME => $params), 'POST');
+        $endPoint = Http::prepare('import/topics/' . $params['topic_id'] . '/comments.json');
+        $response = Http::send($this->client, $endPoint, array(self::OBJ_NAME => $params), 'POST');
         if ((!is_object($response)) || ($this->client->getDebug()->lastResponseCode != 201)) {
             throw new ResponseException(__METHOD__);
         }
         $this->client->setSideload(null);
+
         return $response;
     }
 
@@ -152,27 +163,29 @@ class TopicComments extends ClientAbstract {
      *
      * @return mixed
      */
-    public function update(array $params) {
-        if($this->lastId != null) {
+    public function update(array $params)
+    {
+        if ($this->lastId != null) {
             $params['id'] = $this->lastId;
             $this->lastId = null;
         }
-        if($this->client->topics()->getLastId() != null) {
+        if ($this->client->topics()->getLastId() != null) {
             $params['topic_id'] = $this->client->topics()->getLastId();
             $this->client->topics()->setLastId(null);
         }
-        if(!$this->hasKeys($params, array('id', 'topic_id'))) {
+        if (!$this->hasKeys($params, array('id', 'topic_id'))) {
             throw new MissingParametersException(__METHOD__, array('id', 'topic_id'));
         }
-        $prepare = 'topics/'.$params['topic_id'].'/comments/'.$params['id'].'.json';
+        $prepare = 'topics/' . $params['topic_id'] . '/comments/' . $params['id'] . '.json';
         unset($params['id']);
         unset($params['topic_id']);
         $endPoint = Http::prepare($prepare);
-        $response = Http::send($this->client, $endPoint, array (self::OBJ_NAME => $params), 'PUT');
+        $response = Http::send($this->client, $endPoint, array(self::OBJ_NAME => $params), 'PUT');
         if ((!is_object($response)) || ($this->client->getDebug()->lastResponseCode != 200)) {
             throw new ResponseException(__METHOD__);
         }
         $this->client->setSideload(null);
+
         return $response;
     }
 
@@ -187,24 +200,26 @@ class TopicComments extends ClientAbstract {
      *
      * @return bool
      */
-    public function delete(array $params = array()) {
-        if($this->lastId != null) {
+    public function delete(array $params = array())
+    {
+        if ($this->lastId != null) {
             $params['id'] = $this->lastId;
             $this->lastId = null;
         }
-        if($this->client->topics()->getLastId() != null) {
+        if ($this->client->topics()->getLastId() != null) {
             $params['topic_id'] = $this->client->topics()->getLastId();
             $this->client->topics()->setLastId(null);
         }
-        if(!$this->hasKeys($params, array('id', 'topic_id'))) {
+        if (!$this->hasKeys($params, array('id', 'topic_id'))) {
             throw new MissingParametersException(__METHOD__, array('id', 'topic_id'));
         }
-        $endPoint = Http::prepare('topics/'.$params['topic_id'].'/comments/'.$params['id'].'.json');
+        $endPoint = Http::prepare('topics/' . $params['topic_id'] . '/comments/' . $params['id'] . '.json');
         $response = Http::send($this->client, $endPoint, null, 'DELETE');
         if ($this->client->getDebug()->lastResponseCode != 200) {
             throw new ResponseException(__METHOD__);
         }
         $this->client->setSideload(null);
+
         return true;
     }
 

--- a/src/Zendesk/API/TopicSubscriptions.php
+++ b/src/Zendesk/API/TopicSubscriptions.php
@@ -6,7 +6,8 @@ namespace Zendesk\API;
  * The TopicSubscriptions class exposes topic subscription information
  * @package Zendesk\API
  */
-class TopicSubscriptions extends ClientAbstract {
+class TopicSubscriptions extends ClientAbstract
+{
 
     const OBJ_NAME = 'topic_subscription';
     const OBJ_NAME_PLURAL = 'topic_subscriptions';
@@ -21,17 +22,20 @@ class TopicSubscriptions extends ClientAbstract {
      *
      * @return mixed
      */
-    public function findAll(array $params = array()) {
-        if($this->client->topics()->getLastId() != null) {
+    public function findAll(array $params = array())
+    {
+        if ($this->client->topics()->getLastId() != null) {
             $params['topic_id'] = $this->client->topics()->getLastId();
             $this->client->topics()->setLastId(null);
         }
-        $endPoint = Http::prepare((isset($params['topic_id']) ? 'topics/'.$params['topic_id'].'/subscriptions.json' : 'topic_subscriptions.json'), null, $params);
+        $endPoint = Http::prepare((isset($params['topic_id']) ? 'topics/' . $params['topic_id'] . '/subscriptions.json' : 'topic_subscriptions.json'),
+            null, $params);
         $response = Http::send($this->client, $endPoint);
         if ((!is_object($response)) || ($this->client->getDebug()->lastResponseCode != 200)) {
             throw new ResponseException(__METHOD__);
         }
         $this->client->setSideload(null);
+
         return $response;
     }
 
@@ -46,20 +50,22 @@ class TopicSubscriptions extends ClientAbstract {
      *
      * @return mixed
      */
-    public function find(array $params = array()) {
-        if($this->lastId != null) {
+    public function find(array $params = array())
+    {
+        if ($this->lastId != null) {
             $params['id'] = $this->lastId;
             $this->lastId = null;
         }
-        if(!$this->hasKeys($params, array('id'))) {
+        if (!$this->hasKeys($params, array('id'))) {
             throw new MissingParametersException(__METHOD__, array('id'));
         }
-        $endPoint = Http::prepare('/topic_subscriptions/'.$params['id'].'.json');
+        $endPoint = Http::prepare('/topic_subscriptions/' . $params['id'] . '.json');
         $response = Http::send($this->client, $endPoint);
         if ((!is_object($response)) || ($this->client->getDebug()->lastResponseCode != 200)) {
             throw new ResponseException(__METHOD__);
         }
         $this->client->setSideload(null);
+
         return $response;
     }
 
@@ -74,16 +80,17 @@ class TopicSubscriptions extends ClientAbstract {
      *
      * @return mixed
      */
-    public function create(array $params) {
-        if($this->client->topics()->getLastId() != null) {
+    public function create(array $params)
+    {
+        if ($this->client->topics()->getLastId() != null) {
             $params['topic_id'] = $this->client->topics()->getLastId();
             $this->client->topics()->setLastId(null);
         }
-        if($this->client->users()->getLastId() != null) {
+        if ($this->client->users()->getLastId() != null) {
             $params['user_id'] = $this->client->users()->getLastId();
             $this->client->users()->setLastId(null);
         }
-        if(!$this->hasKeys($params, array('topic_id', 'user_id'))) {
+        if (!$this->hasKeys($params, array('topic_id', 'user_id'))) {
             throw new MissingParametersException(__METHOD__, array('topic_id', 'user_id'));
         }
         $endPoint = Http::prepare('topic_subscriptions.json');
@@ -92,6 +99,7 @@ class TopicSubscriptions extends ClientAbstract {
             throw new ResponseException(__METHOD__);
         }
         $this->client->setSideload(null);
+
         return $response;
     }
 
@@ -106,20 +114,22 @@ class TopicSubscriptions extends ClientAbstract {
      *
      * @return bool
      */
-    public function delete(array $params = array()) {
-        if($this->lastId != null) {
+    public function delete(array $params = array())
+    {
+        if ($this->lastId != null) {
             $params['id'] = $this->lastId;
             $this->lastId = null;
         }
-        if(!$this->hasKeys($params, array('id'))) {
+        if (!$this->hasKeys($params, array('id'))) {
             throw new MissingParametersException(__METHOD__, array('id'));
         }
-        $endPoint = Http::prepare('topic_subscriptions/'.$params['id'].'.json');
+        $endPoint = Http::prepare('topic_subscriptions/' . $params['id'] . '.json');
         $response = Http::send($this->client, $endPoint, null, 'DELETE');
         if ($this->client->getDebug()->lastResponseCode != 200) {
             throw new ResponseException(__METHOD__);
         }
         $this->client->setSideload(null);
+
         return true;
     }
 

--- a/src/Zendesk/API/TopicVotes.php
+++ b/src/Zendesk/API/TopicVotes.php
@@ -6,7 +6,8 @@ namespace Zendesk\API;
  * The TopicVotes class exposes topic subscription information
  * @package Zendesk\API
  */
-class TopicVotes extends ClientAbstract {
+class TopicVotes extends ClientAbstract
+{
 
     const OBJ_NAME = 'topic_vote';
     const OBJ_NAME_PLURAL = 'topic_votes';
@@ -22,24 +23,27 @@ class TopicVotes extends ClientAbstract {
      *
      * @return mixed
      */
-    public function findAll(array $params = array()) {
-        if($this->client->topics()->getLastId() != null) {
+    public function findAll(array $params = array())
+    {
+        if ($this->client->topics()->getLastId() != null) {
             $params['topic_id'] = $this->client->topics()->getLastId();
             $this->client->topics()->setLastId(null);
         }
-        if($this->client->users()->getLastId() != null) {
+        if ($this->client->users()->getLastId() != null) {
             $params['user_id'] = $this->client->users()->getLastId();
             $this->client->users()->setLastId(null);
         }
-        if(!$this->hasAnyKey($params, array('topic_id', 'user_id'))) {
+        if (!$this->hasAnyKey($params, array('topic_id', 'user_id'))) {
             throw new MissingParametersException(__METHOD__, array('topic_id', 'user_id'));
         }
-        $endPoint = Http::prepare((isset($params['topic_id']) ? 'topics/'.$params['topic_id'].'/votes.json' : 'users/'.$params['user_id'].'/topic_votes.json'), null, $params);
+        $endPoint = Http::prepare((isset($params['topic_id']) ? 'topics/' . $params['topic_id'] . '/votes.json' : 'users/' . $params['user_id'] . '/topic_votes.json'),
+            null, $params);
         $response = Http::send($this->client, $endPoint);
         if ((!is_object($response)) || ($this->client->getDebug()->lastResponseCode != 200)) {
             throw new ResponseException(__METHOD__);
         }
         $this->client->setSideload(null);
+
         return $response;
     }
 
@@ -54,24 +58,26 @@ class TopicVotes extends ClientAbstract {
      *
      * @return mixed
      */
-    public function find(array $params = array()) {
-        if($this->client->topics()->getLastId() != null) {
+    public function find(array $params = array())
+    {
+        if ($this->client->topics()->getLastId() != null) {
             $params['topic_id'] = $this->client->topics()->getLastId();
             $this->client->topics()->setLastId(null);
         }
-        if($this->client->users()->getLastId() != null) {
+        if ($this->client->users()->getLastId() != null) {
             $params['user_id'] = $this->client->users()->getLastId();
             $this->client->users()->setLastId(null);
         }
-        if(!$this->hasKeys($params, array('topic_id'))) {
+        if (!$this->hasKeys($params, array('topic_id'))) {
             throw new MissingParametersException(__METHOD__, array('topic_id'));
         }
-        $endPoint = Http::prepare('/topics/'.$params['topic_id'].'/vote.json'.(isset($params['user_id']) ? '?user_id='.$params['user_id'] : ''));
+        $endPoint = Http::prepare('/topics/' . $params['topic_id'] . '/vote.json' . (isset($params['user_id']) ? '?user_id=' . $params['user_id'] : ''));
         $response = Http::send($this->client, $endPoint);
         if ((!is_object($response)) || (($this->client->getDebug()->lastResponseCode != 200) && ($this->client->getDebug()->lastResponseCode != 404))) {
             throw new ResponseException(__METHOD__);
         }
         $this->client->setSideload(null);
+
         return $response;
     }
 
@@ -86,24 +92,26 @@ class TopicVotes extends ClientAbstract {
      *
      * @return mixed
      */
-    public function create(array $params) {
-        if($this->client->topics()->getLastId() != null) {
+    public function create(array $params)
+    {
+        if ($this->client->topics()->getLastId() != null) {
             $params['topic_id'] = $this->client->topics()->getLastId();
             $this->client->topics()->setLastId(null);
         }
-        if($this->client->users()->getLastId() != null) {
+        if ($this->client->users()->getLastId() != null) {
             $params['user_id'] = $this->client->users()->getLastId();
             $this->client->users()->setLastId(null);
         }
-        if(!$this->hasKeys($params, array('topic_id'))) {
+        if (!$this->hasKeys($params, array('topic_id'))) {
             throw new MissingParametersException(__METHOD__, array('topic_id'));
         }
-        $endPoint = Http::prepare('topics/'.$params['topic_id'].'/vote.json'.(isset($params['user_id']) ? '?user_id='.$params['user_id'] : ''));
+        $endPoint = Http::prepare('topics/' . $params['topic_id'] . '/vote.json' . (isset($params['user_id']) ? '?user_id=' . $params['user_id'] : ''));
         $response = Http::send($this->client, $endPoint, null, 'POST');
         if ((!is_object($response)) || ($this->client->getDebug()->lastResponseCode != 201)) {
             throw new ResponseException(__METHOD__);
         }
         $this->client->setSideload(null);
+
         return $response;
     }
 
@@ -118,24 +126,26 @@ class TopicVotes extends ClientAbstract {
      *
      * @return bool
      */
-    public function delete(array $params = array()) {
-        if($this->client->topics()->getLastId() != null) {
+    public function delete(array $params = array())
+    {
+        if ($this->client->topics()->getLastId() != null) {
             $params['topic_id'] = $this->client->topics()->getLastId();
             $this->client->topics()->setLastId(null);
         }
-        if($this->client->users()->getLastId() != null) {
+        if ($this->client->users()->getLastId() != null) {
             $params['user_id'] = $this->client->users()->getLastId();
             $this->client->users()->setLastId(null);
         }
-        if(!$this->hasKeys($params, array('topic_id'))) {
+        if (!$this->hasKeys($params, array('topic_id'))) {
             throw new MissingParametersException(__METHOD__, array('topic_id'));
         }
-        $endPoint = Http::prepare('topics/'.$params['topic_id'].'/vote.json'.(isset($params['user_id']) ? '?user_id='.$params['user_id'] : ''));
+        $endPoint = Http::prepare('topics/' . $params['topic_id'] . '/vote.json' . (isset($params['user_id']) ? '?user_id=' . $params['user_id'] : ''));
         $response = Http::send($this->client, $endPoint, null, 'DELETE');
         if ($this->client->getDebug()->lastResponseCode != 200) {
             throw new ResponseException(__METHOD__);
         }
         $this->client->setSideload(null);
+
         return true;
     }
 

--- a/src/Zendesk/API/Topics.php
+++ b/src/Zendesk/API/Topics.php
@@ -10,7 +10,8 @@ namespace Zendesk\API;
  * @method TopicSubscriptions subscriptions()
  * @method TopicVotes votes()
  */
-class Topics extends ClientAbstract {
+class Topics extends ClientAbstract
+{
 
     const OBJ_NAME = 'topic';
     const OBJ_NAME_PLURAL = 'topics';
@@ -31,7 +32,8 @@ class Topics extends ClientAbstract {
     /**
      * @param Client $client
      */
-    public function __construct(Client $client) {
+    public function __construct(Client $client)
+    {
         parent::__construct($client);
         $this->comments = new TopicComments($client);
         $this->subscriptions = new TopicSubscriptions($client);
@@ -48,24 +50,27 @@ class Topics extends ClientAbstract {
      *
      * @return mixed
      */
-    public function findAll(array $params = array()) {
-        if($this->client->forums()->getLastId() != null) {
+    public function findAll(array $params = array())
+    {
+        if ($this->client->forums()->getLastId() != null) {
             $params['forum_id'] = $this->client->forums()->getLastId();
             $this->client->forums()->setLastId(null);
         }
-        if($this->client->users()->getLastId() != null) {
+        if ($this->client->users()->getLastId() != null) {
             $params['user_id'] = $this->client->users()->getLastId();
             $this->client->users()->setLastId(null);
         }
         $endPoint = Http::prepare(
-                (isset($params['forum_id']) ? 'forums/'.$params['forum_id'].'/topics.json' :
-                (isset($params['user_id']) ? 'users/'.$params['user_id'].'/topics.json' : 'topics.json')), $this->client->getSideload($params), $params
-            );
+            (isset($params['forum_id']) ? 'forums/' . $params['forum_id'] . '/topics.json' :
+                (isset($params['user_id']) ? 'users/' . $params['user_id'] . '/topics.json' : 'topics.json')),
+            $this->client->getSideload($params), $params
+        );
         $response = Http::send($this->client, $endPoint);
         if ((!is_object($response)) || ($this->client->getDebug()->lastResponseCode != 200)) {
             throw new ResponseException(__METHOD__);
         }
         $this->client->setSideload(null);
+
         return $response;
     }
 
@@ -80,20 +85,23 @@ class Topics extends ClientAbstract {
      *
      * @return mixed
      */
-    public function find(array $params = array()) {
-        if($this->lastId != null) {
+    public function find(array $params = array())
+    {
+        if ($this->lastId != null) {
             $params['id'] = $this->lastId;
             $this->lastId = null;
         }
-        if(!$this->hasKeys($params, array('id'))) {
+        if (!$this->hasKeys($params, array('id'))) {
             throw new MissingParametersException(__METHOD__, array('id'));
         }
-        $endPoint = Http::prepare((is_array($params['id']) ? 'topics/show_many.json?ids='.implode(',', $params['id']) : 'topics/'.$params['id'].'.json'), $this->client->getSideload($params));
+        $endPoint = Http::prepare((is_array($params['id']) ? 'topics/show_many.json?ids=' . implode(',',
+                $params['id']) : 'topics/' . $params['id'] . '.json'), $this->client->getSideload($params));
         $response = Http::send($this->client, $endPoint);
         if ((!is_object($response)) || ($this->client->getDebug()->lastResponseCode != 200)) {
             throw new ResponseException(__METHOD__);
         }
         $this->client->setSideload(null);
+
         return $response;
     }
 
@@ -107,17 +115,19 @@ class Topics extends ClientAbstract {
      *
      * @return mixed
      */
-    public function create(array $params) {
-        if($this->client->forums()->getLastId() != null) {
+    public function create(array $params)
+    {
+        if ($this->client->forums()->getLastId() != null) {
             $params['forum_id'] = $this->client->forums()->getLastId();
             $this->client->forums()->setLastId(null);
         }
         $endPoint = Http::prepare('topics.json');
-        $response = Http::send($this->client, $endPoint, array (self::OBJ_NAME => $params), 'POST');
+        $response = Http::send($this->client, $endPoint, array(self::OBJ_NAME => $params), 'POST');
         if ((!is_object($response)) || ($this->client->getDebug()->lastResponseCode != 201)) {
             throw new ResponseException(__METHOD__);
         }
         $this->client->setSideload(null);
+
         return $response;
     }
 
@@ -131,13 +141,15 @@ class Topics extends ClientAbstract {
      *
      * @return mixed
      */
-    public function import(array $params) {
+    public function import(array $params)
+    {
         $endPoint = Http::prepare('import/topics.json');
-        $response = Http::send($this->client, $endPoint, array (self::OBJ_NAME => $params), 'POST');
+        $response = Http::send($this->client, $endPoint, array(self::OBJ_NAME => $params), 'POST');
         if ((!is_object($response)) || ($this->client->getDebug()->lastResponseCode != 201)) {
             throw new ResponseException(__METHOD__);
         }
         $this->client->setSideload(null);
+
         return $response;
     }
 
@@ -152,22 +164,24 @@ class Topics extends ClientAbstract {
      *
      * @return mixed
      */
-    public function update(array $params) {
-        if($this->lastId != null) {
+    public function update(array $params)
+    {
+        if ($this->lastId != null) {
             $params['id'] = $this->lastId;
             $this->lastId = null;
         }
-        if(!$this->hasKeys($params, array('id'))) {
+        if (!$this->hasKeys($params, array('id'))) {
             throw new MissingParametersException(__METHOD__, array('id'));
         }
         $id = $params['id'];
         unset($params['id']);
-        $endPoint = Http::prepare('topics/'.$id.'.json');
-        $response = Http::send($this->client, $endPoint, array (self::OBJ_NAME => $params), 'PUT');
+        $endPoint = Http::prepare('topics/' . $id . '.json');
+        $response = Http::send($this->client, $endPoint, array(self::OBJ_NAME => $params), 'PUT');
         if ((!is_object($response)) || ($this->client->getDebug()->lastResponseCode != 200)) {
             throw new ResponseException(__METHOD__);
         }
         $this->client->setSideload(null);
+
         return $response;
     }
 
@@ -182,20 +196,22 @@ class Topics extends ClientAbstract {
      *
      * @return bool
      */
-    public function delete(array $params = array()) {
-        if($this->lastId != null) {
+    public function delete(array $params = array())
+    {
+        if ($this->lastId != null) {
             $params['id'] = $this->lastId;
             $this->lastId = null;
         }
-        if(!$this->hasKeys($params, array('id'))) {
+        if (!$this->hasKeys($params, array('id'))) {
             throw new MissingParametersException(__METHOD__, array('id'));
         }
-        $endPoint = Http::prepare('topics/'.$params['id'].'.json');
+        $endPoint = Http::prepare('topics/' . $params['id'] . '.json');
         $response = Http::send($this->client, $endPoint, null, 'DELETE');
         if ($this->client->getDebug()->lastResponseCode != 200) {
             throw new ResponseException(__METHOD__);
         }
         $this->client->setSideload(null);
+
         return true;
     }
 
@@ -207,15 +223,16 @@ class Topics extends ClientAbstract {
      *
      * @throws CustomException
      */
-    public function __call($name, $arguments) {
-        if(isset($this->$name)) {
+    public function __call($name, $arguments)
+    {
+        if (isset($this->$name)) {
             return ((isset($arguments[0])) && ($arguments[0] != null) ? $this->$name->setLastId($arguments[0]) : $this->$name);
         }
-        $namePlural = $name.'s'; // try pluralize
-        if(isset($this->$namePlural)) {
+        $namePlural = $name . 's'; // try pluralize
+        if (isset($this->$namePlural)) {
             return $this->$namePlural->setLastId($arguments[0]);
         } else {
-            throw new CustomException("No method called $name available in ".__CLASS__);
+            throw new CustomException("No method called $name available in " . __CLASS__);
         }
     }
 
@@ -224,13 +241,19 @@ class Topics extends ClientAbstract {
      *
      * @return Tags
      */
-    public function tags($id = null) { return ($id != null ? $this->client->tags()->setLastId($id) : $this->client->tags()); }
+    public function tags($id = null)
+    {
+        return ($id != null ? $this->client->tags()->setLastId($id) : $this->client->tags());
+    }
 
     /**
      * @param $id
      *
      * @return Tags
      */
-    public function tag($id) { return $this->client->tags()->setLastId($id); }
+    public function tag($id)
+    {
+        return $this->client->tags()->setLastId($id);
+    }
 
 }

--- a/src/Zendesk/API/Triggers.php
+++ b/src/Zendesk/API/Triggers.php
@@ -6,7 +6,8 @@ namespace Zendesk\API;
  * The Triggers class exposes methods as detailed on http://developer.zendesk.com/documentation/rest_api/triggers.html
  * @package Zendesk\API
  */
-class Triggers extends ClientAbstract {
+class Triggers extends ClientAbstract
+{
 
     const OBJ_NAME = 'trigger';
     const OBJ_NAME_PLURAL = 'triggers';
@@ -21,13 +22,15 @@ class Triggers extends ClientAbstract {
      *
      * @return mixed
      */
-    public function findAll(array $params = array()) {
+    public function findAll(array $params = array())
+    {
         $endPoint = Http::prepare((isset($params['active']) ? 'triggers/active.json' : 'triggers.json'), null, $params);
         $response = Http::send($this->client, $endPoint);
         if ((!is_object($response)) || ($this->client->getDebug()->lastResponseCode != 200)) {
             throw new ResponseException(__METHOD__);
         }
         $this->client->setSideload(null);
+
         return $response;
     }
 
@@ -42,20 +45,22 @@ class Triggers extends ClientAbstract {
      *
      * @return mixed
      */
-    public function find(array $params = array()) {
-        if($this->lastId != null) {
+    public function find(array $params = array())
+    {
+        if ($this->lastId != null) {
             $params['id'] = $this->lastId;
             $this->lastId = null;
         }
-        if(!$this->hasKeys($params, array('id'))) {
+        if (!$this->hasKeys($params, array('id'))) {
             throw new MissingParametersException(__METHOD__, array('id'));
         }
-        $endPoint = Http::prepare('triggers/'.$params['id'].'.json');
+        $endPoint = Http::prepare('triggers/' . $params['id'] . '.json');
         $response = Http::send($this->client, $endPoint);
         if ((!is_object($response)) || ($this->client->getDebug()->lastResponseCode != 200)) {
             throw new ResponseException(__METHOD__);
         }
         $this->client->setSideload(null);
+
         return $response;
     }
 
@@ -69,13 +74,15 @@ class Triggers extends ClientAbstract {
      *
      * @return mixed
      */
-    public function create(array $params) {
+    public function create(array $params)
+    {
         $endPoint = Http::prepare('triggers.json');
         $response = Http::send($this->client, $endPoint, array(self::OBJ_NAME => $params), 'POST');
         if ((!is_object($response)) || ($this->client->getDebug()->lastResponseCode != 201)) {
             throw new ResponseException(__METHOD__);
         }
         $this->client->setSideload(null);
+
         return $response;
     }
 
@@ -90,20 +97,22 @@ class Triggers extends ClientAbstract {
      *
      * @return mixed
      */
-    public function update(array $params) {
-        if($this->lastId != null) {
+    public function update(array $params)
+    {
+        if ($this->lastId != null) {
             $params['id'] = $this->lastId;
             $this->lastId = null;
         }
-        if(!$this->hasKeys($params, array('id'))) {
+        if (!$this->hasKeys($params, array('id'))) {
             throw new MissingParametersException(__METHOD__, array('id'));
         }
-        $endPoint = Http::prepare('triggers/'.$params['id'].'.json');
+        $endPoint = Http::prepare('triggers/' . $params['id'] . '.json');
         $response = Http::send($this->client, $endPoint, array(self::OBJ_NAME => $params), 'PUT');
         if ((!is_object($response)) || ($this->client->getDebug()->lastResponseCode != 200)) {
             throw new ResponseException(__METHOD__);
         }
         $this->client->setSideload(null);
+
         return $response;
     }
 
@@ -118,20 +127,22 @@ class Triggers extends ClientAbstract {
      *
      * @return bool
      */
-    public function delete(array $params = array()) {
-        if($this->lastId != null) {
+    public function delete(array $params = array())
+    {
+        if ($this->lastId != null) {
             $params['id'] = $this->lastId;
             $this->lastId = null;
         }
-        if(!$this->hasKeys($params, array('id'))) {
+        if (!$this->hasKeys($params, array('id'))) {
             throw new MissingParametersException(__METHOD__, array('id'));
         }
-        $endPoint = Http::prepare('triggers/'.$params['id'].'.json');
+        $endPoint = Http::prepare('triggers/' . $params['id'] . '.json');
         $response = Http::send($this->client, $endPoint, null, 'DELETE');
         if ($this->client->getDebug()->lastResponseCode != 200) {
             throw new ResponseException(__METHOD__);
         }
         $this->client->setSideload(null);
+
         return true;
     }
 
@@ -140,6 +151,9 @@ class Triggers extends ClientAbstract {
      *
      * @return mixed
      */
-    public function active() { return $this->findAll(array('active' => true)); }
+    public function active()
+    {
+        return $this->findAll(array('active' => true));
+    }
 
 }

--- a/src/Zendesk/API/Twitter.php
+++ b/src/Zendesk/API/Twitter.php
@@ -6,7 +6,8 @@ namespace Zendesk\API;
  * The Twitter class exposes methods for managing and monitoring Twitter posts
  * @package Zendesk\API
  */
-class Twitter extends ClientAbstract {
+class Twitter extends ClientAbstract
+{
 
     const OBJ_NAME = 'monitored_twitter_handle';
     const OBJ_NAME_PLURAL = 'monitored_twitter_handles';
@@ -21,13 +22,15 @@ class Twitter extends ClientAbstract {
      *
      * @return mixed
      */
-    public function handles(array $params = array()) {
+    public function handles(array $params = array())
+    {
         $endPoint = Http::prepare('channels/twitter/monitored_twitter_handles.json', null, $params);
         $response = Http::send($this->client, $endPoint);
         if ((!is_object($response)) || ($this->client->getDebug()->lastResponseCode != 200)) {
             throw new ResponseException(__METHOD__);
         }
         $this->client->setSideload(null);
+
         return $response;
     }
 
@@ -42,20 +45,22 @@ class Twitter extends ClientAbstract {
      *
      * @return mixed
      */
-    public function handleById(array $params) {
-        if($this->lastId != null) {
+    public function handleById(array $params)
+    {
+        if ($this->lastId != null) {
             $params['id'] = $this->lastId;
             $this->lastId = null;
         }
-        if(!$this->hasKeys($params, array('id'))) {
+        if (!$this->hasKeys($params, array('id'))) {
             throw new MissingParametersException(__METHOD__, array('id'));
         }
-        $endPoint = Http::prepare('channels/twitter/monitored_twitter_handles/'.$params['id'].'.json');
+        $endPoint = Http::prepare('channels/twitter/monitored_twitter_handles/' . $params['id'] . '.json');
         $response = Http::send($this->client, $endPoint);
         if ((!is_object($response)) || ($this->client->getDebug()->lastResponseCode != 200)) {
             throw new ResponseException(__METHOD__);
         }
         $this->client->setSideload(null);
+
         return $response;
     }
 

--- a/src/Zendesk/API/UserFields.php
+++ b/src/Zendesk/API/UserFields.php
@@ -6,7 +6,8 @@ namespace Zendesk\API;
  * The UserFields class exposes fields on the user profile page
  * @package Zendesk\API
  */
-class UserFields extends ClientAbstract {
+class UserFields extends ClientAbstract
+{
 
     const OBJ_NAME = 'user_field';
     const OBJ_NAME_PLURAL = 'user_fields';
@@ -21,13 +22,15 @@ class UserFields extends ClientAbstract {
      *
      * @return mixed
      */
-    public function findAll(array $params = array()) {
+    public function findAll(array $params = array())
+    {
         $endPoint = Http::prepare('user_fields.json', null, $params);
         $response = Http::send($this->client, $endPoint);
         if ((!is_object($response)) || ($this->client->getDebug()->lastResponseCode != 200)) {
             throw new ResponseException(__METHOD__);
         }
         $this->client->setSideload(null);
+
         return $response;
     }
 
@@ -42,20 +45,22 @@ class UserFields extends ClientAbstract {
      *
      * @return mixed
      */
-    public function find(array $params = array()) {
-        if($this->lastId != null) {
+    public function find(array $params = array())
+    {
+        if ($this->lastId != null) {
             $params['id'] = $this->lastId;
             $this->lastId = null;
         }
-        if(!$this->hasKeys($params, array('id'))) {
+        if (!$this->hasKeys($params, array('id'))) {
             throw new MissingParametersException(__METHOD__, array('id'));
         }
-        $endPoint = Http::prepare('user_fields/'.$params['id'].'.json');
+        $endPoint = Http::prepare('user_fields/' . $params['id'] . '.json');
         $response = Http::send($this->client, $endPoint);
         if ((!is_object($response)) || ($this->client->getDebug()->lastResponseCode != 200)) {
             throw new ResponseException(__METHOD__);
         }
         $this->client->setSideload(null);
+
         return $response;
     }
 
@@ -69,13 +74,15 @@ class UserFields extends ClientAbstract {
      *
      * @return mixed
      */
-    public function create(array $params) {
+    public function create(array $params)
+    {
         $endPoint = Http::prepare('user_fields.json');
         $response = Http::send($this->client, $endPoint, array(self::OBJ_NAME => $params), 'POST');
         if ((!is_object($response)) || ($this->client->getDebug()->lastResponseCode != 201)) {
             throw new ResponseException(__METHOD__);
         }
         $this->client->setSideload(null);
+
         return $response;
     }
 
@@ -90,22 +97,24 @@ class UserFields extends ClientAbstract {
      *
      * @return mixed
      */
-    public function update(array $params) {
-        if($this->lastId != null) {
+    public function update(array $params)
+    {
+        if ($this->lastId != null) {
             $params['id'] = $this->lastId;
             $this->lastId = null;
         }
-        if(!$this->hasKeys($params, array('id'))) {
+        if (!$this->hasKeys($params, array('id'))) {
             throw new MissingParametersException(__METHOD__, array('id'));
         }
         $id = $params['id'];
         unset($params['id']);
-        $endPoint = Http::prepare('user_fields/'.$id.'.json');
+        $endPoint = Http::prepare('user_fields/' . $id . '.json');
         $response = Http::send($this->client, $endPoint, array(self::OBJ_NAME => $params), 'PUT');
         if ((!is_object($response)) || ($this->client->getDebug()->lastResponseCode != 200)) {
             throw new ResponseException(__METHOD__);
         }
         $this->client->setSideload(null);
+
         return $response;
     }
 
@@ -120,21 +129,23 @@ class UserFields extends ClientAbstract {
      *
      * @return bool
      */
-    public function delete(array $params = array()) {
-        if($this->lastId != null) {
+    public function delete(array $params = array())
+    {
+        if ($this->lastId != null) {
             $params['id'] = $this->lastId;
             $this->lastId = null;
         }
-        if(!$this->hasKeys($params, array('id'))) {
+        if (!$this->hasKeys($params, array('id'))) {
             throw new MissingParametersException(__METHOD__, array('id'));
         }
         $id = $params['id'];
-        $endPoint = Http::prepare('user_fields/'.$id.'.json');
+        $endPoint = Http::prepare('user_fields/' . $id . '.json');
         $response = Http::send($this->client, $endPoint, null, 'DELETE');
         if ($this->client->getDebug()->lastResponseCode != 200) {
             throw new ResponseException(__METHOD__);
         }
         $this->client->setSideload(null);
+
         return true;
     }
 
@@ -148,13 +159,15 @@ class UserFields extends ClientAbstract {
      *
      * @return mixed
      */
-    public function reorder(array $params) {
+    public function reorder(array $params)
+    {
         $endPoint = Http::prepare('user_fields/reorder.json');
-        $response = Http::send($this->client, $endPoint, array ('user_field_ids' => $params), 'PUT');
+        $response = Http::send($this->client, $endPoint, array('user_field_ids' => $params), 'PUT');
         if ($this->client->getDebug()->lastResponseCode != 200) {
             throw new ResponseException(__METHOD__);
         }
         $this->client->setSideload(null);
+
         return $response;
     }
 

--- a/src/Zendesk/API/UserIdentities.php
+++ b/src/Zendesk/API/UserIdentities.php
@@ -6,7 +6,8 @@ namespace Zendesk\API;
  * The UserIdentities class exposes fields on the user profile page
  * @package Zendesk\API
  */
-class UserIdentities extends ClientAbstract {
+class UserIdentities extends ClientAbstract
+{
 
     const OBJ_NAME = 'identity';
     const OBJ_NAME_PLURAL = 'identities';
@@ -22,20 +23,22 @@ class UserIdentities extends ClientAbstract {
      *
      * @return mixed
      */
-    public function findAll(array $params = array()) {
-        if($this->client->users()->getLastId() != null) {
+    public function findAll(array $params = array())
+    {
+        if ($this->client->users()->getLastId() != null) {
             $params['user_id'] = $this->client->users()->getLastId();
             $this->client->users()->setLastId(null);
         }
-        if(!$this->hasKeys($params, array('user_id'))) {
+        if (!$this->hasKeys($params, array('user_id'))) {
             throw new MissingParametersException(__METHOD__, array('user_id'));
         }
-        $endPoint = Http::prepare('users/'.$params['user_id'].'/identities.json', null, $params);
+        $endPoint = Http::prepare('users/' . $params['user_id'] . '/identities.json', null, $params);
         $response = Http::send($this->client, $endPoint);
         if ((!is_object($response)) || ($this->client->getDebug()->lastResponseCode != 200)) {
             throw new ResponseException(__METHOD__);
         }
         $this->client->setSideload(null);
+
         return $response;
     }
 
@@ -50,24 +53,26 @@ class UserIdentities extends ClientAbstract {
      *
      * @return mixed
      */
-    public function find(array $params = array()) {
-        if($this->client->users()->getLastId() != null) {
+    public function find(array $params = array())
+    {
+        if ($this->client->users()->getLastId() != null) {
             $params['user_id'] = $this->client->users()->getLastId();
             $this->client->users()->setLastId(null);
         }
-        if($this->lastId != null) {
+        if ($this->lastId != null) {
             $params['id'] = $this->lastId;
             $this->lastId = null;
         }
-        if(!$this->hasKeys($params, array('user_id', 'id'))) {
+        if (!$this->hasKeys($params, array('user_id', 'id'))) {
             throw new MissingParametersException(__METHOD__, array('user_id', 'id'));
         }
-        $endPoint = Http::prepare('users/'.$params['user_id'].'/identities/'.$params['id'].'.json');
+        $endPoint = Http::prepare('users/' . $params['user_id'] . '/identities/' . $params['id'] . '.json');
         $response = Http::send($this->client, $endPoint);
         if ((!is_object($response)) || ($this->client->getDebug()->lastResponseCode != 200)) {
             throw new ResponseException(__METHOD__);
         }
         $this->client->setSideload(null);
+
         return $response;
     }
 
@@ -82,24 +87,26 @@ class UserIdentities extends ClientAbstract {
      *
      * @return mixed
      */
-    public function create(array $params) {
-        if($this->client->users()->getLastId() != null) {
+    public function create(array $params)
+    {
+        if ($this->client->users()->getLastId() != null) {
             $params['user_id'] = $this->client->users()->getLastId();
             $this->client->users()->setLastId(null);
         }
-        if(!$this->hasKeys($params, array('user_id'))) {
+        if (!$this->hasKeys($params, array('user_id'))) {
             throw new MissingParametersException(__METHOD__, array('user_id'));
         }
         $user_id = $params['user_id'];
-        $prepare = (isset($params['end_user']) ? 'end_users' : 'users').'/'.$user_id.'/identities.json';
+        $prepare = (isset($params['end_user']) ? 'end_users' : 'users') . '/' . $user_id . '/identities.json';
         unset($params['user_id']);
         unset($params['end_user']);
         $endPoint = Http::prepare($prepare);
-        $response = Http::send($this->client, $endPoint, array (self::OBJ_NAME => $params), 'POST');
+        $response = Http::send($this->client, $endPoint, array(self::OBJ_NAME => $params), 'POST');
         if ((!is_object($response)) || ($this->client->getDebug()->lastResponseCode != 201)) {
             throw new ResponseException(__METHOD__);
         }
         $this->client->setSideload(null);
+
         return $response;
     }
 
@@ -114,24 +121,26 @@ class UserIdentities extends ClientAbstract {
      *
      * @return mixed
      */
-    public function markAsVerified(array $params = array()) {
-        if($this->client->users()->getLastId() != null) {
+    public function markAsVerified(array $params = array())
+    {
+        if ($this->client->users()->getLastId() != null) {
             $params['user_id'] = $this->client->users()->getLastId();
             $this->client->users()->setLastId(null);
         }
-        if($this->lastId != null) {
+        if ($this->lastId != null) {
             $params['id'] = $this->lastId;
             $this->lastId = null;
         }
-        if(!$this->hasKeys($params, array('user_id', 'id'))) {
+        if (!$this->hasKeys($params, array('user_id', 'id'))) {
             throw new MissingParametersException(__METHOD__, array('user_id', 'id'));
         }
-        $endPoint = Http::prepare('users/'.$params['user_id'].'/identities/'.$params['id'].'/verify.json');
+        $endPoint = Http::prepare('users/' . $params['user_id'] . '/identities/' . $params['id'] . '/verify.json');
         $response = Http::send($this->client, $endPoint, null, 'PUT');
         if ((!is_object($response)) || ($this->client->getDebug()->lastResponseCode != 200)) {
             throw new ResponseException(__METHOD__);
         }
         $this->client->setSideload(null);
+
         return $response;
     }
 
@@ -146,24 +155,26 @@ class UserIdentities extends ClientAbstract {
      *
      * @return mixed
      */
-    public function makePrimary(array $params = array()) {
-        if($this->client->users()->getLastId() != null) {
+    public function makePrimary(array $params = array())
+    {
+        if ($this->client->users()->getLastId() != null) {
             $params['user_id'] = $this->client->users()->getLastId();
             $this->client->users()->setLastId(null);
         }
-        if($this->lastId != null) {
+        if ($this->lastId != null) {
             $params['id'] = $this->lastId;
             $this->lastId = null;
         }
-        if(!$this->hasKeys($params, array('user_id', 'id'))) {
+        if (!$this->hasKeys($params, array('user_id', 'id'))) {
             throw new MissingParametersException(__METHOD__, array('user_id', 'id'));
         }
-        $endPoint = Http::prepare('users/'.$params['user_id'].'/identities/'.$params['id'].'/make_primary.json');
+        $endPoint = Http::prepare('users/' . $params['user_id'] . '/identities/' . $params['id'] . '/make_primary.json');
         $response = Http::send($this->client, $endPoint, null, 'PUT');
         if ((!is_object($response)) || ($this->client->getDebug()->lastResponseCode != 200)) {
             throw new ResponseException(__METHOD__);
         }
         $this->client->setSideload(null);
+
         return $response;
     }
 
@@ -178,24 +189,26 @@ class UserIdentities extends ClientAbstract {
      *
      * @return mixed
      */
-    public function requestVerification(array $params = array()) {
-        if($this->client->users()->getLastId() != null) {
+    public function requestVerification(array $params = array())
+    {
+        if ($this->client->users()->getLastId() != null) {
             $params['user_id'] = $this->client->users()->getLastId();
             $this->client->users()->setLastId(null);
         }
-        if($this->lastId != null) {
+        if ($this->lastId != null) {
             $params['id'] = $this->lastId;
             $this->lastId = null;
         }
-        if(!$this->hasKeys($params, array('user_id', 'id'))) {
+        if (!$this->hasKeys($params, array('user_id', 'id'))) {
             throw new MissingParametersException(__METHOD__, array('user_id', 'id'));
         }
-        $endPoint = Http::prepare('users/'.$params['user_id'].'/identities/'.$params['id'].'/request_verification.json');
+        $endPoint = Http::prepare('users/' . $params['user_id'] . '/identities/' . $params['id'] . '/request_verification.json');
         $response = Http::send($this->client, $endPoint, null, 'PUT');
         if ($this->client->getDebug()->lastResponseCode != 200) {
             throw new ResponseException(__METHOD__);
         }
         $this->client->setSideload(null);
+
         return $response;
     }
 
@@ -210,25 +223,27 @@ class UserIdentities extends ClientAbstract {
      *
      * @return bool
      */
-    public function delete(array $params = array()) {
-        if($this->client->users()->getLastId() != null) {
+    public function delete(array $params = array())
+    {
+        if ($this->client->users()->getLastId() != null) {
             $params['user_id'] = $this->client->users()->getLastId();
             $this->client->users()->setLastId(null);
         }
-        if($this->lastId != null) {
+        if ($this->lastId != null) {
             $params['id'] = $this->lastId;
             $this->lastId = null;
         }
-        if(!$this->hasKeys($params, array('user_id', 'id'))) {
+        if (!$this->hasKeys($params, array('user_id', 'id'))) {
             throw new MissingParametersException(__METHOD__, array('user_id', 'id'));
         }
         $id = $params['id'];
-        $endPoint = Http::prepare('users/'.$params['user_id'].'/identities/'.$params['id'].'.json');
+        $endPoint = Http::prepare('users/' . $params['user_id'] . '/identities/' . $params['id'] . '.json');
         $response = Http::send($this->client, $endPoint, null, 'DELETE');
         if ($this->client->getDebug()->lastResponseCode != 200) {
             throw new ResponseException(__METHOD__);
         }
         $this->client->setSideload(null);
+
         return true;
     }
 

--- a/src/Zendesk/API/Users.php
+++ b/src/Zendesk/API/Users.php
@@ -8,7 +8,8 @@ namespace Zendesk\API;
  *
  * @package Zendesk\API
  */
-class Users extends ClientAbstract {
+class Users extends ClientAbstract
+{
 
     const OBJ_NAME = 'user';
     const OBJ_NAME_PLURAL = 'users';
@@ -21,7 +22,8 @@ class Users extends ClientAbstract {
     /**
      * @param Client $client
      */
-    public function __construct(Client $client) {
+    public function __construct(Client $client)
+    {
         parent::__construct($client);
         $this->identities = new UserIdentities($client);
     }
@@ -36,16 +38,20 @@ class Users extends ClientAbstract {
      *
      * @return mixed
      */
-    public function findAll(array $params = array()) {
+    public function findAll(array $params = array())
+    {
         $endPoint = Http::prepare(
-                (isset($params['organization_id']) ? 'organizations/'.$params['organization_id'].'/users' :
-                (isset($params['group_id']) ? 'groups/'.$params['group_id'].'/users' : 'users')
-            ).'.json'.(isset($params['role']) ? (is_array($params['role']) ? '?role[]='.implode('&role[]=', $params['role']) : '?role='.$params['role']) : '').(isset($params['permission_set']) ? (isset($params['role']) ? '&' : '?').'permission_set='.$params['permission_set'] : ''), $this->client->getSideload($params), $params);
+            (isset($params['organization_id']) ? 'organizations/' . $params['organization_id'] . '/users' :
+                (isset($params['group_id']) ? 'groups/' . $params['group_id'] . '/users' : 'users')
+            ) . '.json' . (isset($params['role']) ? (is_array($params['role']) ? '?role[]=' . implode('&role[]=',
+                    $params['role']) : '?role=' . $params['role']) : '') . (isset($params['permission_set']) ? (isset($params['role']) ? '&' : '?') . 'permission_set=' . $params['permission_set'] : ''),
+            $this->client->getSideload($params), $params);
         $response = Http::send($this->client, $endPoint);
         if ((!is_object($response)) || ($this->client->getDebug()->lastResponseCode != 200)) {
             throw new ResponseException(__METHOD__);
         }
         $this->client->setSideload(null);
+
         return $response;
     }
 
@@ -60,20 +66,23 @@ class Users extends ClientAbstract {
      *
      * @return mixed
      */
-    public function find(array $params = array()) {
-        if($this->lastId != null) {
+    public function find(array $params = array())
+    {
+        if ($this->lastId != null) {
             $params['id'] = $this->lastId;
             $this->lastId = null;
         }
-        if(!$this->hasKeys($params, array('id'))) {
+        if (!$this->hasKeys($params, array('id'))) {
             throw new MissingParametersException(__METHOD__, array('id'));
         }
-        $endPoint = Http::prepare((is_array($params['id']) ? 'users/show_many.json?ids='.implode(',', $params['id']) : 'users/'.$params['id'].'.json'), $this->client->getSideload($params));
+        $endPoint = Http::prepare((is_array($params['id']) ? 'users/show_many.json?ids=' . implode(',',
+                $params['id']) : 'users/' . $params['id'] . '.json'), $this->client->getSideload($params));
         $response = Http::send($this->client, $endPoint);
         if ((!is_object($response)) || ($this->client->getDebug()->lastResponseCode != 200)) {
             throw new ResponseException(__METHOD__);
         }
         $this->client->setSideload(null);
+
         return $response;
     }
 
@@ -87,15 +96,16 @@ class Users extends ClientAbstract {
      *
      * @return mixed
      */
-    public function showMany(array $params = array()) {
+    public function showMany(array $params = array())
+    {
         if (isset($params['ids']) && isset($params['external_ids'])) {
             throw new \Exception('Only one parameter of ids or external_ids is allowed');
         } elseif (!isset($params['ids']) && !isset($params['external_ids'])) {
             throw new \Exception('Missing parameters ids or external_ids');
         } elseif (isset($params['ids']) && is_array($params['ids'])) {
-            $path = 'users/show_many.json?ids='.implode(',', $params['ids']);
+            $path = 'users/show_many.json?ids=' . implode(',', $params['ids']);
         } elseif (isset($params['external_ids']) && is_array($params['external_ids'])) {
-            $path = 'users/show_many.json?external_ids='.implode(',', $params['external_ids']);
+            $path = 'users/show_many.json?external_ids=' . implode(',', $params['external_ids']);
         } else {
             throw new \Exception('Parameters ids or external_ids must be arrays');
         }
@@ -106,6 +116,7 @@ class Users extends ClientAbstract {
             throw new ResponseException(__METHOD__);
         }
         $this->client->setSideload(null);
+
         return $response;
     }
 
@@ -120,20 +131,23 @@ class Users extends ClientAbstract {
      *
      * @return mixed
      */
-    public function related(array $params = array()) {
-        if($this->lastId != null) {
+    public function related(array $params = array())
+    {
+        if ($this->lastId != null) {
             $params['id'] = $this->lastId;
             $this->lastId = null;
         }
-        if(!$this->hasKeys($params, array('id'))) {
+        if (!$this->hasKeys($params, array('id'))) {
             throw new MissingParametersException(__METHOD__, array('id'));
         }
-        $endPoint = Http::prepare('users/'.$params['id'].'/related.json', $this->client->getSideload($params), $params);
+        $endPoint = Http::prepare('users/' . $params['id'] . '/related.json', $this->client->getSideload($params),
+            $params);
         $response = Http::send($this->client, $endPoint);
         if ((!is_object($response)) || ($this->client->getDebug()->lastResponseCode != 200)) {
             throw new ResponseException(__METHOD__);
         }
         $this->client->setSideload(null);
+
         return $response;
     }
 
@@ -147,13 +161,15 @@ class Users extends ClientAbstract {
      *
      * @return mixed
      */
-    public function create(array $params) {
+    public function create(array $params)
+    {
         $endPoint = Http::prepare('users.json');
-        $response = Http::send($this->client, $endPoint, array (self::OBJ_NAME => $params), 'POST');
+        $response = Http::send($this->client, $endPoint, array(self::OBJ_NAME => $params), 'POST');
         if ((!is_object($response)) || ($this->client->getDebug()->lastResponseCode != 201)) {
             throw new ResponseException(__METHOD__);
         }
         $this->client->setSideload(null);
+
         return $response;
     }
 
@@ -185,6 +201,7 @@ class Users extends ClientAbstract {
             throw new ResponseException(__METHOD__);
         }
         $this->client->setSideload(null);
+
         return $response;
     }
 
@@ -198,13 +215,15 @@ class Users extends ClientAbstract {
      *
      * @return mixed
      */
-    public function createMany(array $params) {
+    public function createMany(array $params)
+    {
         $endPoint = Http::prepare('users/create_many.json');
-        $response = Http::send($this->client, $endPoint, array (self::OBJ_NAME_PLURAL => $params), 'POST');
+        $response = Http::send($this->client, $endPoint, array(self::OBJ_NAME_PLURAL => $params), 'POST');
         if ((!is_object($response)) || ($this->client->getDebug()->lastResponseCode != 200)) {
             throw new ResponseException(__METHOD__);
         }
         $this->client->setSideload(null);
+
         return $response;
     }
 
@@ -219,22 +238,24 @@ class Users extends ClientAbstract {
      *
      * @return mixed
      */
-    public function update(array $params) {
-        if($this->lastId != null) {
+    public function update(array $params)
+    {
+        if ($this->lastId != null) {
             $params['id'] = $this->lastId;
             $this->lastId = null;
         }
-        if(!$this->hasKeys($params, array('id'))) {
+        if (!$this->hasKeys($params, array('id'))) {
             throw new MissingParametersException(__METHOD__, array('id'));
         }
         $id = $params['id'];
         unset($params['id']);
-        $endPoint = Http::prepare('users/'.$id.'.json');
-        $response = Http::send($this->client, $endPoint, array (self::OBJ_NAME => $params), 'PUT');
+        $endPoint = Http::prepare('users/' . $id . '.json');
+        $response = Http::send($this->client, $endPoint, array(self::OBJ_NAME => $params), 'PUT');
         if ((!is_object($response)) || ($this->client->getDebug()->lastResponseCode != 200)) {
             throw new ResponseException(__METHOD__);
         }
         $this->client->setSideload(null);
+
         return $response;
     }
 
@@ -250,18 +271,20 @@ class Users extends ClientAbstract {
      * @return mixed
      */
 
-    public function updateMany(array $params) {
-        if(!$this->hasKeys($params, array('ids'))) {
+    public function updateMany(array $params)
+    {
+        if (!$this->hasKeys($params, array('ids'))) {
             throw new MissingParametersException(__METHOD__, array('ids'));
         }
         $ids = $params['ids'];
         unset($params['ids']);
-        $endPoint = Http::prepare('users/update_many.json?ids='.$ids);            
-        $response = Http::send($this->client, $endPoint, array (self::OBJ_NAME => $params), 'PUT');
+        $endPoint = Http::prepare('users/update_many.json?ids=' . $ids);
+        $response = Http::send($this->client, $endPoint, array(self::OBJ_NAME => $params), 'PUT');
         if ((!is_object($response)) || ($this->client->getDebug()->lastResponseCode != 200)) {
             throw new ResponseException(__METHOD__);
         }
         $this->client->setSideload(null);
+
         return $response;
     }
 
@@ -277,14 +300,16 @@ class Users extends ClientAbstract {
      * @return mixed
      */
 
-    public function updateManyIndividualUsers(array $params) {
+    public function updateManyIndividualUsers(array $params)
+    {
         $endPoint = Http::prepare('users/update_many.json');
-        $response = Http::send($this->client, $endPoint, array (self::OBJ_NAME_PLURAL => $params), 'PUT');
+        $response = Http::send($this->client, $endPoint, array(self::OBJ_NAME_PLURAL => $params), 'PUT');
 
         if ((!is_object($response)) || ($this->client->getDebug()->lastResponseCode != 200)) {
             throw new ResponseException(__METHOD__);
         }
         $this->client->setSideload(null);
+
         return $response;
     }
 
@@ -299,15 +324,17 @@ class Users extends ClientAbstract {
      *
      * @return mixed
      */
-    public function suspend(array $params = array()) {
-        if($this->lastId != null) {
+    public function suspend(array $params = array())
+    {
+        if ($this->lastId != null) {
             $params['id'] = $this->lastId;
             $this->lastId = null;
         }
-        if(!$this->hasKeys($params, array('id'))) {
+        if (!$this->hasKeys($params, array('id'))) {
             throw new MissingParametersException(__METHOD__, array('id'));
         }
         $params['suspended'] = true;
+
         return $this->update($params);
     }
 
@@ -322,21 +349,23 @@ class Users extends ClientAbstract {
      *
      * @return bool
      */
-    public function delete(array $params = array()) {
-        if($this->lastId != null) {
+    public function delete(array $params = array())
+    {
+        if ($this->lastId != null) {
             $params['id'] = $this->lastId;
             $this->lastId = null;
         }
-        if(!$this->hasKeys($params, array('id'))) {
+        if (!$this->hasKeys($params, array('id'))) {
             throw new MissingParametersException(__METHOD__, array('id'));
         }
         $id = $params['id'];
-        $endPoint = Http::prepare('users/'.$id.'.json');
+        $endPoint = Http::prepare('users/' . $id . '.json');
         $response = Http::send($this->client, $endPoint, null, 'DELETE');
         if ($this->client->getDebug()->lastResponseCode != 200) {
             throw new ResponseException(__METHOD__);
         }
         $this->client->setSideload(null);
+
         return true;
     }
 
@@ -350,13 +379,16 @@ class Users extends ClientAbstract {
      *
      * @return mixed
      */
-    public function search(array $params) {
-        $endPoint = Http::prepare('users/search.json?'.http_build_query($params), $this->client->getSideload($params), $params);
+    public function search(array $params)
+    {
+        $endPoint = Http::prepare('users/search.json?' . http_build_query($params), $this->client->getSideload($params),
+            $params);
         $response = Http::send($this->client, $endPoint);
         if ((!is_object($response)) || ($this->client->getDebug()->lastResponseCode != 200)) {
             throw new ResponseException(__METHOD__);
         }
         $this->client->setSideload(null);
+
         return $response;
     }
 
@@ -370,13 +402,15 @@ class Users extends ClientAbstract {
      *
      * @return mixed
      */
-    public function autocomplete(array $params) {
-        $endPoint = Http::prepare('users/autocomplete.json?'.http_build_query($params));
+    public function autocomplete(array $params)
+    {
+        $endPoint = Http::prepare('users/autocomplete.json?' . http_build_query($params));
         $response = Http::send($this->client, $endPoint, null, 'POST');
         if ((!is_object($response)) || ($this->client->getDebug()->lastResponseCode != 200)) {
             throw new ResponseException(__METHOD__);
         }
         $this->client->setSideload(null);
+
         return $response;
     }
 
@@ -392,29 +426,34 @@ class Users extends ClientAbstract {
      *
      * @return mixed
      */
-    public function updateProfileImage(array $params) {
-        if($this->lastId != null) {
+    public function updateProfileImage(array $params)
+    {
+        if ($this->lastId != null) {
             $params['id'] = $this->lastId;
             $this->lastId = null;
         }
-        if(!$this->hasKeys($params, array('id', 'file'))) {
+        if (!$this->hasKeys($params, array('id', 'file'))) {
             throw new MissingParametersException(__METHOD__, array('id', 'file'));
         }
-        if(!file_exists($params['file'])) {
-            throw new CustomException('File '.$params['file'].' could not be found in '.__METHOD__);
+        if (!file_exists($params['file'])) {
+            throw new CustomException('File ' . $params['file'] . ' could not be found in ' . __METHOD__);
         }
         $id = $params['id'];
         unset($params['id']);
-        $endPoint = Http::prepare('users/'.$id.'.json');
+        $endPoint = Http::prepare('users/' . $id . '.json');
         if (function_exists('curl_file_create')) {
-            $response = Http::send($this->client, $endPoint, $params['file'], 'PUT', (isset($params['type']) ? $params['type'] : 'application/binary'));
-        }else {
-            $response = Http::send($this->client, $endPoint, array('user[photo][uploaded_data]' => '@'.$params['file']), 'PUT', (isset($params['type']) ? $params['type'] : 'application/binary'));
+            $response = Http::send($this->client, $endPoint, $params['file'], 'PUT',
+                (isset($params['type']) ? $params['type'] : 'application/binary'));
+        } else {
+            $response = Http::send($this->client, $endPoint,
+                array('user[photo][uploaded_data]' => '@' . $params['file']), 'PUT',
+                (isset($params['type']) ? $params['type'] : 'application/binary'));
         }
         if ((!is_object($response)) || ($this->client->getDebug()->lastResponseCode != 200)) {
             throw new ResponseException(__METHOD__);
         }
         $this->client->setSideload(null);
+
         return $response;
     }
 
@@ -428,8 +467,10 @@ class Users extends ClientAbstract {
      *
      * @return mixed
      */
-    public function me(array $params = array()) {
+    public function me(array $params = array())
+    {
         $params['id'] = 'me';
+
         return $this->find($params);
     }
 
@@ -444,22 +485,24 @@ class Users extends ClientAbstract {
      *
      * @return mixed
      */
-    public function setPassword(array $params) {
-        if($this->lastId != null) {
+    public function setPassword(array $params)
+    {
+        if ($this->lastId != null) {
             $params['id'] = $this->lastId;
             $this->lastId = null;
         }
-        if(!$this->hasKeys($params, array('id', 'password'))) {
+        if (!$this->hasKeys($params, array('id', 'password'))) {
             throw new MissingParametersException(__METHOD__, array('id', 'password'));
         }
         $id = $params['id'];
         unset($params['id']);
-        $endPoint = Http::prepare('users/'.$id.'/password.json');
+        $endPoint = Http::prepare('users/' . $id . '/password.json');
         $response = Http::send($this->client, $endPoint, $params, 'POST');
         if ($this->client->getDebug()->lastResponseCode != 200) {
             throw new ResponseException(__METHOD__);
         }
         $this->client->setSideload(null);
+
         return $response;
     }
 
@@ -474,22 +517,24 @@ class Users extends ClientAbstract {
      *
      * @return mixed
      */
-    public function changePassword(array $params) {
-        if($this->lastId != null) {
+    public function changePassword(array $params)
+    {
+        if ($this->lastId != null) {
             $params['id'] = $this->lastId;
             $this->lastId = null;
         }
-        if(!$this->hasKeys($params, array('id', 'previous_password', 'password'))) {
+        if (!$this->hasKeys($params, array('id', 'previous_password', 'password'))) {
             throw new MissingParametersException(__METHOD__, array('id', 'previous_password', 'password'));
         }
         $id = $params['id'];
         unset($params['id']);
-        $endPoint = Http::prepare('users/'.$id.'/password.json');
+        $endPoint = Http::prepare('users/' . $id . '/password.json');
         $response = Http::send($this->client, $endPoint, $params, 'PUT');
         if ($this->client->getDebug()->lastResponseCode != 200) {
             throw new ResponseException(__METHOD__);
         }
         $this->client->setSideload(null);
+
         return $response;
     }
 
@@ -503,55 +548,79 @@ class Users extends ClientAbstract {
      *
      * @return Tickets
      */
-    public function tickets($id = null) { return ($id != null ? $this->client->tickets()->setLastId($id) : $this->client->tickets()); }
+    public function tickets($id = null)
+    {
+        return ($id != null ? $this->client->tickets()->setLastId($id) : $this->client->tickets());
+    }
 
     /**
      * @param int $id
      *
      * @return Tickets
      */
-    public function ticket($id) { return $this->client->tickets()->setLastId($id); }
+    public function ticket($id)
+    {
+        return $this->client->tickets()->setLastId($id);
+    }
 
     /**
      * @param int|null $id
      *
      * @return UserIdentities
      */
-    public function identities($id = null) { return ($id != null ? $this->identities->setLastId($id) : $this->identities); }
+    public function identities($id = null)
+    {
+        return ($id != null ? $this->identities->setLastId($id) : $this->identities);
+    }
 
     /**
      * @param int $id
      *
      * @return UserIdentities
      */
-    public function identity($id) { return $this->identities->setLastId($id); }
+    public function identity($id)
+    {
+        return $this->identities->setLastId($id);
+    }
 
     /**
      * @param int|null $id
      *
      * @return Groups
      */
-    public function groups($id = null) { return ($id != null ? $this->client->groups()->setLastId($id) : $this->client->groups()); }
+    public function groups($id = null)
+    {
+        return ($id != null ? $this->client->groups()->setLastId($id) : $this->client->groups());
+    }
 
     /**
      * @param int $id
      *
      * @return Groups
      */
-    public function group($id) { return $this->client->groups()->setLastId($id); }
+    public function group($id)
+    {
+        return $this->client->groups()->setLastId($id);
+    }
 
     /**
      * @param int|null $id
      *
      * @return GroupMemberships
      */
-    public function groupMemberships($id = null) { return ($id != null ? $this->client->groupMemberships()->setLastId($id) : $this->client->groupMemberships()); }
+    public function groupMemberships($id = null)
+    {
+        return ($id != null ? $this->client->groupMemberships()->setLastId($id) : $this->client->groupMemberships());
+    }
 
     /**
      * @param int $id
      *
      * @return GroupMemberships
      */
-    public function groupMembership($id) { return $this->client->groupMemberships()->setLastId($id); }
+    public function groupMembership($id)
+    {
+        return $this->client->groupMemberships()->setLastId($id);
+    }
 
 }

--- a/src/Zendesk/API/Views.php
+++ b/src/Zendesk/API/Views.php
@@ -6,7 +6,8 @@ namespace Zendesk\API;
  * The Views class exposes view management methods
  * @package Zendesk\API
  */
-class Views extends ClientAbstract {
+class Views extends ClientAbstract
+{
 
     const OBJ_NAME = 'view';
     const OBJ_NAME_PLURAL = 'views';
@@ -21,16 +22,19 @@ class Views extends ClientAbstract {
      *
      * @return mixed
      */
-    public function findAll(array $params = array()) {
+    public function findAll(array $params = array())
+    {
         $endPoint = Http::prepare(
-                (isset($params['active']) ? 'views/active.json' :
-                (isset($params['compact']) ? 'views/compact.json' : 'views.json')), $this->client->getSideload($params), $params
-            );
+            (isset($params['active']) ? 'views/active.json' :
+                (isset($params['compact']) ? 'views/compact.json' : 'views.json')), $this->client->getSideload($params),
+            $params
+        );
         $response = Http::send($this->client, $endPoint);
         if ((!is_object($response)) || ($this->client->getDebug()->lastResponseCode != 200)) {
             throw new ResponseException(__METHOD__);
         }
         $this->client->setSideload(null);
+
         return $response;
     }
 
@@ -45,20 +49,22 @@ class Views extends ClientAbstract {
      *
      * @return mixed
      */
-    public function find(array $params = array()) {
-        if($this->lastId != null) {
+    public function find(array $params = array())
+    {
+        if ($this->lastId != null) {
             $params['id'] = $this->lastId;
             $this->lastId = null;
         }
-        if(!$this->hasKeys($params, array('id'))) {
+        if (!$this->hasKeys($params, array('id'))) {
             throw new MissingParametersException(__METHOD__, array('id'));
         }
-        $endPoint = Http::prepare('views/'.$params['id'].'.json', $this->client->getSideload($params));
+        $endPoint = Http::prepare('views/' . $params['id'] . '.json', $this->client->getSideload($params));
         $response = Http::send($this->client, $endPoint);
         if ((!is_object($response)) || ($this->client->getDebug()->lastResponseCode != 200)) {
             throw new ResponseException(__METHOD__);
         }
         $this->client->setSideload(null);
+
         return $response;
     }
 
@@ -72,13 +78,15 @@ class Views extends ClientAbstract {
      *
      * @return mixed
      */
-    public function create(array $params) {
+    public function create(array $params)
+    {
         $endPoint = Http::prepare('views.json');
-        $response = Http::send($this->client, $endPoint, array (self::OBJ_NAME => $params), 'POST');
+        $response = Http::send($this->client, $endPoint, array(self::OBJ_NAME => $params), 'POST');
         if ((!is_object($response)) || ($this->client->getDebug()->lastResponseCode != 201)) {
             throw new ResponseException(__METHOD__);
         }
         $this->client->setSideload(null);
+
         return $response;
     }
 
@@ -93,22 +101,24 @@ class Views extends ClientAbstract {
      *
      * @return mixed
      */
-    public function update(array $params) {
-        if($this->lastId != null) {
+    public function update(array $params)
+    {
+        if ($this->lastId != null) {
             $params['id'] = $this->lastId;
             $this->lastId = null;
         }
-        if(!$this->hasKeys($params, array('id'))) {
+        if (!$this->hasKeys($params, array('id'))) {
             throw new MissingParametersException(__METHOD__, array('id'));
         }
         $id = $params['id'];
         unset($params['id']);
-        $endPoint = Http::prepare('views/'.$id.'.json');
-        $response = Http::send($this->client, $endPoint, array (self::OBJ_NAME => $params), 'PUT');
+        $endPoint = Http::prepare('views/' . $id . '.json');
+        $response = Http::send($this->client, $endPoint, array(self::OBJ_NAME => $params), 'PUT');
         if ((!is_object($response)) || ($this->client->getDebug()->lastResponseCode != 200)) {
             throw new ResponseException(__METHOD__);
         }
         $this->client->setSideload(null);
+
         return $response;
     }
 
@@ -123,21 +133,23 @@ class Views extends ClientAbstract {
      *
      * @return bool
      */
-    public function delete(array $params = array()) {
-        if($this->lastId != null) {
+    public function delete(array $params = array())
+    {
+        if ($this->lastId != null) {
             $params['id'] = $this->lastId;
             $this->lastId = null;
         }
-        if(!$this->hasKeys($params, array('id'))) {
+        if (!$this->hasKeys($params, array('id'))) {
             throw new MissingParametersException(__METHOD__, array('id'));
         }
         $id = $params['id'];
-        $endPoint = Http::prepare('views/'.$id.'.json');
+        $endPoint = Http::prepare('views/' . $id . '.json');
         $response = Http::send($this->client, $endPoint, null, 'DELETE');
         if ($this->client->getDebug()->lastResponseCode != 200) {
             throw new ResponseException(__METHOD__);
         }
         $this->client->setSideload(null);
+
         return true;
     }
 
@@ -152,20 +164,23 @@ class Views extends ClientAbstract {
      *
      * @return mixed
      */
-    public function execute(array $params = array()) {
-        if($this->lastId != null) {
+    public function execute(array $params = array())
+    {
+        if ($this->lastId != null) {
             $params['id'] = $this->lastId;
             $this->lastId = null;
         }
-        if(!$this->hasKeys($params, array('id'))) {
+        if (!$this->hasKeys($params, array('id'))) {
             throw new MissingParametersException(__METHOD__, array('id'));
         }
-        $endPoint = Http::prepare('views/'.$params['id'].'/execute.json'.(isset($params['sort_by']) ? '?sort_by='.$params['sort_by'].(isset($params['sort_order']) ? '&sort_order='.$params['sort_order'] : '') : ''), $this->client->getSideload($params), $params);
+        $endPoint = Http::prepare('views/' . $params['id'] . '/execute.json' . (isset($params['sort_by']) ? '?sort_by=' . $params['sort_by'] . (isset($params['sort_order']) ? '&sort_order=' . $params['sort_order'] : '') : ''),
+            $this->client->getSideload($params), $params);
         $response = Http::send($this->client, $endPoint);
         if ((!is_object($response)) || ($this->client->getDebug()->lastResponseCode != 200)) {
             throw new ResponseException(__METHOD__);
         }
         $this->client->setSideload(null);
+
         return $response;
     }
 
@@ -180,20 +195,23 @@ class Views extends ClientAbstract {
      *
      * @return mixed
      */
-    public function tickets(array $params = array()) {
-        if($this->lastId != null) {
+    public function tickets(array $params = array())
+    {
+        if ($this->lastId != null) {
             $params['id'] = $this->lastId;
             $this->lastId = null;
         }
-        if(!$this->hasKeys($params, array('id'))) {
+        if (!$this->hasKeys($params, array('id'))) {
             throw new MissingParametersException(__METHOD__, array('id'));
         }
-        $endPoint = Http::prepare('views/'.$params['id'].'/tickets.json', $this->client->getSideload($params), $params);
+        $endPoint = Http::prepare('views/' . $params['id'] . '/tickets.json', $this->client->getSideload($params),
+            $params);
         $response = Http::send($this->client, $endPoint);
         if ((!is_object($response)) || ($this->client->getDebug()->lastResponseCode != 200)) {
             throw new ResponseException(__METHOD__);
         }
         $this->client->setSideload(null);
+
         return $response;
     }
 
@@ -208,20 +226,23 @@ class Views extends ClientAbstract {
      *
      * @return mixed
      */
-    public function count(array $params = array()) {
-        if($this->lastId != null) {
+    public function count(array $params = array())
+    {
+        if ($this->lastId != null) {
             $params['id'] = $this->lastId;
             $this->lastId = null;
         }
-        if(!$this->hasKeys($params, array('id'))) {
+        if (!$this->hasKeys($params, array('id'))) {
             throw new MissingParametersException(__METHOD__, array('id'));
         }
-        $endPoint = Http::prepare('views/'.(is_array($params['id']) ? 'count_many.json?ids='.implode(',', $params['id']) : $params['id'].'/count.json'), $this->client->getSideload($params), $params);
+        $endPoint = Http::prepare('views/' . (is_array($params['id']) ? 'count_many.json?ids=' . implode(',',
+                    $params['id']) : $params['id'] . '/count.json'), $this->client->getSideload($params), $params);
         $response = Http::send($this->client, $endPoint);
         if ((!is_object($response)) || ($this->client->getDebug()->lastResponseCode != 200)) {
             throw new ResponseException(__METHOD__);
         }
         $this->client->setSideload(null);
+
         return $response;
     }
 
@@ -236,20 +257,23 @@ class Views extends ClientAbstract {
      *
      * @return mixed
      */
-    public function export(array $params = array()) {
-        if($this->lastId != null) {
+    public function export(array $params = array())
+    {
+        if ($this->lastId != null) {
             $params['id'] = $this->lastId;
             $this->lastId = null;
         }
-        if(!$this->hasKeys($params, array('id'))) {
+        if (!$this->hasKeys($params, array('id'))) {
             throw new MissingParametersException(__METHOD__, array('id'));
         }
-        $endPoint = Http::prepare('views/'.$params['id'].'/export.json', $this->client->getSideload($params), $params);
+        $endPoint = Http::prepare('views/' . $params['id'] . '/export.json', $this->client->getSideload($params),
+            $params);
         $response = Http::send($this->client, $endPoint);
         if ((!is_object($response)) || ($this->client->getDebug()->lastResponseCode != 200)) {
             throw new ResponseException(__METHOD__);
         }
         $this->client->setSideload(null);
+
         return $response;
     }
 
@@ -263,13 +287,15 @@ class Views extends ClientAbstract {
      *
      * @return mixed
      */
-    public function preview(array $params) {
+    public function preview(array $params)
+    {
         $endPoint = Http::prepare('views/preview.json', $this->client->getSideload($params), $params);
         $response = Http::send($this->client, $endPoint, array('view' => $params), 'POST');
         if ((!is_object($response)) || ($this->client->getDebug()->lastResponseCode != 200)) {
             throw new ResponseException(__METHOD__);
         }
         $this->client->setSideload(null);
+
         return $response;
     }
 
@@ -283,13 +309,15 @@ class Views extends ClientAbstract {
      *
      * @return mixed
      */
-    public function previewCount(array $params) {
+    public function previewCount(array $params)
+    {
         $endPoint = Http::prepare('views/preview/count.json', $this->client->getSideload($params), $params);
         $response = Http::send($this->client, $endPoint, array('view' => $params), 'POST');
         if ((!is_object($response)) || ($this->client->getDebug()->lastResponseCode != 200)) {
             throw new ResponseException(__METHOD__);
         }
         $this->client->setSideload(null);
+
         return $response;
     }
 

--- a/src/Zendesk/API/Voice.php
+++ b/src/Zendesk/API/Voice.php
@@ -12,7 +12,8 @@ namespace Zendesk\API;
  * @method VoiceAgents agents()
  * @method VoiceTickets tickets()
  */
-class Voice extends ClientAbstract {
+class Voice extends ClientAbstract
+{
 
     /**
      * @var VoicePhoneNumbers
@@ -38,7 +39,8 @@ class Voice extends ClientAbstract {
     /**
      * @param Client $client
      */
-    public function __construct(Client $client) {
+    public function __construct(Client $client)
+    {
         parent::__construct($client);
         $this->phoneNumbers = new VoicePhoneNumbers($client);
         $this->greetings = new VoiceGreetings($client);
@@ -57,15 +59,16 @@ class Voice extends ClientAbstract {
      *
      * @throws CustomException
      */
-    public function __call($name, $arguments) {
-        if(isset($this->$name)) {
+    public function __call($name, $arguments)
+    {
+        if (isset($this->$name)) {
             return ((isset($arguments[0])) && ($arguments[0] != null) ? $this->$name->setLastId($arguments[0]) : $this->$name);
         }
-        $namePlural = $name.'s'; // try pluralize
-        if(isset($this->$namePlural)) {
+        $namePlural = $name . 's'; // try pluralize
+        if (isset($this->$namePlural)) {
             return $this->$namePlural->setLastId($arguments[0]);
         } else {
-            throw new CustomException("No method called $name available in ".__CLASS__);
+            throw new CustomException("No method called $name available in " . __CLASS__);
         }
     }
 

--- a/src/Zendesk/API/VoiceAgents.php
+++ b/src/Zendesk/API/VoiceAgents.php
@@ -6,7 +6,8 @@ namespace Zendesk\API;
  * The VoiceAgents class exposes methods as outlined in http://developer.zendesk.com/documentation/rest_api/voice_integration.html
  * @package Zendesk\API
  */
-class VoiceAgents extends ClientAbstract {
+class VoiceAgents extends ClientAbstract
+{
 
     /**
      * Opens a user's profile in an agent's browser
@@ -19,16 +20,18 @@ class VoiceAgents extends ClientAbstract {
      *
      * @return bool
      */
-    public function openUserProfile(array $params = array()) {
-        if(!$this->hasKeys($params, array('agent_id', 'user_id'))) {
+    public function openUserProfile(array $params = array())
+    {
+        if (!$this->hasKeys($params, array('agent_id', 'user_id'))) {
             throw new MissingParametersException(__METHOD__, array('agent_id', 'user_id'));
         }
-        $endPoint = Http::prepare('channels/voice/agents/'.$params['agent_id'].'/users/'.$params['user_id'].'/display.json');
+        $endPoint = Http::prepare('channels/voice/agents/' . $params['agent_id'] . '/users/' . $params['user_id'] . '/display.json');
         $response = Http::send($this->client, $endPoint, null, 'POST');
         if ((!is_object($response)) || ($this->client->getDebug()->lastResponseCode != 200)) {
             throw new ResponseException(__METHOD__);
         }
         $this->client->setSideload(null);
+
         return true;
     }
 
@@ -43,16 +46,18 @@ class VoiceAgents extends ClientAbstract {
      *
      * @return bool
      */
-    public function openTicket(array $params = array()) {
-        if(!$this->hasKeys($params, array('agent_id', 'ticket_id'))) {
+    public function openTicket(array $params = array())
+    {
+        if (!$this->hasKeys($params, array('agent_id', 'ticket_id'))) {
             throw new MissingParametersException(__METHOD__, array('agent_id', 'ticket_id'));
         }
-        $endPoint = Http::prepare('channels/voice/agents/'.$params['agent_id'].'/tickets/'.$params['ticket_id'].'/display.json');
+        $endPoint = Http::prepare('channels/voice/agents/' . $params['agent_id'] . '/tickets/' . $params['ticket_id'] . '/display.json');
         $response = Http::send($this->client, $endPoint, null, 'POST');
         if (($this->client->getDebug()->lastResponseCode != 200)) {
             throw new ResponseException(__METHOD__);
         }
         $this->client->setSideload(null);
+
         return true;
     }
 

--- a/src/Zendesk/API/VoiceGreetings.php
+++ b/src/Zendesk/API/VoiceGreetings.php
@@ -6,7 +6,8 @@ namespace Zendesk\API;
  * The VoiceGreetings class exposes methods as outlined in http://developer.zendesk.com/documentation/rest_api/voice.html
  * @package Zendesk\API
  */
-class VoiceGreetings extends ClientAbstract {
+class VoiceGreetings extends ClientAbstract
+{
 
     const OBJ_NAME = 'greeting';
     const OBJ_NAME_PLURAL = 'greetings';
@@ -21,13 +22,15 @@ class VoiceGreetings extends ClientAbstract {
      *
      * @return mixed
      */
-    public function findAll(array $params = array()) {
+    public function findAll(array $params = array())
+    {
         $endPoint = Http::prepare('channels/voice/greetings.json', null, $params);
         $response = Http::send($this->client, $endPoint);
         if ((!is_object($response)) || ($this->client->getDebug()->lastResponseCode != 200)) {
             throw new ResponseException(__METHOD__);
         }
         $this->client->setSideload(null);
+
         return $response;
     }
 
@@ -42,20 +45,22 @@ class VoiceGreetings extends ClientAbstract {
      *
      * @return mixed
      */
-    public function find(array $params = array()) {
-        if($this->lastId != null) {
+    public function find(array $params = array())
+    {
+        if ($this->lastId != null) {
             $params['id'] = $this->lastId;
             $this->lastId = null;
         }
-        if(!$this->hasKeys($params, array('id'))) {
+        if (!$this->hasKeys($params, array('id'))) {
             throw new MissingParametersException(__METHOD__, array('id'));
         }
-        $endPoint = Http::prepare('channels/voice/greetings/'.$params['id'].'.json');
+        $endPoint = Http::prepare('channels/voice/greetings/' . $params['id'] . '.json');
         $response = Http::send($this->client, $endPoint);
         if ((!is_object($response)) || ($this->client->getDebug()->lastResponseCode != 200)) {
             throw new ResponseException(__METHOD__);
         }
         $this->client->setSideload(null);
+
         return $response;
     }
 
@@ -69,13 +74,15 @@ class VoiceGreetings extends ClientAbstract {
      *
      * @return mixed
      */
-    public function create(array $params) {
+    public function create(array $params)
+    {
         $endPoint = Http::prepare('channels/voice/greetings.json');
         $response = Http::send($this->client, $endPoint, array(self::OBJ_NAME => $params), 'POST');
         if ((!is_object($response)) || ($this->client->getDebug()->lastResponseCode != 201)) {
             throw new ResponseException(__METHOD__);
         }
         $this->client->setSideload(null);
+
         return $response;
     }
 
@@ -90,22 +97,24 @@ class VoiceGreetings extends ClientAbstract {
      *
      * @return mixed
      */
-    public function update(array $params) {
-        if($this->lastId != null) {
+    public function update(array $params)
+    {
+        if ($this->lastId != null) {
             $params['id'] = $this->lastId;
             $this->lastId = null;
         }
-        if(!$this->hasKeys($params, array('id'))) {
+        if (!$this->hasKeys($params, array('id'))) {
             throw new MissingParametersException(__METHOD__, array('id'));
         }
         $id = $params['id'];
         unset($params['id']);
-        $endPoint = Http::prepare('channels/voice/greetings/'.$id.'.json');
+        $endPoint = Http::prepare('channels/voice/greetings/' . $id . '.json');
         $response = Http::send($this->client, $endPoint, array(self::OBJ_NAME => $params), 'PUT');
         if ((!is_object($response)) || ($this->client->getDebug()->lastResponseCode != 200)) {
             throw new ResponseException(__METHOD__);
         }
         $this->client->setSideload(null);
+
         return $response;
     }
 
@@ -120,21 +129,23 @@ class VoiceGreetings extends ClientAbstract {
      *
      * @return bool
      */
-    public function delete(array $params = array()) {
-        if($this->lastId != null) {
+    public function delete(array $params = array())
+    {
+        if ($this->lastId != null) {
             $params['id'] = $this->lastId;
             $this->lastId = null;
         }
-        if(!$this->hasKeys($params, array('id'))) {
+        if (!$this->hasKeys($params, array('id'))) {
             throw new MissingParametersException(__METHOD__, array('id'));
         }
         $id = $params['id'];
-        $endPoint = Http::prepare('channels/voice/greetings/'.$id.'.json');
+        $endPoint = Http::prepare('channels/voice/greetings/' . $id . '.json');
         $response = Http::send($this->client, $endPoint, null, 'DELETE');
         if ($this->client->getDebug()->lastResponseCode != 200) {
             throw new ResponseException(__METHOD__);
         }
         $this->client->setSideload(null);
+
         return true;
     }
 
@@ -147,21 +158,25 @@ class VoiceGreetings extends ClientAbstract {
      *
      * @return mixed
      */
-    public function upload(array $params) {
-        if($this->lastId != null) {
+    public function upload(array $params)
+    {
+        if ($this->lastId != null) {
             $params['id'] = $this->lastId;
             $this->lastId = null;
         }
-        if(!$this->hasKeys($params, array('id', 'file'))) {
+        if (!$this->hasKeys($params, array('id', 'file'))) {
             throw new MissingParametersException(__METHOD__, array('id', 'file'));
         }
         $id = $params['id'];
-        $endPoint = Http::prepare('channels/voice/greetings/'.$id.'.json');
-        $response = Http::send($this->client, $endPoint, array(self::OBJ_NAME => array('uploaded_data' => '@'.$params['file'])), 'POST', (isset($params['type']) ? $params['type'] : 'application/binary'));
+        $endPoint = Http::prepare('channels/voice/greetings/' . $id . '.json');
+        $response = Http::send($this->client, $endPoint,
+            array(self::OBJ_NAME => array('uploaded_data' => '@' . $params['file'])), 'POST',
+            (isset($params['type']) ? $params['type'] : 'application/binary'));
         if ((!is_object($response)) || ($this->client->getDebug()->lastResponseCode != 201)) {
             throw new ResponseException(__METHOD__);
         }
         $this->client->setSideload(null);
+
         return $response;
     }
 

--- a/src/Zendesk/API/VoicePhoneNumbers.php
+++ b/src/Zendesk/API/VoicePhoneNumbers.php
@@ -6,7 +6,8 @@ namespace Zendesk\API;
  * The VoicePhoneNumbers class exposes methods as outlined in http://developer.zendesk.com/documentation/rest_api/voice.html
  * @package Zendesk\API
  */
-class VoicePhoneNumbers extends ClientAbstract {
+class VoicePhoneNumbers extends ClientAbstract
+{
 
     const OBJ_NAME = 'phone_number';
     const OBJ_NAME_PLURAL = 'phone_numbers';
@@ -21,13 +22,15 @@ class VoicePhoneNumbers extends ClientAbstract {
      *
      * @return mixed
      */
-    public function findAll(array $params = array()) {
+    public function findAll(array $params = array())
+    {
         $endPoint = Http::prepare('channels/voice/phone_numbers.json', null, $params);
         $response = Http::send($this->client, $endPoint);
         if ((!is_object($response)) || ($this->client->getDebug()->lastResponseCode != 200)) {
             throw new ResponseException(__METHOD__);
         }
         $this->client->setSideload(null);
+
         return $response;
     }
 
@@ -42,20 +45,22 @@ class VoicePhoneNumbers extends ClientAbstract {
      *
      * @return mixed
      */
-    public function find(array $params = array()) {
-        if($this->lastId != null) {
+    public function find(array $params = array())
+    {
+        if ($this->lastId != null) {
             $params['id'] = $this->lastId;
             $this->lastId = null;
         }
-        if(!$this->hasKeys($params, array('id'))) {
+        if (!$this->hasKeys($params, array('id'))) {
             throw new MissingParametersException(__METHOD__, array('id'));
         }
-        $endPoint = Http::prepare('channels/voice/phone_numbers/'.$params['id'].'.json');
+        $endPoint = Http::prepare('channels/voice/phone_numbers/' . $params['id'] . '.json');
         $response = Http::send($this->client, $endPoint);
         if ((!is_object($response)) || ($this->client->getDebug()->lastResponseCode != 200)) {
             throw new ResponseException(__METHOD__);
         }
         $this->client->setSideload(null);
+
         return $response;
     }
 
@@ -70,16 +75,18 @@ class VoicePhoneNumbers extends ClientAbstract {
      *
      * @return mixed
      */
-    public function search(array $params) {
-        if(!$this->hasKeys($params, array('country'))) {
+    public function search(array $params)
+    {
+        if (!$this->hasKeys($params, array('country'))) {
             throw new MissingParametersException(__METHOD__, array('country'));
         }
-        $endPoint = Http::prepare('channels/voice/phone_numbers/search.json?'.http_build_query($params));
+        $endPoint = Http::prepare('channels/voice/phone_numbers/search.json?' . http_build_query($params));
         $response = Http::send($this->client, $endPoint);
         if ((!is_object($response)) || ($this->client->getDebug()->lastResponseCode != 200)) {
             throw new ResponseException(__METHOD__);
         }
         $this->client->setSideload(null);
+
         return $response;
     }
 
@@ -94,8 +101,9 @@ class VoicePhoneNumbers extends ClientAbstract {
      *
      * @return mixed
      */
-    public function create(array $params) {
-        if(!$this->hasKeys($params, array('token'))) {
+    public function create(array $params)
+    {
+        if (!$this->hasKeys($params, array('token'))) {
             throw new MissingParametersException(__METHOD__, array('token'));
         }
         $endPoint = Http::prepare('channels/voice/phone_numbers.json');
@@ -104,6 +112,7 @@ class VoicePhoneNumbers extends ClientAbstract {
             throw new ResponseException(__METHOD__);
         }
         $this->client->setSideload(null);
+
         return $response;
     }
 
@@ -118,22 +127,24 @@ class VoicePhoneNumbers extends ClientAbstract {
      *
      * @return mixed
      */
-    public function update(array $params) {
-        if($this->lastId != null) {
+    public function update(array $params)
+    {
+        if ($this->lastId != null) {
             $params['id'] = $this->lastId;
             $this->lastId = null;
         }
-        if(!$this->hasKeys($params, array('id'))) {
+        if (!$this->hasKeys($params, array('id'))) {
             throw new MissingParametersException(__METHOD__, array('id'));
         }
         $id = $params['id'];
         unset($params['id']);
-        $endPoint = Http::prepare('channels/voice/phone_numbers/'.$id.'.json');
-        $response = Http::send($this->client, $endPoint, array (self::OBJ_NAME => $params), 'PUT');
+        $endPoint = Http::prepare('channels/voice/phone_numbers/' . $id . '.json');
+        $response = Http::send($this->client, $endPoint, array(self::OBJ_NAME => $params), 'PUT');
         if ((!is_object($response)) || ($this->client->getDebug()->lastResponseCode != 200)) {
             throw new ResponseException(__METHOD__);
         }
         $this->client->setSideload(null);
+
         return $response;
     }
 
@@ -148,21 +159,23 @@ class VoicePhoneNumbers extends ClientAbstract {
      *
      * @return bool
      */
-    public function delete(array $params = array()) {
-        if($this->lastId != null) {
+    public function delete(array $params = array())
+    {
+        if ($this->lastId != null) {
             $params['id'] = $this->lastId;
             $this->lastId = null;
         }
-        if(!$this->hasKeys($params, array('id'))) {
+        if (!$this->hasKeys($params, array('id'))) {
             throw new MissingParametersException(__METHOD__, array('id'));
         }
         $id = $params['id'];
-        $endPoint = Http::prepare('channels/voice/phone_numbers/'.$id.'.json');
+        $endPoint = Http::prepare('channels/voice/phone_numbers/' . $id . '.json');
         $response = Http::send($this->client, $endPoint, null, 'DELETE');
         if ($this->client->getDebug()->lastResponseCode != 200) {
             throw new ResponseException(__METHOD__);
         }
         $this->client->setSideload(null);
+
         return true;
     }
 

--- a/src/Zendesk/API/VoiceStats.php
+++ b/src/Zendesk/API/VoiceStats.php
@@ -6,7 +6,8 @@ namespace Zendesk\API;
  * The VoiceStats class exposes methods as outlined in http://developer.zendesk.com/documentation/rest_api/voice.html
  * @package Zendesk\API
  */
-class VoiceStats extends ClientAbstract {
+class VoiceStats extends ClientAbstract
+{
 
     /**
      * List all stats
@@ -19,20 +20,25 @@ class VoiceStats extends ClientAbstract {
      *
      * @return mixed
      */
-    public function findAll(array $params = array()) {
-        if(!$this->hasAnyKey($params, array('current_queue_activity', 'historical_queue_activity', 'agents_activity'))) {
-            throw new MissingParametersException(__METHOD__, array('current_queue_activity', 'historical_queue_activity', 'agents_activity'));
+    public function findAll(array $params = array())
+    {
+        if (!$this->hasAnyKey($params, array('current_queue_activity', 'historical_queue_activity', 'agents_activity'))
+        ) {
+            throw new MissingParametersException(__METHOD__,
+                array('current_queue_activity', 'historical_queue_activity', 'agents_activity'));
         }
         $endPoint = Http::prepare(
-                (isset($params['current_queue_activity']) ? 'channels/voice/stats/current_queue_activity.json' :
+            (isset($params['current_queue_activity']) ? 'channels/voice/stats/current_queue_activity.json' :
                 (isset($params['historical_queue_activity']) ? 'channels/voice/stats/historical_queue_activity.json' :
-                (isset($params['agents_activity']) ? 'channels/voice/stats/agents_activity.json' : ''))), null, $params
-            );
+                    (isset($params['agents_activity']) ? 'channels/voice/stats/agents_activity.json' : ''))), null,
+            $params
+        );
         $response = Http::send($this->client, $endPoint);
         if ((!is_object($response)) || ($this->client->getDebug()->lastResponseCode != 200)) {
             throw new ResponseException(__METHOD__);
         }
         $this->client->setSideload(null);
+
         return $response;
     }
 

--- a/src/Zendesk/API/VoiceTickets.php
+++ b/src/Zendesk/API/VoiceTickets.php
@@ -6,7 +6,8 @@ namespace Zendesk\API;
  * The VoiceTickets class exposes methods as outlined in http://developer.zendesk.com/documentation/rest_api/voice_integration.html
  * @package Zendesk\API
  */
-class VoiceTickets extends ClientAbstract {
+class VoiceTickets extends ClientAbstract
+{
 
     /**
      * Create a voice or voicemail ticket
@@ -18,13 +19,15 @@ class VoiceTickets extends ClientAbstract {
      *
      * @return mixed
      */
-    public function create(array $params) {
+    public function create(array $params)
+    {
         $endPoint = Http::prepare('channels/voice/tickets.json');
         $response = Http::send($this->client, $endPoint, $params, 'POST'); // note: specify the whole package
         if ((!is_object($response)) || ($this->client->getDebug()->lastResponseCode != 201)) {
             throw new ResponseException(__METHOD__);
         }
         $this->client->setSideload(null);
+
         return $response;
     }
 

--- a/tests/Zendesk/API/LiveTests/ActivityStreamTest.php
+++ b/tests/Zendesk/API/LiveTests/ActivityStreamTest.php
@@ -7,19 +7,23 @@ use Zendesk\API\Client;
 /**
  * ActivityStream test class
  */
-class ActivityStreamTest extends BasicTest {
+class ActivityStreamTest extends BasicTest
+{
 
-    public function testCredentials() {
+    public function testCredentials()
+    {
         parent::credentialsTest();
     }
 
-    public function testAuthToken() {
+    public function testAuthToken()
+    {
         parent::authTokenTest();
     }
 
     protected $ticket_id;
 
-    public function setUP() {
+    public function setUP()
+    {
 
         $username = getenv('END_USER_USERNAME');
         $password = getenv('END_USER_PASSWORD');
@@ -28,7 +32,7 @@ class ActivityStreamTest extends BasicTest {
 
         $testTicket = array(
             'subject' => 'Activity Stream Test',
-            'comment' => array (
+            'comment' => array(
                 'body' => 'ce est biche Actions test.'
             ),
             'priority' => 'normal'
@@ -37,14 +41,17 @@ class ActivityStreamTest extends BasicTest {
         $this->ticket_id = $request->request->id;
     }
 
-    public function testAll() {
+    public function testAll()
+    {
         $activities = $this->client->activities()->findAll();
         $this->assertEquals(is_object($activities), true, 'Should return an object');
-        $this->assertEquals(is_array($activities->activities), true, 'Should return an array of objects called "activities"');
+        $this->assertEquals(is_array($activities->activities), true,
+            'Should return an array of objects called "activities"');
         $this->assertEquals($this->client->getDebug()->lastResponseCode, '200', 'Does not return HTTP code 200');
     }
 
-    public function testFind() {
+    public function testFind()
+    {
         $activity_id = $this->client->activities()->findAll()->activities[0]->id;
         $activity = $this->client->activity($activity_id)->find();
         $this->assertEquals(is_object($activity), true, 'Should return an object');
@@ -52,7 +59,8 @@ class ActivityStreamTest extends BasicTest {
         $this->assertEquals($this->client->getDebug()->lastResponseCode, '200', 'Does not return HTTP code 200');
     }
 
-    public function tearDown(){
+    public function tearDown()
+    {
         $this->client->tickets($this->ticket_id)->delete();
     }
 

--- a/tests/Zendesk/API/LiveTests/AppsTest.php
+++ b/tests/Zendesk/API/LiveTests/AppsTest.php
@@ -7,18 +7,22 @@ use Zendesk\API\Client;
 /**
  * Attachments test class
  */
-class AppsTests extends BasicTest {
+class AppsTests extends BasicTest
+{
 
-    public function testAuthToken() {
+    public function testAuthToken()
+    {
         parent::authTokenTest();
     }
 
-    public function testUploadApps() {
+    public function testUploadApps()
+    {
         $apps = new \Zendesk\API\Apps($this->client);
-        if (version_compare(PHP_VERSION, '5.5.0', '<'))
-            $file = ['file' => '@'.getcwd().'/tests/assets/app.zip'];
-        else
-            $file = ['file' => curl_file_create(getcwd().'/tests/assets/app.zip')];
+        if (version_compare(PHP_VERSION, '5.5.0', '<')) {
+            $file = ['file' => '@' . getcwd() . '/tests/assets/app.zip'];
+        } else {
+            $file = ['file' => curl_file_create(getcwd() . '/tests/assets/app.zip')];
+        }
 
         $upload = $apps->upload($file);
 
@@ -26,50 +30,60 @@ class AppsTests extends BasicTest {
         $this->assertEquals(is_object($upload), true, 'Should return an object');
         $this->assertEquals(is_integer($upload->id), true, 'Should return an integer called "id"');
         $stack = array($upload);
+
         return $stack;
     }
 
     /**
      * @depends testUploadApps
      */
-    public function testCreateApps(array $stack) {
+    public function testCreateApps(array $stack)
+    {
         $upload = array_pop($stack);
         $apps = new \Zendesk\API\Apps($this->client);
 
-        $create = $apps->create(['name' => 'TESTING APP'.rand(), 'short_description' => 'testing', 'upload_id' => (string) $upload->id]);
+        $create = $apps->create([
+            'name' => 'TESTING APP' . rand(),
+            'short_description' => 'testing',
+            'upload_id' => (string)$upload->id
+        ]);
         $this->assertEquals($this->client->getDebug()->lastResponseCode, '202', 'Does not return HTTP code 202');
         $this->assertEquals(is_object($create), true, 'Should return an object');
         $this->assertEquals(is_string($create->job_id), true, 'Should return a string called "job_id"');
         $stack = array($create);
+
         return $stack;
     }
 
     /**
      * @depends testCreateApps
      */
-    public function testJobStatusApps(array $stack) {
+    public function testJobStatusApps(array $stack)
+    {
         $jobStatus = array_pop($stack);
         $apps = new \Zendesk\API\Apps($this->client);
 
-        $jobStatus = $apps->jobStatus(['id' => (string) $jobStatus->job_id]);
+        $jobStatus = $apps->jobStatus(['id' => (string)$jobStatus->job_id]);
         $this->assertEquals($this->client->getDebug()->lastResponseCode, '200', 'Does not return HTTP code 200');
         $this->assertEquals(is_object($jobStatus), true, 'Should return an object');
         $this->assertEquals(is_string($jobStatus->id), true, 'Should return a string called "job_id"');
         $this->assertEquals(isset($jobStatus->url), true, 'Should return a "url"');
         $this->assertEquals(is_string($jobStatus->status), true, 'Should return a string called "status"');
         $stack = array($jobStatus);
+
         return $stack;
     }
 
     /**
      * @depends testJobStatusApps
      */
-    public function testKeepTestingJobStatusUntilDone(array $stack) {
+    public function testKeepTestingJobStatusUntilDone(array $stack)
+    {
         $jobStatus = array_pop($stack);
         $apps = new \Zendesk\API\Apps($this->client);
 
         do {
-            $response = $apps->jobStatus(['id' => (string) $jobStatus->id]);
+            $response = $apps->jobStatus(['id' => (string)$jobStatus->id]);
             $status = $response->status;
 
             if ($status === 'failed') {
@@ -84,20 +98,23 @@ class AppsTests extends BasicTest {
         $this->assertEquals(is_integer($response->app_id), true, 'Should return a string called "app_id"');
 
         $stack = array($response);
+
         return $stack;
     }
 
     /**
      * @depends testKeepTestingJobStatusUntilDone
      */
-    public function testUpdateApps(array $stack) {
+    public function testUpdateApps(array $stack)
+    {
         $jobStatus = array_pop($stack);
         $apps = new \Zendesk\API\Apps($this->client);
 
-        if (version_compare(PHP_VERSION, '5.5.0', '<'))
-            $file = ['id' => $jobStatus->app_id, 'file' => '@'.getcwd().'/tests/assets/app.zip'];
-        else
-            $file = ['id' => $jobStatus->app_id, 'file' => curl_file_create(getcwd().'/tests/assets/app.zip')];
+        if (version_compare(PHP_VERSION, '5.5.0', '<')) {
+            $file = ['id' => $jobStatus->app_id, 'file' => '@' . getcwd() . '/tests/assets/app.zip'];
+        } else {
+            $file = ['id' => $jobStatus->app_id, 'file' => curl_file_create(getcwd() . '/tests/assets/app.zip')];
+        }
 
         $upload = $apps->update($file);
         $this->assertEquals($this->client->getDebug()->lastResponseCode, '200', 'Does not return HTTP code 200');
@@ -105,13 +122,15 @@ class AppsTests extends BasicTest {
         $this->assertEquals(is_integer($upload->id), true, 'Should return an integer called "id"');
         $this->assertEquals(is_string($upload->name), true, 'Should return a string called "name"');
         $stack = array($upload);
+
         return $stack;
     }
 
     /**
      * @depends testUpdateApps
      */
-    public function testDeleteApps(array $stack) {
+    public function testDeleteApps(array $stack)
+    {
         $app = array_pop($stack);
         $apps = new \Zendesk\API\Apps($this->client);
 

--- a/tests/Zendesk/API/LiveTests/AttachmentsTest.php
+++ b/tests/Zendesk/API/LiveTests/AttachmentsTest.php
@@ -7,15 +7,18 @@ use Zendesk\API\Client;
 /**
  * Attachments test class
  */
-class AttachmentsTest extends BasicTest {
+class AttachmentsTest extends BasicTest
+{
 
-    public function testAuthToken() {
+    public function testAuthToken()
+    {
         parent::authTokenTest();
     }
 
-    public function testUploadAttachment() {
+    public function testUploadAttachment()
+    {
         $attachment = $this->client->attachments()->upload(array(
-            'file' => getcwd().'/tests/assets/UK.png',
+            'file' => getcwd() . '/tests/assets/UK.png',
             'type' => 'image/png',
             'name' => 'UK test non-alpha chars.png'
         ));
@@ -23,27 +26,34 @@ class AttachmentsTest extends BasicTest {
         $this->assertEquals(is_object($attachment), true, 'Should return an object');
         $this->assertEquals(is_object($attachment->upload), true, 'Should return an object called "upload"');
         $this->assertEquals(($attachment->upload->token != ''), true, 'Should return a token');
-        $this->assertEquals(is_array($attachment->upload->attachments), true, 'Should return an array called "upload->attachments"');
-        $this->assertGreaterThan(0, $attachment->upload->attachments[0]->id, 'Returns a non-numeric id for upload->attachments[0]');
-        $this->assertGreaterThan(0, $attachment->upload->attachments[0]->size, 'returns a file with a greater than nothing filesize');
+        $this->assertEquals(is_array($attachment->upload->attachments), true,
+            'Should return an array called "upload->attachments"');
+        $this->assertGreaterThan(0, $attachment->upload->attachments[0]->id,
+            'Returns a non-numeric id for upload->attachments[0]');
+        $this->assertGreaterThan(0, $attachment->upload->attachments[0]->size,
+            'returns a file with a greater than nothing filesize');
         $stack = array($attachment);
+
         return $stack;
     }
 
     /**
      * @depends testUploadAttachment
      */
-    public function testDeleteAttachment(array $stack) {
+    public function testDeleteAttachment(array $stack)
+    {
         $attachment = array_pop($stack);
-        $this->assertEquals(($attachment->upload->token != ''), true, 'Cannot find a token to test with. Did testUploadAttachment fail?');
+        $this->assertEquals(($attachment->upload->token != ''), true,
+            'Cannot find a token to test with. Did testUploadAttachment fail?');
         $confirmed = $this->client->attachments()->delete(array(
             'token' => $attachment->upload->token
         ));
         $this->assertEquals($this->client->getDebug()->lastResponseCode, '200', 'Does not return HTTP code 200');
     }
 
-    public function testUploadAttachmentBody() {
-        $body = file_get_contents(getcwd().'/tests/assets/UK.png');
+    public function testUploadAttachmentBody()
+    {
+        $body = file_get_contents(getcwd() . '/tests/assets/UK.png');
         $attachment = $this->client->attachments()->uploadWithBody(array(
             'body' => $body,
             'type' => 'image/png',
@@ -53,10 +63,14 @@ class AttachmentsTest extends BasicTest {
         $this->assertEquals(is_object($attachment), true, 'Should return an object');
         $this->assertEquals(is_object($attachment->upload), true, 'Should return an object called "upload"');
         $this->assertEquals(($attachment->upload->token != ''), true, 'Should return a token');
-        $this->assertEquals(is_array($attachment->upload->attachments), true, 'Should return an array called "upload->attachments"');
-        $this->assertGreaterThan(0, $attachment->upload->attachments[0]->id, 'Returns a non-numeric id for upload->attachments[0]');
-        $this->assertEquals(strlen($body), $attachment->upload->attachments[0]->size, 'returns a file with correct filesize');
+        $this->assertEquals(is_array($attachment->upload->attachments), true,
+            'Should return an array called "upload->attachments"');
+        $this->assertGreaterThan(0, $attachment->upload->attachments[0]->id,
+            'Returns a non-numeric id for upload->attachments[0]');
+        $this->assertEquals(strlen($body), $attachment->upload->attachments[0]->size,
+            'returns a file with correct filesize');
         $stack = array($attachment);
+
         return $stack;
     }
 

--- a/tests/Zendesk/API/LiveTests/AuditLogsTest.php
+++ b/tests/Zendesk/API/LiveTests/AuditLogsTest.php
@@ -7,21 +7,26 @@ use Zendesk\API\Client;
 /**
  * AuditLogs test class
  */
-class AuditLogsTest extends BasicTest {
+class AuditLogsTest extends BasicTest
+{
 
-    public function testCredentials() {
+    public function testCredentials()
+    {
         parent::credentialsTest();
     }
 
-    public function testAuthToken() {
+    public function testAuthToken()
+    {
         parent::authTokenTest();
     }
+
     protected $ticket;
 
-    public function setUp(){
+    public function setUp()
+    {
         $testTicket = array(
             'subject' => 'The is for Audit Logs test',
-            'comment' => array (
+            'comment' => array(
                 'body' => 'Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.'
             ),
             'priority' => 'normal'
@@ -29,22 +34,27 @@ class AuditLogsTest extends BasicTest {
         $this->ticket = $this->client->tickets()->create($testTicket);
     }
 
-    public function tearDown(){
+    public function tearDown()
+    {
         $this->client->tickets($this->ticket->ticket->id)->delete();
     }
-    public function testAll() {
+
+    public function testAll()
+    {
         $auditLogs = $this->client->auditLogs()->findAll(array(
             'filter' => array(
                 'source_type' => 'rule'
             )
         ));
         $this->assertEquals(is_object($auditLogs), true, 'Should return an object');
-        $this->assertEquals(is_array($auditLogs->audit_logs), true, 'Should return an object containing an array called "audit_logs"');
+        $this->assertEquals(is_array($auditLogs->audit_logs), true,
+            'Should return an object containing an array called "audit_logs"');
         $this->assertGreaterThan(0, $auditLogs->audit_logs[0]->id, 'Returns a non-numeric id for audit_logs[0]');
         $this->assertEquals($this->client->getDebug()->lastResponseCode, '200', 'Does not return HTTP code 200');
     }
 
-    public function testFind() {
+    public function testFind()
+    {
         $auditLog_id = $this->client->auditLogs()->findAll()->audit_logs[0]->id;
         $auditLog = $this->client->auditLog($auditLog_id)->find(); // don't delete audit log #24000361
         $this->assertEquals(is_object($auditLog), true, 'Should return an object');

--- a/tests/Zendesk/API/LiveTests/AutocompleteTest.php
+++ b/tests/Zendesk/API/LiveTests/AutocompleteTest.php
@@ -7,17 +7,21 @@ use Zendesk\API\Client;
 /**
  * Autocomplete test class
  */
-class AutocompleteTest extends BasicTest {
+class AutocompleteTest extends BasicTest
+{
 
-    public function testCredentials() {
+    public function testCredentials()
+    {
         parent::credentialsTest();
     }
 
-    public function testAuthToken() {
+    public function testAuthToken()
+    {
         parent::authTokenTest();
     }
 
-    public function testTags() {
+    public function testTags()
+    {
         $tags = $this->client->autocomplete()->tags(array(
             'name' => 'att'
         ));

--- a/tests/Zendesk/API/LiveTests/AutomationsTest.php
+++ b/tests/Zendesk/API/LiveTests/AutomationsTest.php
@@ -7,19 +7,23 @@ use Zendesk\API\Client;
 /**
  * Automations test class
  */
-class AutomationsTest extends BasicTest {
+class AutomationsTest extends BasicTest
+{
 
-    public function testCredentials() {
+    public function testCredentials()
+    {
         parent::credentialsTest();
     }
 
-    public function testAuthToken() {
+    public function testAuthToken()
+    {
         parent::authTokenTest();
     }
 
     protected $id;
 
-    public function setUP(){
+    public function setUP()
+    {
         $automation = $this->client->automations()->create(array(
             'title' => 'Roger Wilco',
             'all' => array(
@@ -49,36 +53,43 @@ class AutomationsTest extends BasicTest {
         $this->id = $automation->automation->id;
     }
 
-    public function tearDown(){
+    public function tearDown()
+    {
         $this->assertGreaterThan(0, $this->id, 'Cannot find a automation id to test with. Did setUP fail?');
         $topic = $this->client->automation($this->id)->delete();
         $this->assertEquals($this->client->getDebug()->lastResponseCode, '200', 'Does not return HTTP code 200');
     }
 
-    public function testAll() {
+    public function testAll()
+    {
         $automations = $this->client->automations()->findAll();
         $this->assertEquals(is_object($automations), true, 'Should return an object');
-        $this->assertEquals(is_array($automations->automations), true, 'Should return an object containing an array called "automations"');
+        $this->assertEquals(is_array($automations->automations), true,
+            'Should return an object containing an array called "automations"');
         $this->assertGreaterThan(0, $automations->automations[0]->id, 'Returns a non-numeric id for automations[0]');
         $this->assertEquals($this->client->getDebug()->lastResponseCode, '200', 'Does not return HTTP code 200');
     }
 
-    public function testActive() {
+    public function testActive()
+    {
         $automations = $this->client->automations()->findAll(array('active' => true));
         $this->assertEquals(is_object($automations), true, 'Should return an object');
-        $this->assertEquals(is_array($automations->automations), true, 'Should return an object containing an array called "automations"');
+        $this->assertEquals(is_array($automations->automations), true,
+            'Should return an object containing an array called "automations"');
         $this->assertGreaterThan(0, $automations->automations[0]->id, 'Returns a non-numeric id for automations[0]');
         $this->assertEquals($this->client->getDebug()->lastResponseCode, '200', 'Does not return HTTP code 200');
     }
 
-    public function testFind() {
+    public function testFind()
+    {
         $automation = $this->client->automations($this->id)->find();
         $this->assertEquals(is_object($automation), true, 'Should return an object');
         $this->assertGreaterThan(0, $automation->automation->id, 'Returns a non-numeric id for automation');
         $this->assertEquals($this->client->getDebug()->lastResponseCode, '200', 'Does not return HTTP code 200');
     }
 
-    public function testUpdate() {
+    public function testUpdate()
+    {
         $automation = $this->client->automation($this->id)->update(array(
             'title' => 'Roger Wilco II'
         ));

--- a/tests/Zendesk/API/LiveTests/BasicTest.php
+++ b/tests/Zendesk/API/LiveTests/BasicTest.php
@@ -7,7 +7,8 @@ use Zendesk\API\Client;
 /**
  * Basic test class
  */
-abstract class BasicTest extends \PHPUnit_Framework_TestCase {
+abstract class BasicTest extends \PHPUnit_Framework_TestCase
+{
 
     protected $client;
     protected $subdomain;
@@ -15,7 +16,8 @@ abstract class BasicTest extends \PHPUnit_Framework_TestCase {
     protected $token;
     protected $oAuthToken;
 
-    public function __construct() {
+    public function __construct()
+    {
         $this->subdomain = getenv('SUBDOMAIN');
         $this->username = getenv('USERNAME');
         $this->password = getenv('PASSWORD');
@@ -25,14 +27,18 @@ abstract class BasicTest extends \PHPUnit_Framework_TestCase {
         $this->client->setAuth('token', $this->token);
     }
 
-    public function authTokenTest() {
+    public function authTokenTest()
+    {
         $tickets = $this->client->tickets()->findAll();
         $this->assertEquals($this->client->getDebug()->lastResponseCode, '200', 'Does not return HTTP code 200');
     }
 
-    public function credentialsTest() {
-        $this->assertEquals($this->subdomain != '', true, 'Expecting $this->subdomain parameter; does phpunit.xml exist?');
+    public function credentialsTest()
+    {
+        $this->assertEquals($this->subdomain != '', true,
+            'Expecting $this->subdomain parameter; does phpunit.xml exist?');
         $this->assertEquals($this->token != '', true, 'Expecting $this->token parameter; does phpunit.xml exist?');
-        $this->assertEquals($this->username != '', true, 'Expecting $this->username parameter; does phpunit.xml exist?');
+        $this->assertEquals($this->username != '', true,
+            'Expecting $this->username parameter; does phpunit.xml exist?');
     }
 }

--- a/tests/Zendesk/API/LiveTests/CategoriesTest.php
+++ b/tests/Zendesk/API/LiveTests/CategoriesTest.php
@@ -7,17 +7,21 @@ use Zendesk\API\Client;
 /**
  * Categories test class
  */
-class CategoriesTest extends BasicTest {
+class CategoriesTest extends BasicTest
+{
 
-    public function testCredentials() {
+    public function testCredentials()
+    {
         parent::credentialsTest();
     }
 
-    public function testAuthToken() {
+    public function testAuthToken()
+    {
         parent::authTokenTest();
     }
 
-    public function testCreate() {
+    public function testCreate()
+    {
         $category = $this->client->categories()->create(array(
             'name' => 'My Category'
         ));
@@ -28,38 +32,45 @@ class CategoriesTest extends BasicTest {
         $this->assertEquals($this->client->getDebug()->lastResponseCode, '201', 'Does not return HTTP code 201');
         $id = $category->category->id;
         $stack = array($id);
+
         return $stack;
     }
 
     /**
      * @depends testCreate
      */
-    public function testAll($stack) {
+    public function testAll($stack)
+    {
         $categories = $this->client->categories()->findAll();
         $this->assertEquals(is_object($categories), true, 'Should return an object');
-        $this->assertEquals(is_array($categories->categories), true, 'Should return an object containing an array called "categories"');
+        $this->assertEquals(is_array($categories->categories), true,
+            'Should return an object containing an array called "categories"');
         $this->assertGreaterThan(0, $categories->categories[0]->id, 'Returns a non-numeric id for categories[0]');
         $this->assertEquals($this->client->getDebug()->lastResponseCode, '200', 'Does not return HTTP code 200');
+
         return $stack;
     }
 
     /**
      * @depends testCreate
      */
-    public function testFind($stack) {
+    public function testFind($stack)
+    {
         $id = array_pop($stack);
         $category = $this->client->category($id)->find();
         $this->assertEquals(is_object($category), true, 'Should return an object');
         $this->assertGreaterThan(0, $category->category->id, 'Returns a non-numeric id for category');
         $this->assertEquals($this->client->getDebug()->lastResponseCode, '200', 'Does not return HTTP code 200');
         $stack = array($id);
+
         return $stack;
     }
 
     /**
      * @depends testCreate
      */
-    public function testUpdate(array $stack) {
+    public function testUpdate(array $stack)
+    {
         $id = array_pop($stack);
         $category = $this->client->category($id)->update(array(
             'name' => 'My Category II'
@@ -70,13 +81,15 @@ class CategoriesTest extends BasicTest {
         $this->assertEquals($category->category->name, 'My Category II', 'Name of test category does not match');
         $this->assertEquals($this->client->getDebug()->lastResponseCode, '200', 'Does not return HTTP code 200');
         $stack = array($id);
+
         return $stack;
     }
 
     /**
      * @depends testCreate
      */
-    public function testDelete(array $stack) {
+    public function testDelete(array $stack)
+    {
         $id = array_pop($stack);
         $this->assertGreaterThan(0, $id, 'Cannot find a category id to test with. Did testCreate fail?');
         $view = $this->client->category($id)->delete();

--- a/tests/Zendesk/API/LiveTests/CustomRolesTest.php
+++ b/tests/Zendesk/API/LiveTests/CustomRolesTest.php
@@ -7,20 +7,25 @@ use Zendesk\API\Client;
 /**
  * Custom Roles test class
  */
-class CustomRolesTest extends BasicTest {
+class CustomRolesTest extends BasicTest
+{
 
-    public function testCredentials() {
+    public function testCredentials()
+    {
         parent::credentialsTest();
     }
 
-    public function testAuthToken() {
+    public function testAuthToken()
+    {
         parent::authTokenTest();
     }
 
-    public function testAll() {
+    public function testAll()
+    {
         $customRoles = $this->client->customRoles()->findAll();
         $this->assertEquals(is_object($customRoles), true, 'Should return an object');
-        $this->assertEquals(is_array($customRoles->custom_roles), true, 'Should return an object containing an array called "custom_roles"');
+        $this->assertEquals(is_array($customRoles->custom_roles), true,
+            'Should return an object containing an array called "custom_roles"');
         $this->assertGreaterThan(0, $customRoles->custom_roles[0]->id, 'Returns a non-numeric id for custom_roles[0]');
         $this->assertEquals($this->client->getDebug()->lastResponseCode, '200', 'Does not return HTTP code 200');
     }

--- a/tests/Zendesk/API/LiveTests/DynamicContentTest.php
+++ b/tests/Zendesk/API/LiveTests/DynamicContentTest.php
@@ -5,19 +5,23 @@ namespace Zendesk\API\LiveTests;
 /**
  * Macros test class
  */
-class DynamicContentTest extends BasicTest {
+class DynamicContentTest extends BasicTest
+{
 
-    public function testCredentials() {
+    public function testCredentials()
+    {
         parent::credentialsTest();
     }
 
-    public function testAuthToken() {
+    public function testAuthToken()
+    {
         parent::authTokenTest();
     }
 
     protected $id;
 
-    public function setUp() {
+    public function setUp()
+    {
         $number = strval(time());
 
         $dynamicContent = $this->client->dynamicContent()->create(array(
@@ -28,20 +32,24 @@ class DynamicContentTest extends BasicTest {
         $this->assertEquals(is_object($dynamicContent), true, 'Should return an object');
         $this->assertEquals(is_object($dynamicContent->item), true, 'Should return an object called "item"');
         $this->assertGreaterThan(0, $dynamicContent->item->id, 'Returns a non-numeric id for item');
-        $this->assertEquals($dynamicContent->item->name, "Test Content Name {$number}", 'Name of test item does not match');
+        $this->assertEquals($dynamicContent->item->name, "Test Content Name {$number}",
+            'Name of test item does not match');
         $this->assertEquals('201', $this->client->getDebug()->lastResponseCode, 'Does not return HTTP code 201');
         $this->id = $dynamicContent->item->id;
     }
 
-    public function testFindAll() {
+    public function testFindAll()
+    {
         $dynamicContents = $this->client->dynamicContent()->findAll();
         $this->assertEquals(is_object($dynamicContents), true, 'Should return an object');
-        $this->assertEquals(is_array($dynamicContents->items), true, 'Should return an object containing an array called "items"');
+        $this->assertEquals(is_array($dynamicContents->items), true,
+            'Should return an object containing an array called "items"');
         $this->assertGreaterThan(0, $dynamicContents->items[0]->id, 'Returns a non-numeric id for items[0]');
         $this->assertEquals('200', $this->client->getDebug()->lastResponseCode, 'Does not return HTTP code 200');
     }
 
-    public function tearDown(){
+    public function tearDown()
+    {
         $this->assertGreaterThan(0, $this->id, 'Cannot find a item id to test with. Did setUp fail?');
         $dynamicContent = $this->client->dynamicContent($this->id)->delete();
         $this->assertEquals('200', $this->client->getDebug()->lastResponseCode, 'Does not return HTTP code 200');

--- a/tests/Zendesk/API/LiveTests/ForumSubscriptionsTest.php
+++ b/tests/Zendesk/API/LiveTests/ForumSubscriptionsTest.php
@@ -7,23 +7,28 @@ use Zendesk\API\Client;
 /**
  * ForumSubscriptions test class
  */
-class ForumSubscriptionsTest extends BasicTest {
+class ForumSubscriptionsTest extends BasicTest
+{
 
-    public function testCredentials() {
+    public function testCredentials()
+    {
         parent::credentialsTest();
     }
 
-    public function testAuthToken() {
+    public function testAuthToken()
+    {
         parent::authTokenTest();
     }
 
     protected $forum_id, $user_id, $id;
 
-    public function testCreateUser(){
+    public function testCreateUser()
+    {
 
     }
 
-    public function setUp(){
+    public function setUp()
+    {
         $forum = $this->client->forums()->create(array(
             'name' => 'My Forum',
             'forum_type' => 'articles',
@@ -39,13 +44,16 @@ class ForumSubscriptionsTest extends BasicTest {
         ));
 
         $this->assertEquals(is_object($forumSubscription), true, 'Should return an object');
-        $this->assertEquals(is_object($forumSubscription->forum_subscription), true, 'Should return an object called "forum_subscription"');
-        $this->assertGreaterThan(0, $forumSubscription->forum_subscription->id, 'Returns a non-numeric id for forum_subscription');
+        $this->assertEquals(is_object($forumSubscription->forum_subscription), true,
+            'Should return an object called "forum_subscription"');
+        $this->assertGreaterThan(0, $forumSubscription->forum_subscription->id,
+            'Returns a non-numeric id for forum_subscription');
         $this->assertEquals($this->client->getDebug()->lastResponseCode, '201', 'Does not return HTTP code 201');
         $this->id = $forumSubscription->forum_subscription->id;
     }
 
-    public function tearDown(){
+    public function tearDown()
+    {
         $this->assertGreaterThan(0, $this->id, 'Cannot find a forum subscription id to test with. Did setUp fail?');
         $view = $this->client->forums()->subscription($this->id)->delete();
         $this->assertEquals($this->client->getDebug()->lastResponseCode, '200', 'Does not return HTTP code 200');
@@ -53,18 +61,23 @@ class ForumSubscriptionsTest extends BasicTest {
         $this->client->forum($this->forum_id)->delete();
     }
 
-    public function testAll() {
+    public function testAll()
+    {
         $forumSubscriptions = $this->client->forums()->subscriptions()->findAll();
         $this->assertEquals(is_object($forumSubscriptions), true, 'Should return an object');
-        $this->assertEquals(is_array($forumSubscriptions->forum_subscriptions), true, 'Should return an object containing an array called "forum_subscriptions"');
-        $this->assertGreaterThan(0, $forumSubscriptions->forum_subscriptions[0]->id, 'Returns a non-numeric id for forum_subscriptions[0]');
+        $this->assertEquals(is_array($forumSubscriptions->forum_subscriptions), true,
+            'Should return an object containing an array called "forum_subscriptions"');
+        $this->assertGreaterThan(0, $forumSubscriptions->forum_subscriptions[0]->id,
+            'Returns a non-numeric id for forum_subscriptions[0]');
         $this->assertEquals($this->client->getDebug()->lastResponseCode, '200', 'Does not return HTTP code 200');
     }
 
-    public function testFind() {
+    public function testFind()
+    {
         $forumSubscription = $this->client->forums()->subscription($this->id)->find(); // find the one we just created
         $this->assertEquals(is_object($forumSubscription), true, 'Should return an object');
-        $this->assertGreaterThan(0, $forumSubscription->forum_subscription->id, 'Returns a non-numeric id for forum_subscription');
+        $this->assertGreaterThan(0, $forumSubscription->forum_subscription->id,
+            'Returns a non-numeric id for forum_subscription');
         $this->assertEquals($this->client->getDebug()->lastResponseCode, '200', 'Does not return HTTP code 200');
     }
 }

--- a/tests/Zendesk/API/LiveTests/ForumsTest.php
+++ b/tests/Zendesk/API/LiveTests/ForumsTest.php
@@ -7,18 +7,23 @@ use Zendesk\API\Client;
 /**
  * Forums test class
  */
-class ForumsTest extends BasicTest {
+class ForumsTest extends BasicTest
+{
 
-    public function testCredentials() {
+    public function testCredentials()
+    {
         parent::credentialsTest();
     }
 
-    public function testAuthToken() {
+    public function testAuthToken()
+    {
         parent::authTokenTest();
     }
 
     protected $id;
-    public function setUp() {
+
+    public function setUp()
+    {
         $forum = $this->client->forums()->create(array(
             'name' => 'My Forum',
             'forum_type' => 'articles',
@@ -32,22 +37,26 @@ class ForumsTest extends BasicTest {
         $this->id = $forum->forum->id;
     }
 
-    public function testAll() {
+    public function testAll()
+    {
         $forums = $this->client->forums()->findAll();
         $this->assertEquals(is_object($forums), true, 'Should return an object');
-        $this->assertEquals(is_array($forums->forums), true, 'Should return an object containing an array called "forums"');
+        $this->assertEquals(is_array($forums->forums), true,
+            'Should return an object containing an array called "forums"');
         $this->assertGreaterThan(0, $forums->forums[0]->id, 'Returns a non-numeric id for forums[0]');
         $this->assertEquals($this->client->getDebug()->lastResponseCode, '200', 'Does not return HTTP code 200');
     }
 
-    public function testFind() {
+    public function testFind()
+    {
         $forum = $this->client->forum($this->id)->find();
         $this->assertEquals(is_object($forum), true, 'Should return an object');
         $this->assertGreaterThan(0, $forum->forum->id, 'Returns a non-numeric id for forum');
         $this->assertEquals($this->client->getDebug()->lastResponseCode, '200', 'Does not return HTTP code 200');
     }
 
-    public function testUpdate() {
+    public function testUpdate()
+    {
         $forum = $this->client->forum($this->id)->update(array(
             'name' => 'My Forum II'
         ));
@@ -58,7 +67,8 @@ class ForumsTest extends BasicTest {
         $this->assertEquals($this->client->getDebug()->lastResponseCode, '200', 'Does not return HTTP code 200');
     }
 
-    public function tearDown() {
+    public function tearDown()
+    {
         $this->assertGreaterThan(0, $this->id, 'Cannot find a forum id to test with. Did setUp fail?');
         $view = $this->client->forum($this->id)->delete();
         $this->assertEquals($this->client->getDebug()->lastResponseCode, '200', 'Does not return HTTP code 200');

--- a/tests/Zendesk/API/LiveTests/GroupMembershipsTest.php
+++ b/tests/Zendesk/API/LiveTests/GroupMembershipsTest.php
@@ -7,20 +7,24 @@ use Zendesk\API\Client;
 /**
  * GroupMemberships test class
  */
-class GroupMembershipsTest extends BasicTest {
+class GroupMembershipsTest extends BasicTest
+{
 
-    public function testCredentials() {
+    public function testCredentials()
+    {
         parent::credentialsTest();
     }
 
-    public function testAuthToken() {
+    public function testAuthToken()
+    {
         parent::authTokenTest();
     }
 
     protected $id, $group_id, $user_id, $number;
 
-    public function setUp() {
-        $this->number = strval(rand(1,1000));
+    public function setUp()
+    {
+        $this->number = strval(rand(1, 1000));
         /*
          * First start by creating a topic (we'll delete it later)
          */
@@ -30,8 +34,8 @@ class GroupMembershipsTest extends BasicTest {
         $this->group_id = $group->group->id;
 
         $user = $this->client->users()->create(array(
-            'name' => 'Roger Wilco'.$this->number,
-            'email' => 'roge'.$this->number.'@example.org',
+            'name' => 'Roger Wilco' . $this->number,
+            'email' => 'roge' . $this->number . '@example.org',
             'role' => 'agent',
             'verified' => true
         ));
@@ -43,51 +47,67 @@ class GroupMembershipsTest extends BasicTest {
         ));
 
         $this->assertEquals(is_object($groupMembership), true, 'Should return an object');
-        $this->assertEquals(is_object($groupMembership->group_membership), true, 'Should return an object called "group_membership"');
-        $this->assertGreaterThan(0, $groupMembership->group_membership->id, 'Returns a non-numeric id for group_membership');
+        $this->assertEquals(is_object($groupMembership->group_membership), true,
+            'Should return an object called "group_membership"');
+        $this->assertGreaterThan(0, $groupMembership->group_membership->id,
+            'Returns a non-numeric id for group_membership');
         $this->assertEquals($this->client->getDebug()->lastResponseCode, '201', 'Does not return HTTP code 201');
         $this->id = $groupMembership->group_membership->id;
     }
 
-    public function testAll() {
+    public function testAll()
+    {
         $groupMemberships = $this->client->groupMemberships()->findAll();
         $this->assertEquals(is_object($groupMemberships), true, 'Should return an object');
-        $this->assertEquals(is_array($groupMemberships->group_memberships), true, 'Should return an object containing an array called "group_memberships"');
-        $this->assertGreaterThan(0, $groupMemberships->group_memberships[0]->id, 'Returns a non-numeric id for groups[0]');
+        $this->assertEquals(is_array($groupMemberships->group_memberships), true,
+            'Should return an object containing an array called "group_memberships"');
+        $this->assertGreaterThan(0, $groupMemberships->group_memberships[0]->id,
+            'Returns a non-numeric id for groups[0]');
         $this->assertEquals($this->client->getDebug()->lastResponseCode, '200', 'Does not return HTTP code 200');
     }
 
-    public function testAllByUser() {
+    public function testAllByUser()
+    {
         $groupMemberships = $this->client->user($this->user_id)->groupMemberships()->findAll();
         $this->assertEquals(is_object($groupMemberships), true, 'Should return an object');
-        $this->assertEquals(is_array($groupMemberships->group_memberships), true, 'Should return an object containing an array called "group_memberships"');
-        $this->assertGreaterThan(0, $groupMemberships->group_memberships[0]->id, 'Returns a non-numeric id for groups[0]');
+        $this->assertEquals(is_array($groupMemberships->group_memberships), true,
+            'Should return an object containing an array called "group_memberships"');
+        $this->assertGreaterThan(0, $groupMemberships->group_memberships[0]->id,
+            'Returns a non-numeric id for groups[0]');
         $this->assertEquals($this->client->getDebug()->lastResponseCode, '200', 'Does not return HTTP code 200');
     }
 
-    public function testAllByGroup() {
+    public function testAllByGroup()
+    {
         $groupMemberships = $this->client->group($this->group_id)->members()->findAll();
         $this->assertEquals(is_object($groupMemberships), true, 'Should return an object');
-        $this->assertEquals(is_array($groupMemberships->group_memberships), true, 'Should return an object containing an array called "group_memberships"');
-        $this->assertGreaterThan(0, $groupMemberships->group_memberships[0]->id, 'Returns a non-numeric id for groups[0]');
+        $this->assertEquals(is_array($groupMemberships->group_memberships), true,
+            'Should return an object containing an array called "group_memberships"');
+        $this->assertGreaterThan(0, $groupMemberships->group_memberships[0]->id,
+            'Returns a non-numeric id for groups[0]');
         $this->assertEquals($this->client->getDebug()->lastResponseCode, '200', 'Does not return HTTP code 200');
     }
 
-    public function testFind() {
+    public function testFind()
+    {
         $groupMembership = $this->client->groupMembership($this->id)->find(); // don't delete group membership #22534232
         $this->assertEquals(is_object($groupMembership), true, 'Should return an object');
         $this->assertGreaterThan(0, $groupMembership->group_membership->id, 'Returns a non-numeric id for group');
         $this->assertEquals($this->client->getDebug()->lastResponseCode, '200', 'Does not return HTTP code 200');
     }
 
-    public function testMakeDefault() {
+    public function testMakeDefault()
+    {
         $groupMemberships = $this->client->user($this->user_id)->groupMembership($this->id)->makeDefault();
         $this->assertEquals(is_object($groupMemberships), true, 'Should return an object');
-        $this->assertEquals(is_array($groupMemberships->group_memberships), true, 'Should return an object containing an array called "group_memberships"');
-        $this->assertGreaterThan(0, $groupMemberships->group_memberships[0]->id, 'Returns a non-numeric id for groups[0]');
+        $this->assertEquals(is_array($groupMemberships->group_memberships), true,
+            'Should return an object containing an array called "group_memberships"');
+        $this->assertGreaterThan(0, $groupMemberships->group_memberships[0]->id,
+            'Returns a non-numeric id for groups[0]');
     }
 
-    public function tearDown() {
+    public function tearDown()
+    {
         $this->assertGreaterThan(0, $this->id, 'Cannot find a group membership id to test with. Did setUP fail?');
         $view = $this->client->groupMembership($this->id)->delete();
         $this->assertEquals($this->client->getDebug()->lastResponseCode, '200', 'Does not return HTTP code 200');

--- a/tests/Zendesk/API/LiveTests/GroupsTest.php
+++ b/tests/Zendesk/API/LiveTests/GroupsTest.php
@@ -7,18 +7,23 @@ use Zendesk\API\Client;
 /**
  * Groups test class
  */
-class GroupsTest extends BasicTest {
+class GroupsTest extends BasicTest
+{
 
-    public function testCredentials() {
+    public function testCredentials()
+    {
         parent::credentialsTest();
     }
 
-    public function testAuthToken() {
+    public function testAuthToken()
+    {
         parent::authTokenTest();
     }
 
     protected $id;
-    public function setUP() {
+
+    public function setUP()
+    {
         $group = $this->client->groups()->create(array(
             'name' => 'New Group'
         ));
@@ -30,30 +35,36 @@ class GroupsTest extends BasicTest {
         $this->id = $group->group->id;
     }
 
-    public function testAll() {
+    public function testAll()
+    {
         $groups = $this->client->groups()->findAll();
         $this->assertEquals(is_object($groups), true, 'Should return an object');
-        $this->assertEquals(is_array($groups->groups), true, 'Should return an object containing an array called "groups"');
+        $this->assertEquals(is_array($groups->groups), true,
+            'Should return an object containing an array called "groups"');
         $this->assertGreaterThan(0, $groups->groups[0]->id, 'Returns a non-numeric id for groups[0]');
         $this->assertEquals($this->client->getDebug()->lastResponseCode, '200', 'Does not return HTTP code 200');
     }
 
-    public function testAssignable() {
+    public function testAssignable()
+    {
         $groups = $this->client->groups()->findAll(array('assignable' => true));
         $this->assertEquals(is_object($groups), true, 'Should return an object');
-        $this->assertEquals(is_array($groups->groups), true, 'Should return an object containing an array called "groups"');
+        $this->assertEquals(is_array($groups->groups), true,
+            'Should return an object containing an array called "groups"');
         $this->assertGreaterThan(0, $groups->groups[0]->id, 'Returns a non-numeric id for groups[0]');
         $this->assertEquals($this->client->getDebug()->lastResponseCode, '200', 'Does not return HTTP code 200');
     }
 
-    public function testFind() {
+    public function testFind()
+    {
         $group = $this->client->group($this->id)->find();
         $this->assertEquals(is_object($group), true, 'Should return an object');
         $this->assertGreaterThan(0, $group->group->id, 'Returns a non-numeric id for group');
         $this->assertEquals($this->client->getDebug()->lastResponseCode, '200', 'Does not return HTTP code 200');
     }
 
-    public function testUpdate() {
+    public function testUpdate()
+    {
         $group = $this->client->group($this->id)->update(array(
             'name' => 'New Group II'
         ));
@@ -64,7 +75,8 @@ class GroupsTest extends BasicTest {
         $this->assertEquals($this->client->getDebug()->lastResponseCode, '200', 'Does not return HTTP code 200');
     }
 
-    public function tearDown() {
+    public function tearDown()
+    {
         $this->assertGreaterThan(0, $this->id, 'Cannot find a group id to test with. Did setUP fail?');
         $view = $this->client->group($this->id)->delete();
         $this->assertEquals($this->client->getDebug()->lastResponseCode, '200', 'Does not return HTTP code 200');

--- a/tests/Zendesk/API/LiveTests/JobStatusesTest.php
+++ b/tests/Zendesk/API/LiveTests/JobStatusesTest.php
@@ -7,20 +7,24 @@ use Zendesk\API\Client;
 /**
  * JobStatuses test class
  */
-class JobStatusesTest extends BasicTest {
+class JobStatusesTest extends BasicTest
+{
 
-    public function testCredentials() {
+    public function testCredentials()
+    {
         parent::credentialsTest();
     }
 
-    public function testAuthToken() {
+    public function testAuthToken()
+    {
         parent::authTokenTest();
     }
 
-    public function testFind() {
+    public function testFind()
+    {
         $testTicket = array(
             'subject' => 'The quick brown fox jumps over the lazy dog',
-            'comment' => array (
+            'comment' => array(
                 'body' => 'Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.'
             ),
             'priority' => 'normal'
@@ -28,7 +32,7 @@ class JobStatusesTest extends BasicTest {
         $ticket = $this->client->tickets()->create($testTicket);
         $ticket2 = $this->client->tickets()->create($testTicket);
 
-        $testUpdateTicket['id'] = array($ticket->ticket->id,$ticket2->ticket->id);
+        $testUpdateTicket['id'] = array($ticket->ticket->id, $ticket2->ticket->id);
         $testUpdateTicket['subject'] = 'Updated subject';
         $testUpdateTicket['priority'] = 'urgent';
 

--- a/tests/Zendesk/API/LiveTests/LocalesTest.php
+++ b/tests/Zendesk/API/LiveTests/LocalesTest.php
@@ -7,17 +7,21 @@ use Zendesk\API\Client;
 /**
  * Locals test class
  */
-class LocalsTest extends BasicTest {
+class LocalsTest extends BasicTest
+{
 
-    public function testCredentials() {
+    public function testCredentials()
+    {
         parent::credentialsTest();
     }
 
-    public function testAuthToken() {
+    public function testAuthToken()
+    {
         parent::authTokenTest();
     }
 
-    public function testAll() {
+    public function testAll()
+    {
         $locales = $this->client->locales()->findAll();
         $this->assertEquals(is_object($locales), true, 'Should return an object');
         $this->assertEquals(is_array($locales->locales), true, 'Should return an array of objects called "locales"');
@@ -25,7 +29,8 @@ class LocalsTest extends BasicTest {
         $this->assertEquals($this->client->getDebug()->lastResponseCode, '200', 'Does not return HTTP code 200');
     }
 
-    public function testAgent() {
+    public function testAgent()
+    {
         $locales = $this->client->locales()->agent();
         $this->assertEquals(is_object($locales), true, 'Should return an object');
         $this->assertEquals(is_array($locales->locales), true, 'Should return an array of objects called "locales"');
@@ -33,7 +38,8 @@ class LocalsTest extends BasicTest {
         $this->assertEquals($this->client->getDebug()->lastResponseCode, '200', 'Does not return HTTP code 200');
     }
 
-    public function testCurrent() {
+    public function testCurrent()
+    {
         $locale = $this->client->locales()->current();
         $this->assertEquals(is_object($locale), true, 'Should return an object');
         $this->assertEquals(is_object($locale->locale), true, 'Should return an object called "locale"');
@@ -41,7 +47,8 @@ class LocalsTest extends BasicTest {
         $this->assertEquals($this->client->getDebug()->lastResponseCode, '200', 'Does not return HTTP code 200');
     }
 
-    public function testFind() {
+    public function testFind()
+    {
         $locale = $this->client->locale(1)->find();
         $this->assertEquals(is_object($locale), true, 'Should return an object');
         $this->assertEquals(is_object($locale->locale), true, 'Should return an object called "locale"');
@@ -49,7 +56,8 @@ class LocalsTest extends BasicTest {
         $this->assertEquals($this->client->getDebug()->lastResponseCode, '200', 'Does not return HTTP code 200');
     }
 
-    public function testDetectBest() {
+    public function testDetectBest()
+    {
         $locale = $this->client->locales()->detectBest(array('available_locales' => array('en', 'js', 'es')));
         $this->assertEquals(is_object($locale), true, 'Should return an object');
         $this->assertEquals(is_object($locale->locale), true, 'Should return an object called "locale"');

--- a/tests/Zendesk/API/LiveTests/MacrosTest.php
+++ b/tests/Zendesk/API/LiveTests/MacrosTest.php
@@ -7,19 +7,23 @@ use Zendesk\API\Client;
 /**
  * Macros test class
  */
-class MacrosTest extends BasicTest {
+class MacrosTest extends BasicTest
+{
 
-    public function testCredentials() {
+    public function testCredentials()
+    {
         parent::credentialsTest();
     }
 
-    public function testAuthToken() {
+    public function testAuthToken()
+    {
         parent::authTokenTest();
     }
 
     protected $id;
 
-    public function setUp() {
+    public function setUp()
+    {
         $macro = $this->client->macros()->create(array(
             'title' => 'Roger Wilco',
             'actions' => array(
@@ -37,30 +41,36 @@ class MacrosTest extends BasicTest {
         $this->id = $macro->macro->id;
     }
 
-    public function testAll() {
+    public function testAll()
+    {
         $macros = $this->client->macros()->findAll();
         $this->assertEquals(is_object($macros), true, 'Should return an object');
-        $this->assertEquals(is_array($macros->macros), true, 'Should return an object containing an array called "macros"');
+        $this->assertEquals(is_array($macros->macros), true,
+            'Should return an object containing an array called "macros"');
         $this->assertGreaterThan(0, $macros->macros[0]->id, 'Returns a non-numeric id for macros[0]');
         $this->assertEquals($this->client->getDebug()->lastResponseCode, '200', 'Does not return HTTP code 200');
     }
 
-    public function testActive() {
+    public function testActive()
+    {
         $macros = $this->client->macros()->findAll(array('active' => true));
         $this->assertEquals(is_object($macros), true, 'Should return an object');
-        $this->assertEquals(is_array($macros->macros), true, 'Should return an object containing an array called "macros"');
+        $this->assertEquals(is_array($macros->macros), true,
+            'Should return an object containing an array called "macros"');
         $this->assertGreaterThan(0, $macros->macros[0]->id, 'Returns a non-numeric id for macros[0]');
         $this->assertEquals($this->client->getDebug()->lastResponseCode, '200', 'Does not return HTTP code 200');
     }
 
-    public function testFind() {
+    public function testFind()
+    {
         $macro = $this->client->macros($this->id)->find();
         $this->assertEquals(is_object($macro), true, 'Should return an object');
         $this->assertGreaterThan(0, $macro->macro->id, 'Returns a non-numeric id for macro');
         $this->assertEquals($this->client->getDebug()->lastResponseCode, '200', 'Does not return HTTP code 200');
     }
 
-    public function testUpdate() {
+    public function testUpdate()
+    {
         $macro = $this->client->macro($this->id)->update(array(
             'title' => 'Roger Wilco II'
         ));
@@ -71,7 +81,8 @@ class MacrosTest extends BasicTest {
         $this->assertEquals($this->client->getDebug()->lastResponseCode, '200', 'Does not return HTTP code 200');
     }
 
-    public function tearDown(){
+    public function tearDown()
+    {
         $this->assertGreaterThan(0, $this->id, 'Cannot find a macro id to test with. Did setUp fail?');
         $topic = $this->client->macro($this->id)->delete();
         $this->assertEquals($this->client->getDebug()->lastResponseCode, '200', 'Does not return HTTP code 200');

--- a/tests/Zendesk/API/LiveTests/OAuthClientsTest.php
+++ b/tests/Zendesk/API/LiveTests/OAuthClientsTest.php
@@ -7,68 +7,78 @@ use Zendesk\API\Client;
 /**
  * OAuthClients test class
  */
-class OAuthClientsTest extends BasicTest {
+class OAuthClientsTest extends BasicTest
+{
 
-    public function testCredentials() {
+    public function testCredentials()
+    {
         parent::credentialsTest();
     }
 
-    public function testAuthToken() {
+    public function testAuthToken()
+    {
         parent::authTokenTest();
     }
 
     protected $id, $user_id, $number;
 
-    public function setUP() {
+    public function setUP()
+    {
         $this->number = strval(time());
         $user = $this->client->users()->create(array(
-            'name' => 'Roger Wilco'.$this->number,
-            'email' => 'roge'.$this->number.'@example.org',
+            'name' => 'Roger Wilco' . $this->number,
+            'email' => 'roge' . $this->number . '@example.org',
             'role' => 'agent',
             'verified' => true
         ));
         $this->user_id = $user->user->id;
 
         $client = $this->client->oauthClients()->create(array(
-            'name' => 'Test Client'.$this->number,
+            'name' => 'Test Client' . $this->number,
             'identifier' => md5(time()),
             'user_id' => $this->user_id
         ));
         $this->assertEquals(is_object($client), true, 'Should return an object');
         $this->assertEquals(is_object($client->client), true, 'Should return an object called "client"');
         $this->assertGreaterThan(0, $client->client->id, 'Returns a non-numeric id for client');
-        $this->assertEquals($client->client->name, 'Test Client'.$this->number, 'Name of test client does not match');
+        $this->assertEquals($client->client->name, 'Test Client' . $this->number, 'Name of test client does not match');
         $this->assertEquals($this->client->getDebug()->lastResponseCode, '201', 'Does not return HTTP code 201');
         $this->id = $client->client->id;
     }
 
-    public function testAll() {
+    public function testAll()
+    {
         $clients = $this->client->oauthClients()->findAll();
         $this->assertEquals(is_object($clients), true, 'Should return an object');
-        $this->assertEquals(is_array($clients->clients), true, 'Should return an object containing an array called "clients"');
+        $this->assertEquals(is_array($clients->clients), true,
+            'Should return an object containing an array called "clients"');
         $this->assertGreaterThan(0, $clients->clients[0]->id, 'Returns a non-numeric id for clients[0]');
         $this->assertEquals($this->client->getDebug()->lastResponseCode, '200', 'Does not return HTTP code 200');
     }
 
-    public function testFind() {
+    public function testFind()
+    {
         $client = $this->client->oauthClient($this->id)->find();
         $this->assertEquals(is_object($client), true, 'Should return an object');
         $this->assertGreaterThan(0, $client->client->id, 'Returns a non-numeric id for client');
         $this->assertEquals($this->client->getDebug()->lastResponseCode, '200', 'Does not return HTTP code 200');
     }
 
-    public function testUpdate() {
+    public function testUpdate()
+    {
         $client = $this->client->oauthClient($this->id)->update(array(
-            'name' => 'New Client Name'.$this->number
+            'name' => 'New Client Name' . $this->number
         ));
         $this->assertEquals(is_object($client), true, 'Should return an object');
         $this->assertEquals(is_object($client->client), true, 'Should return an object called "client"');
         $this->assertGreaterThan(0, $client->client->id, 'Returns a non-numeric id for client');
-        $this->assertEquals($client->client->name, 'New Client Name'.$this->number, 'Name of test client does not match');
+        $this->assertEquals($client->client->name, 'New Client Name' . $this->number,
+            'Name of test client does not match');
         $this->assertEquals($this->client->getDebug()->lastResponseCode, '200', 'Does not return HTTP code 200');
     }
 
-    public function tearDown() {
+    public function tearDown()
+    {
         $this->assertGreaterThan(0, $this->id, 'Cannot find a client id to test with. Did setUp fail?');
         $topic = $this->client->oauthClient($this->id)->delete();
         $this->assertEquals($this->client->getDebug()->lastResponseCode, '200', 'Does not return HTTP code 200');

--- a/tests/Zendesk/API/LiveTests/OAuthTokensTest.php
+++ b/tests/Zendesk/API/LiveTests/OAuthTokensTest.php
@@ -7,26 +7,31 @@ use Zendesk\API\Client;
 /**
  * OAuthTokens test class
  */
-class OAuthTokensTest extends BasicTest {
+class OAuthTokensTest extends BasicTest
+{
 
-    public function testCredentials() {
+    public function testCredentials()
+    {
         parent::credentialsTest();
     }
 
-    public function testAuthToken() {
+    public function testAuthToken()
+    {
         parent::authTokenTest();
     }
 
     /**
      * @depends testAuthToken
      */
-    public function testAll() {
+    public function testAll()
+    {
         $this->markTestSkipped(
             'Since there\'s no way to create a token programmatically, we can\'t test testAll'
         );
         $tokens = $this->client->oauthTokens()->findAll();
         $this->assertEquals(is_object($tokens), true, 'Should return an object');
-        $this->assertEquals(is_array($tokens->tokens), true, 'Should return an object containing an array called "tokens"');
+        $this->assertEquals(is_array($tokens->tokens), true,
+            'Should return an object containing an array called "tokens"');
         $this->assertGreaterThan(0, $tokens->tokens[0]->id, 'Returns a non-numeric id for tokens[0]');
         $this->assertEquals($this->client->getDebug()->lastResponseCode, '200', 'Does not return HTTP code 200');
     }
@@ -34,7 +39,8 @@ class OAuthTokensTest extends BasicTest {
     /**
      * @depends testAuthToken
      */
-    public function testFind() {
+    public function testFind()
+    {
         $this->markTestSkipped(
             'Since there\'s no way to create a token programmatically, we can\'t test testFind'
         );
@@ -48,7 +54,8 @@ class OAuthTokensTest extends BasicTest {
     /**
      * @depends testAuthToken
      */
-    public function testRevoke() {
+    public function testRevoke()
+    {
         $this->markTestSkipped(
             'Since there\'s no way to create a token programmatically, we can\'t test revoke'
         );

--- a/tests/Zendesk/API/LiveTests/OrganizationFieldsTest.php
+++ b/tests/Zendesk/API/LiveTests/OrganizationFieldsTest.php
@@ -7,67 +7,85 @@ use Zendesk\API\Client;
 /**
  * OrganizationFields test class
  */
-class OrganizationFieldsTest extends BasicTest {
+class OrganizationFieldsTest extends BasicTest
+{
 
-    public function testCredentials() {
+    public function testCredentials()
+    {
         parent::credentialsTest();
     }
 
-    public function testAuthToken() {
+    public function testAuthToken()
+    {
         parent::authTokenTest();
     }
 
     protected $id;
 
-    public function setUp() {
+    public function setUp()
+    {
         $organizationFields = $this->client->organizationFields()->create(array(
             'type' => 'text',
             'title' => 'Support description',
             'description' => 'This field describes the support plan this user has',
             'position' => 0,
             'active' => true,
-            'key' => 'support_description'.date("YmdHis")
+            'key' => 'support_description' . date("YmdHis")
         ));
         $this->assertEquals(is_object($organizationFields), true, 'Should return an object');
-        $this->assertEquals(is_object($organizationFields->organization_field), true, 'Should return an object called "organization_field"');
-        $this->assertGreaterThan(0, $organizationFields->organization_field->id, 'Returns a non-numeric id for organization_field');
-        $this->assertEquals($organizationFields->organization_field->title, 'Support description', 'Name of test organization field does not match');
+        $this->assertEquals(is_object($organizationFields->organization_field), true,
+            'Should return an object called "organization_field"');
+        $this->assertGreaterThan(0, $organizationFields->organization_field->id,
+            'Returns a non-numeric id for organization_field');
+        $this->assertEquals($organizationFields->organization_field->title, 'Support description',
+            'Name of test organization field does not match');
         $this->assertEquals($this->client->getDebug()->lastResponseCode, '201', 'Does not return HTTP code 201');
         $this->id = $organizationFields->organization_field->id;
     }
 
-    public function testAll() {
+    public function testAll()
+    {
         $organizationFields = $this->client->organizationFields()->findAll();
         $this->assertEquals(is_object($organizationFields), true, 'Should return an object');
-        $this->assertEquals(is_array($organizationFields->organization_fields), true, 'Should return an object containing an array called "organization_fields"');
-        $this->assertGreaterThan(0, $organizationFields->organization_fields[0]->id, 'Returns a non-numeric id for organization_fields[0]');
+        $this->assertEquals(is_array($organizationFields->organization_fields), true,
+            'Should return an object containing an array called "organization_fields"');
+        $this->assertGreaterThan(0, $organizationFields->organization_fields[0]->id,
+            'Returns a non-numeric id for organization_fields[0]');
         $this->assertEquals($this->client->getDebug()->lastResponseCode, '200', 'Does not return HTTP code 200');
     }
 
-    public function testFind() {
+    public function testFind()
+    {
         $organizationField = $this->client->organizationField($this->id)->find();
         $this->assertEquals(is_object($organizationField), true, 'Should return an object');
-        $this->assertGreaterThan(0, $organizationField->organization_field->id, 'Returns a non-numeric id for organization_field');
+        $this->assertGreaterThan(0, $organizationField->organization_field->id,
+            'Returns a non-numeric id for organization_field');
         $this->assertEquals($this->client->getDebug()->lastResponseCode, '200', 'Does not return HTTP code 200');
     }
 
-    public function testUpdate() {
+    public function testUpdate()
+    {
         $organizationField = $this->client->organizationField($this->id)->update(array(
             'title' => 'Roger Wilco II'
         ));
         $this->assertEquals(is_object($organizationField), true, 'Should return an object');
-        $this->assertEquals(is_object($organizationField->organization_field), true, 'Should return an object called "organization_field"');
-        $this->assertGreaterThan(0, $organizationField->organization_field->id, 'Returns a non-numeric id for organization_field');
-        $this->assertEquals($organizationField->organization_field->title, 'Roger Wilco II', 'Title of test organization field does not match');
+        $this->assertEquals(is_object($organizationField->organization_field), true,
+            'Should return an object called "organization_field"');
+        $this->assertGreaterThan(0, $organizationField->organization_field->id,
+            'Returns a non-numeric id for organization_field');
+        $this->assertEquals($organizationField->organization_field->title, 'Roger Wilco II',
+            'Title of test organization field does not match');
         $this->assertEquals($this->client->getDebug()->lastResponseCode, '200', 'Does not return HTTP code 200');
     }
 
-    public function testReorder() {
+    public function testReorder()
+    {
         $result = $this->client->organizationFields()->reorder(array('organization_field_ids' => array(14382, 14342)));
         $this->assertEquals($this->client->getDebug()->lastResponseCode, '200', 'Does not return HTTP code 200');
     }
 
-    public function tearDown() {
+    public function tearDown()
+    {
         $this->assertGreaterThan(0, $this->id, 'Cannot find an organization field id to test with. Did setUp fail?');
         $organizationField = $this->client->organizationField($this->id)->delete();
         $this->assertEquals($this->client->getDebug()->lastResponseCode, '200', 'Does not return HTTP code 200');

--- a/tests/Zendesk/API/LiveTests/OrganizationsTest.php
+++ b/tests/Zendesk/API/LiveTests/OrganizationsTest.php
@@ -7,79 +7,99 @@ use Zendesk\API\Client;
 /**
  * Organizations test class
  */
-class OrganizationsTest extends BasicTest {
+class OrganizationsTest extends BasicTest
+{
 
-    public function testCredentials() {
+    public function testCredentials()
+    {
         parent::credentialsTest();
     }
 
-    public function testAuthToken() {
+    public function testAuthToken()
+    {
         parent::authTokenTest();
     }
 
     protected $id, $number;
 
-    public function setUP() {
+    public function setUP()
+    {
         $this->number = strval(time());
         $organization = $this->client->organizations()->create(array(
-            'name' => 'My New Organization'.$this->number
+            'name' => 'My New Organization' . $this->number
         ));
         $this->assertEquals(is_object($organization), true, 'Should return an object');
-        $this->assertEquals(is_object($organization->organization), true, 'Should return an object called "organization"');
+        $this->assertEquals(is_object($organization->organization), true,
+            'Should return an object called "organization"');
         $this->assertGreaterThan(0, $organization->organization->id, 'Returns a non-numeric id for organization');
-        $this->assertEquals($organization->organization->name, 'My New Organization'.$this->number, 'Name of test organization does not match');
+        $this->assertEquals($organization->organization->name, 'My New Organization' . $this->number,
+            'Name of test organization does not match');
         $this->assertEquals($this->client->getDebug()->lastResponseCode, '201', 'Does not return HTTP code 201');
         $this->id = $organization->organization->id;
     }
 
-    public function testAll() {
+    public function testAll()
+    {
         $organizations = $this->client->organizations()->findAll();
         $this->assertEquals(is_object($organizations), true, 'Should return an object');
-        $this->assertEquals(is_array($organizations->organizations), true, 'Should return an object containing an array called "organizations"');
-        $this->assertGreaterThan(0, $organizations->organizations[0]->id, 'Returns a non-numeric id for organizations[0]');
+        $this->assertEquals(is_array($organizations->organizations), true,
+            'Should return an object containing an array called "organizations"');
+        $this->assertGreaterThan(0, $organizations->organizations[0]->id,
+            'Returns a non-numeric id for organizations[0]');
         $this->assertEquals($this->client->getDebug()->lastResponseCode, '200', 'Does not return HTTP code 200');
     }
 
-    public function testFind() {
+    public function testFind()
+    {
         $organization = $this->client->organization($this->id)->find();
         $this->assertEquals(is_object($organization), true, 'Should return an object');
         $this->assertGreaterThan(0, $organization->organization->id, 'Returns a non-numeric id for organization');
         $this->assertEquals($this->client->getDebug()->lastResponseCode, '200', 'Does not return HTTP code 200');
     }
 
-    public function testUpdate() {
+    public function testUpdate()
+    {
         $organization = $this->client->organization($this->id)->update(array(
             'name' => 'My Organization II'
         ));
         $this->assertEquals(is_object($organization), true, 'Should return an object');
-        $this->assertEquals(is_object($organization->organization), true, 'Should return an object called "organization"');
+        $this->assertEquals(is_object($organization->organization), true,
+            'Should return an object called "organization"');
         $this->assertGreaterThan(0, $organization->organization->id, 'Returns a non-numeric id for organization');
-        $this->assertEquals($organization->organization->name, 'My Organization II', 'Name of test organization does not match');
+        $this->assertEquals($organization->organization->name, 'My Organization II',
+            'Name of test organization does not match');
         $this->assertEquals($this->client->getDebug()->lastResponseCode, '200', 'Does not return HTTP code 200');
     }
 
-    public function testRelated() {
+    public function testRelated()
+    {
         $organizationRelated = $this->client->organization($this->id)->related();
         $this->assertEquals(is_object($organizationRelated), true, 'Should return an object');
-        $this->assertEquals(is_object($organizationRelated->organization_related), true, 'Should return an object containing an array called "organization_related"');
+        $this->assertEquals(is_object($organizationRelated->organization_related), true,
+            'Should return an object containing an array called "organization_related"');
         $this->assertEquals($this->client->getDebug()->lastResponseCode, '200', 'Does not return HTTP code 200');
     }
 
-    public function testSearch() {
+    public function testSearch()
+    {
         $organizations = $this->client->organizations()->search(array('external_id' => 'my'));
         $this->assertEquals(is_object($organizations), true, 'Should return an object');
-        $this->assertEquals(is_array($organizations->organizations), true, 'Should return an object containing an array called "organizations"');
+        $this->assertEquals(is_array($organizations->organizations), true,
+            'Should return an object containing an array called "organizations"');
         $this->assertEquals($this->client->getDebug()->lastResponseCode, '200', 'Does not return HTTP code 200');
     }
 
-    public function testAutocomplete() {
+    public function testAutocomplete()
+    {
         $organizations = $this->client->organizations()->autocomplete(array('name' => 'rog'));
         $this->assertEquals(is_object($organizations), true, 'Should return an object');
-        $this->assertEquals(is_array($organizations->organizations), true, 'Should return an object containing an array called "organizations"');
+        $this->assertEquals(is_array($organizations->organizations), true,
+            'Should return an object containing an array called "organizations"');
         $this->assertEquals($this->client->getDebug()->lastResponseCode, '200', 'Does not return HTTP code 200');
     }
 
-    public function tearDown() {
+    public function tearDown()
+    {
         $this->assertGreaterThan(0, $this->id, 'Cannot find an organization id to test with. Did setUp fail?');
         $organization = $this->client->organization($this->id)->delete();
         $this->assertEquals($this->client->getDebug()->lastResponseCode, '200', 'Does not return HTTP code 200');

--- a/tests/Zendesk/API/LiveTests/PushNotificationDevicesTest.php
+++ b/tests/Zendesk/API/LiveTests/PushNotificationDevicesTest.php
@@ -7,10 +7,12 @@ use Zendesk\API\Client;
 /**
  * PushNotificationDevices test class
  */
-class PushNotificationDevicesTest extends BasicTest {
+class PushNotificationDevicesTest extends BasicTest
+{
 
-    public function testDelete() {
-        $devices = array("token1","token2","token3");
+    public function testDelete()
+    {
+        $devices = array("token1", "token2", "token3");
         $deleted = $this->client->push_notification_devices()->delete($devices);
         $this->assertEquals(true, $deleted, 'Returns true on success');
     }

--- a/tests/Zendesk/API/LiveTests/RequestsTest.php
+++ b/tests/Zendesk/API/LiveTests/RequestsTest.php
@@ -7,19 +7,23 @@ use Zendesk\API\Client;
 /**
  * Requests test class
  */
-class RequestsTest extends BasicTest {
+class RequestsTest extends BasicTest
+{
 
-    public function testCredentials() {
+    public function testCredentials()
+    {
         parent::credentialsTest();
     }
 
-    public function testAuthToken() {
+    public function testAuthToken()
+    {
         parent::authTokenTest();
     }
 
     protected $id;
 
-    public function setUP() {
+    public function setUP()
+    {
         $request = $this->client->requests()->create(array(
             'subject' => 'Help!',
             'comment' => array(
@@ -30,19 +34,24 @@ class RequestsTest extends BasicTest {
         $this->assertEquals(is_object($request->request), true, 'Should return an object called "request"');
         $this->assertGreaterThan(0, $request->request->id, 'Returns a non-numeric id for request');
         $this->assertEquals($request->request->subject, 'Help!', 'Subject of test request does not match');
-        $this->assertEquals($request->request->description, 'My printer is on fire!', 'Description of test request does not match');
+        $this->assertEquals($request->request->description, 'My printer is on fire!',
+            'Description of test request does not match');
         $this->assertEquals($this->client->getDebug()->lastResponseCode, '201', 'Does not return HTTP code 201');
         $this->id = $request->request->id;
     }
-    public function testAll() {
+
+    public function testAll()
+    {
         $requests = $this->client->requests()->findAll();
         $this->assertEquals(is_object($requests), true, 'Should return an object');
-        $this->assertEquals(is_array($requests->requests), true, 'Should return an object containing an array called "requests"');
+        $this->assertEquals(is_array($requests->requests), true,
+            'Should return an object containing an array called "requests"');
         $this->assertGreaterThan(0, $requests->requests[0]->id, 'Returns a non-numeric id for requests[0]');
         $this->assertEquals($this->client->getDebug()->lastResponseCode, '200', 'Does not return HTTP code 200');
     }
 
-    public function testFind() {
+    public function testFind()
+    {
         $request = $this->client->request($this->id)->find();
         $this->assertEquals(is_object($request), true, 'Should return an object');
         $this->assertEquals(is_object($request->request), true, 'Should return an object called "request"');
@@ -50,7 +59,8 @@ class RequestsTest extends BasicTest {
         $this->assertEquals($this->client->getDebug()->lastResponseCode, '200', 'Does not return HTTP code 200');
     }
 
-    public function testUpdate() {
+    public function testUpdate()
+    {
         $request = $this->client->request($this->id)->update(array(
             'comment' => array(
                 'body' => 'Thanks!'
@@ -65,15 +75,18 @@ class RequestsTest extends BasicTest {
         $this->assertEquals($this->client->getDebug()->lastResponseCode, '200', 'Does not return HTTP code 200');
     }
 
-    public function testComments() {
+    public function testComments()
+    {
         $comments = $this->client->request($this->id)->comments()->findAll();
         $this->assertEquals(is_object($comments), true, 'Should return an object');
-        $this->assertEquals(is_array($comments->comments), true, 'Should return an object containing an array called "comments"');
+        $this->assertEquals(is_array($comments->comments), true,
+            'Should return an object containing an array called "comments"');
         $this->assertGreaterThan(0, $comments->comments[0]->id, 'Returns a non-numeric id for comments[0]');
         $this->assertEquals($this->client->getDebug()->lastResponseCode, '200', 'Does not return HTTP code 200');
     }
 
-    public function testFindComment() {
+    public function testFindComment()
+    {
         $comment_id = $this->client->request($this->id)->comments()->findAll()->comments[0]->id;
         $comment = $this->client->request($this->id)->comment($comment_id)->find();
         $this->assertEquals(is_object($comment), true, 'Should return an object');
@@ -82,7 +95,8 @@ class RequestsTest extends BasicTest {
         $this->assertEquals($this->client->getDebug()->lastResponseCode, '200', 'Does not return HTTP code 200');
     }
 
-    public function tearDown(){
+    public function tearDown()
+    {
         $this->client->ticket($this->id)->delete();
     }
 

--- a/tests/Zendesk/API/LiveTests/SatisfactionRatingsTest.php
+++ b/tests/Zendesk/API/LiveTests/SatisfactionRatingsTest.php
@@ -7,15 +7,18 @@ use Zendesk\API\Client;
 /**
  * SatisfactionRatings test class
  */
-class SatisfactionRatingsTest extends BasicTest {
+class SatisfactionRatingsTest extends BasicTest
+{
 
-    public function testCredentials() {
+    public function testCredentials()
+    {
         parent::credentialsTest();
     }
 
     protected $id, $ticket_id;
 
-    public function setUp() {
+    public function setUp()
+    {
 
         // Auth as end user
         $username = getenv('END_USER_USERNAME');
@@ -25,7 +28,7 @@ class SatisfactionRatingsTest extends BasicTest {
 
         $testTicket = array(
             'subject' => 'Satisfaction Ratings Test',
-            'comment' => array (
+            'comment' => array(
                 'body' => 'Dette er for tilfredshed ratings test.'
             ),
             'priority' => 'normal'
@@ -42,29 +45,37 @@ class SatisfactionRatingsTest extends BasicTest {
             'comment' => 'Awesome support'
         ));
         $this->assertEquals(is_object($rating), true, 'Should return an object');
-        $this->assertEquals(is_object($rating->satisfaction_rating), true, 'Should return an object called "satisfaction_rating"');
-        $this->assertGreaterThan(0, $rating->satisfaction_rating->id, 'Returns a non-numeric id for satisfaction_rating');
+        $this->assertEquals(is_object($rating->satisfaction_rating), true,
+            'Should return an object called "satisfaction_rating"');
+        $this->assertGreaterThan(0, $rating->satisfaction_rating->id,
+            'Returns a non-numeric id for satisfaction_rating');
         $this->assertEquals($rating->satisfaction_rating->score, 'good', 'Score of test rating does not match');
         $this->assertEquals($client_end_user->getDebug()->lastResponseCode, '200', 'Does not return HTTP code 200');
         $this->id = $rating->satisfaction_rating->id;
     }
 
-    public function testAll() {
+    public function testAll()
+    {
         $ratings = $this->client->ticket($this->ticket_id)->satisfactionRatings()->findAll();
         $this->assertEquals(is_object($ratings), true, 'Should return an object');
-        $this->assertEquals(is_array($ratings->satisfaction_ratings), true, 'Should return an object containing an array called "satisfaction_ratings"');
-        $this->assertGreaterThan(0, $ratings->satisfaction_ratings[0]->id, 'Returns a non-numeric id for satisfaction_ratings[0]');
+        $this->assertEquals(is_array($ratings->satisfaction_ratings), true,
+            'Should return an object containing an array called "satisfaction_ratings"');
+        $this->assertGreaterThan(0, $ratings->satisfaction_ratings[0]->id,
+            'Returns a non-numeric id for satisfaction_ratings[0]');
         $this->assertEquals($this->client->getDebug()->lastResponseCode, '200', 'Does not return HTTP code 200');
     }
 
-    public function testFind() {
+    public function testFind()
+    {
         $rating = $this->client->ticket($this->ticket_id)->satisfactionRating($this->id)->find();
         $this->assertEquals(is_object($rating), true, 'Should return an object');
-        $this->assertGreaterThan(0, $rating->satisfaction_rating->id, 'Returns a non-numeric id for satisfaction_rating');
+        $this->assertGreaterThan(0, $rating->satisfaction_rating->id,
+            'Returns a non-numeric id for satisfaction_rating');
         $this->assertEquals($this->client->getDebug()->lastResponseCode, '200', 'Does not return HTTP code 200');
     }
 
-    public function tearDown(){
+    public function tearDown()
+    {
         $this->client->ticket($this->ticket_id)->delete();
     }
 

--- a/tests/Zendesk/API/LiveTests/SearchTest.php
+++ b/tests/Zendesk/API/LiveTests/SearchTest.php
@@ -7,41 +7,50 @@ use Zendesk\API\Client;
 /**
  * Search test class
  */
-class SearchTest extends BasicTest {
+class SearchTest extends BasicTest
+{
 
     protected $ticket_id;
 
-    public function testCredentials() {
+    public function testCredentials()
+    {
         parent::credentialsTest();
     }
 
-    public function testAuthToken() {
+    public function testAuthToken()
+    {
         parent::authTokenTest();
     }
 
     /*
      * Needs an existed ticket with the specified query keyword to test all Search functions
      */
-    public function testSearch() {
+    public function testSearch()
+    {
         $results = $this->client->search(array('query' => 'hello'));
         $this->assertEquals(is_object($results), true, 'Should return an object');
-        $this->assertEquals(is_array($results->results), true, 'Should return an object containing an array called "results"');
+        $this->assertEquals(is_array($results->results), true,
+            'Should return an object containing an array called "results"');
         $this->assertGreaterThan(0, $results->results[0]->id, 'Returns a non-numeric id for results[0]');
         $this->assertEquals($this->client->getDebug()->lastResponseCode, '200', 'Does not return HTTP code 200');
     }
 
-    public function testComplexSearch() {
+    public function testComplexSearch()
+    {
         $results = $this->client->search(array('query' => 'status<solved type:ticket'));
         $this->assertEquals(is_object($results), true, 'Should return an object');
-        $this->assertEquals(is_array($results->results), true, 'Should return an object containing an array called "results"');
+        $this->assertEquals(is_array($results->results), true,
+            'Should return an object containing an array called "results"');
         $this->assertGreaterThan(0, $results->results[0]->id, 'Returns a non-numeric id for results[0]');
         $this->assertEquals($this->client->getDebug()->lastResponseCode, '200', 'Does not return HTTP code 200');
     }
 
-    public function testAnonymousSearch() {
+    public function testAnonymousSearch()
+    {
         $results = $this->client->anonymousSearch(array('query' => 'hello'));
         $this->assertEquals(is_object($results), true, 'Should return an object');
-        $this->assertEquals(is_array($results->results), true, 'Should return an object containing an array called "results"');
+        $this->assertEquals(is_array($results->results), true,
+            'Should return an object containing an array called "results"');
         $this->assertGreaterThan(0, $results->results[0]->id, 'Returns a non-numeric id for results[0]');
         $this->assertEquals($this->client->getDebug()->lastResponseCode, '200', 'Does not return HTTP code 200');
     }

--- a/tests/Zendesk/API/LiveTests/SettingsTest.php
+++ b/tests/Zendesk/API/LiveTests/SettingsTest.php
@@ -7,24 +7,29 @@ use Zendesk\API\Client;
 /**
  * Settings test class
  */
-class SettingsTest extends BasicTest {
+class SettingsTest extends BasicTest
+{
 
-    public function testCredentials() {
+    public function testCredentials()
+    {
         parent::credentialsTest();
     }
 
-    public function testAuthToken() {
+    public function testAuthToken()
+    {
         parent::authTokenTest();
     }
 
-    public function testAll() {
+    public function testAll()
+    {
         $settings = $this->client->settings()->findAll();
         $this->assertEquals(is_object($settings), true, 'Should return an object');
         $this->assertEquals(is_object($settings->settings), true, 'Should return an object called "settings"');
         $this->assertEquals($this->client->getDebug()->lastResponseCode, '200', 'Does not return HTTP code 200');
     }
 
-    public function testUpdate() {
+    public function testUpdate()
+    {
         $settings = $this->client->settings()->update(array(
             'lotus' => array(
                 'prefer_lotus' => false

--- a/tests/Zendesk/API/LiveTests/SharingAgreementsTest.php
+++ b/tests/Zendesk/API/LiveTests/SharingAgreementsTest.php
@@ -7,20 +7,25 @@ use Zendesk\API\Client;
 /**
  * SharingAgreements test class
  */
-class SharingAgreementsTest extends BasicTest {
+class SharingAgreementsTest extends BasicTest
+{
 
-    public function testCredentials() {
+    public function testCredentials()
+    {
         parent::credentialsTest();
     }
 
-    public function testAuthToken() {
+    public function testAuthToken()
+    {
         parent::authTokenTest();
     }
 
-    public function testAll() {
+    public function testAll()
+    {
         $agreements = $this->client->sharingAgreements()->findAll();
         $this->assertEquals(is_object($agreements), true, 'Should return an object');
-        $this->assertEquals(is_array($agreements->sharing_agreements), true, 'Should return an array of objects called "sharing_agreements"');
+        $this->assertEquals(is_array($agreements->sharing_agreements), true,
+            'Should return an array of objects called "sharing_agreements"');
         $this->assertEquals($this->client->getDebug()->lastResponseCode, '200', 'Does not return HTTP code 200');
     }
 

--- a/tests/Zendesk/API/LiveTests/SuspendedTicketsTest.php
+++ b/tests/Zendesk/API/LiveTests/SuspendedTicketsTest.php
@@ -7,37 +7,46 @@ use Zendesk\API\Client;
 /**
  * SuspendedTickets test class
  */
-class SuspendedTicketsTest extends BasicTest {
+class SuspendedTicketsTest extends BasicTest
+{
 
-    public function testCredentials() {
+    public function testCredentials()
+    {
         parent::credentialsTest();
     }
 
-    public function testAuthToken() {
+    public function testAuthToken()
+    {
         parent::authTokenTest();
     }
 
     /*
      * Need at least one suspend ticket for this test.
      */
-    public function testAll() {
+    public function testAll()
+    {
         $tickets = $this->client->suspendedTickets()->findAll();
         $this->assertEquals(is_object($tickets), true, 'Should return an object');
-        $this->assertEquals(is_array($tickets->suspended_tickets), true, 'Should return an object containing an array called "suspended_tickets"');
-        $this->assertGreaterThan(0, $tickets->suspended_tickets[0]->id, 'Returns a non-numeric id for suspended_tickets[0]');
+        $this->assertEquals(is_array($tickets->suspended_tickets), true,
+            'Should return an object containing an array called "suspended_tickets"');
+        $this->assertGreaterThan(0, $tickets->suspended_tickets[0]->id,
+            'Returns a non-numeric id for suspended_tickets[0]');
         $this->assertEquals($this->client->getDebug()->lastResponseCode, '200', 'Does not return HTTP code 200');
     }
 
-    public function testFind() {
+    public function testFind()
+    {
         $id = $this->client->suspendedTickets()->findAll()->suspended_tickets[0]->id;
         $ticket = $this->client->suspendedTicket($id)->find();
         $this->assertEquals(is_object($ticket), true, 'Should return an object');
-        $this->assertEquals(is_object($ticket->suspended_ticket), true, 'Should return an object called "suspended_ticket"');
+        $this->assertEquals(is_object($ticket->suspended_ticket), true,
+            'Should return an object called "suspended_ticket"');
         $this->assertGreaterThan(0, $ticket->suspended_ticket->id, 'Returns a non-numeric id for view');
         $this->assertEquals($this->client->getDebug()->lastResponseCode, '200', 'Does not return HTTP code 200');
     }
 
-    public function testRecover() {
+    public function testRecover()
+    {
         $this->markTestSkipped(
             'The only way to recover a ticket is to suspend it first (but that would result in a suspended user too)'
         );
@@ -48,7 +57,8 @@ class SuspendedTicketsTest extends BasicTest {
         $this->assertEquals($this->client->getDebug()->lastResponseCode, '200', 'Does not return HTTP code 200');
     }
 
-    public function testDelete() {
+    public function testDelete()
+    {
         $this->markTestSkipped(
             'The only way to delete a suspended ticket is to suspend it first (but that would result in a suspended user too)'
         );

--- a/tests/Zendesk/API/LiveTests/TagsTest.php
+++ b/tests/Zendesk/API/LiveTests/TagsTest.php
@@ -8,24 +8,29 @@ use Zendesk\API\Client;
 /**
  * Tags test class
  */
-class TagsTest extends BasicTest {
+class TagsTest extends BasicTest
+{
 
-    public function testCredentials() {
+    public function testCredentials()
+    {
         parent::credentialsTest();
     }
 
-    public function testAuthToken() {
+    public function testAuthToken()
+    {
         parent::authTokenTest();
     }
 
     protected $ticket_id;
-    public function setUp() {
+
+    public function setUp()
+    {
         /*
          * First start by creating a topic (we'll delete it later)
          */
         $testTicket = array(
             'subject' => 'This is for tag test',
-            'comment' => array (
+            'comment' => array(
                 'body' => 'Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.'
             ),
             'priority' => 'normal'
@@ -42,14 +47,16 @@ class TagsTest extends BasicTest {
         $this->assertEquals($this->client->getDebug()->lastResponseCode, '201', 'Does not return HTTP code 201');
     }
 
-    public function testAll() {
+    public function testAll()
+    {
         $tags = $this->client->tags()->findAll();
         $this->assertEquals(is_object($tags), true, 'Should return an object');
         $this->assertEquals(is_array($tags->tags), true, 'Should return an array called "tags"');
         $this->assertEquals($this->client->getDebug()->lastResponseCode, '200', 'Does not return HTTP code 200');
     }
 
-    public function testUpdate() {
+    public function testUpdate()
+    {
         $tags = $this->client->ticket($this->ticket_id)->tags()->update(array('tags' => array('customer')));
         $this->assertEquals(is_object($tags), true, 'Should return an object');
         $this->assertEquals(is_array($tags->tags), true, 'Should return an array called "tags"');
@@ -57,7 +64,8 @@ class TagsTest extends BasicTest {
         $this->assertEquals($this->client->getDebug()->lastResponseCode, '200', 'Does not return HTTP code 200');
     }
 
-    public function testFind() {
+    public function testFind()
+    {
         $tags = $this->client->ticket($this->ticket_id)->tags()->find();
         $this->assertEquals(is_object($tags), true, 'Should return an object');
         $this->assertEquals(is_array($tags->tags), true, 'Should return an array called "tags"');
@@ -65,15 +73,16 @@ class TagsTest extends BasicTest {
         $this->assertEquals($this->client->getDebug()->lastResponseCode, '200', 'Does not return HTTP code 200');
     }
 
-    public function tearDown() {
+    public function tearDown()
+    {
         $tags = $this->client->ticket($this->ticket_id)->tags()->delete(array('tags' => 'customer'));
         $this->assertEquals(is_object($tags), true, 'Should return an object');
         $this->assertEquals(is_array($tags->tags), true, 'Should return an array called "tags"');
         $this->assertEquals(in_array('important', $tags->tags), true, 'Added tag does not exist');
         $this->assertEquals($this->client->getDebug()->lastResponseCode, '200', 'Does not return HTTP code 200');
-         /*
-         * Clean-up
-         */
+        /*
+        * Clean-up
+        */
         $this->client->ticket($this->ticket_id)->delete();
     }
 

--- a/tests/Zendesk/API/LiveTests/TargetsTest.php
+++ b/tests/Zendesk/API/LiveTests/TargetsTest.php
@@ -7,19 +7,23 @@ use Zendesk\API\Client;
 /**
  * Targets test class
  */
-class TargetsTest extends BasicTest {
+class TargetsTest extends BasicTest
+{
 
-    public function testCredentials() {
+    public function testCredentials()
+    {
         parent::credentialsTest();
     }
 
-    public function testAuthToken() {
+    public function testAuthToken()
+    {
         parent::authTokenTest();
     }
 
     protected $id;
 
-    public function setUp() {
+    public function setUp()
+    {
         $target = $this->client->targets()->create(array(
             'type' => 'email_target',
             'title' => 'Test Email Target',
@@ -34,22 +38,26 @@ class TargetsTest extends BasicTest {
         $this->id = $target->target->id;
     }
 
-    public function testAll() {
+    public function testAll()
+    {
         $targets = $this->client->targets()->findAll();
         $this->assertEquals(is_object($targets), true, 'Should return an object');
-        $this->assertEquals(is_array($targets->targets), true, 'Should return an object containing an array called "targets"');
+        $this->assertEquals(is_array($targets->targets), true,
+            'Should return an object containing an array called "targets"');
         $this->assertGreaterThan(0, $targets->targets[0]->id, 'Returns a non-numeric id for targets[0]');
         $this->assertEquals($this->client->getDebug()->lastResponseCode, '200', 'Does not return HTTP code 200');
     }
 
-    public function testFind() {
+    public function testFind()
+    {
         $target = $this->client->target($this->id)->find();
         $this->assertEquals(is_object($target), true, 'Should return an object');
         $this->assertGreaterThan(0, $target->target->id, 'Returns a non-numeric id for target');
         $this->assertEquals($this->client->getDebug()->lastResponseCode, '200', 'Does not return HTTP code 200');
     }
 
-    public function testUpdate() {
+    public function testUpdate()
+    {
         $target = $this->client->target($this->id)->update(array(
             'email' => 'roger@example.com'
         ));
@@ -60,7 +68,8 @@ class TargetsTest extends BasicTest {
         $this->assertEquals($this->client->getDebug()->lastResponseCode, '200', 'Does not return HTTP code 200');
     }
 
-    public function tearDown() {
+    public function tearDown()
+    {
         $this->assertGreaterThan(0, $this->id, 'Cannot find a target id to test with. Did setUp fail?');
         $result = $this->client->target($this->id)->delete();
         $this->assertEquals($this->client->getDebug()->lastResponseCode, '200', 'Does not return HTTP code 200');

--- a/tests/Zendesk/API/LiveTests/TicketAuditsTest.php
+++ b/tests/Zendesk/API/LiveTests/TicketAuditsTest.php
@@ -7,22 +7,26 @@ use Zendesk\API\Client;
 /**
  * Ticket Audits test class
  */
-class TicketAuditsTest extends BasicTest {
+class TicketAuditsTest extends BasicTest
+{
 
-    public function testCredentials() {
+    public function testCredentials()
+    {
         parent::credentialsTest();
     }
 
-    public function testAuthToken() {
+    public function testAuthToken()
+    {
         parent::authTokenTest();
     }
 
     protected $ticket_id;
 
-    public function setUp(){
+    public function setUp()
+    {
         $testTicket = array(
             'subject' => 'The quick brown fox jumps over the lazy dog',
-            'comment' => array (
+            'comment' => array(
                 'body' => 'Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.'
             ),
             'priority' => 'normal'
@@ -37,35 +41,51 @@ class TicketAuditsTest extends BasicTest {
         $this->ticket_id = $ticket->ticket->id;
 
     }
-    public function testAll() {
+
+    public function testAll()
+    {
         $audits = $this->client->ticket($this->ticket_id)->audits()->findAll();
         $this->assertEquals(is_object($audits), true, 'Should return an object');
-        $this->assertEquals(is_array($audits->audits), true, 'Should return an object containing an array called "audits"');
+        $this->assertEquals(is_array($audits->audits), true,
+            'Should return an object containing an array called "audits"');
         $this->assertGreaterThan(0, $audits->audits[0]->id, 'Returns a non-numeric id in first audit');
         $this->assertEquals($this->client->getDebug()->lastResponseCode, '200', 'Does not return HTTP code 200');
     }
 
-    public function testAllSideLoadedMethod() {
+    public function testAllSideLoadedMethod()
+    {
         $audits = $this->client->ticket($this->ticket_id)->sideload(array('users', 'groups'))->audits()->findAll();
         $this->assertEquals(is_object($audits), true, 'Should return an object');
-        $this->assertEquals(is_array($audits->users), true, 'Should return an object containing an array called "users"');
-        $this->assertEquals(is_array($audits->groups), true, 'Should return an object containing an array called "groups"');
+        $this->assertEquals(is_array($audits->users), true,
+            'Should return an object containing an array called "users"');
+        $this->assertEquals(is_array($audits->groups), true,
+            'Should return an object containing an array called "groups"');
         $this->assertEquals($this->client->getDebug()->lastResponseCode, '200', 'Does not return HTTP code 200');
     }
 
-    public function testAllSideLoadedParameter() {
-        $audits = $this->client->ticket($this->ticket_id)->audits()->findAll(array('sideload' => array('users', 'groups')));
+    public function testAllSideLoadedParameter()
+    {
+        $audits = $this->client->ticket($this->ticket_id)->audits()->findAll(array(
+            'sideload' => array(
+                'users',
+                'groups'
+            )
+        ));
         $this->assertEquals(is_object($audits), true, 'Should return an object');
-        $this->assertEquals(is_array($audits->users), true, 'Should return an object containing an array called "users"');
-        $this->assertEquals(is_array($audits->groups), true, 'Should return an object containing an array called "groups"');
+        $this->assertEquals(is_array($audits->users), true,
+            'Should return an object containing an array called "users"');
+        $this->assertEquals(is_array($audits->groups), true,
+            'Should return an object containing an array called "groups"');
         $this->assertEquals($this->client->getDebug()->lastResponseCode, '200', 'Does not return HTTP code 200');
     }
 
-    public function testFind() {
+    public function testFind()
+    {
         $audit_id = $this->client->ticket($this->ticket_id)->audits()->findAll()->audits[0]->id;
         $audits = $this->client->ticket($this->ticket_id)->audit($audit_id)->find();
         $this->assertEquals(is_object($audits), true, 'Should return an object');
-        $this->assertEquals(is_object($audits->audit), true, 'Should return an object containing an array called "audit"');
+        $this->assertEquals(is_object($audits->audit), true,
+            'Should return an object containing an array called "audit"');
         $this->assertEquals($audit_id, $audits->audit->id, 'Returns an incorrect id in audit object');
         $this->assertEquals($this->client->getDebug()->lastResponseCode, '200', 'Does not return HTTP code 200');
     }
@@ -78,7 +98,8 @@ class TicketAuditsTest extends BasicTest {
     //     $this->assertEquals($this->client->getDebug()->lastResponseCode, '200', 'Does not return HTTP code 200');
     // }
 
-    public function tearDown(){
+    public function tearDown()
+    {
         $this->client->tickets($this->ticket_id)->delete();
     }
 

--- a/tests/Zendesk/API/LiveTests/TicketCommentsTest.php
+++ b/tests/Zendesk/API/LiveTests/TicketCommentsTest.php
@@ -7,22 +7,26 @@ use Zendesk\API\Client;
 /**
  * Ticket Comments test class
  */
-class TicketCommentsTest extends BasicTest {
+class TicketCommentsTest extends BasicTest
+{
 
-    public function testCredentials() {
+    public function testCredentials()
+    {
         parent::credentialsTest();
     }
 
-    public function testAuthToken() {
+    public function testAuthToken()
+    {
         parent::authTokenTest();
     }
 
     protected $ticket_id;
 
-    public function setUp(){
+    public function setUp()
+    {
         $testTicket = array(
             'subject' => 'Ticket comment test',
-            'comment' => array (
+            'comment' => array(
                 'body' => 'Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.'
             ),
             'priority' => 'normal'
@@ -31,10 +35,12 @@ class TicketCommentsTest extends BasicTest {
         $this->ticket_id = $ticket->ticket->id;
     }
 
-    public function testAll() {
+    public function testAll()
+    {
         $comments = $this->client->ticket($this->ticket_id)->comments()->findAll();
         $this->assertEquals(is_object($comments), true, 'Should return an object');
-        $this->assertEquals(is_array($comments->comments), true, 'Should return an object containing an array called "comments"');
+        $this->assertEquals(is_array($comments->comments), true,
+            'Should return an object containing an array called "comments"');
         $this->assertGreaterThan(0, $comments->comments[0]->id, 'Returns a non-numeric id in first audit');
         $this->assertEquals($this->client->getDebug()->lastResponseCode, '200', 'Does not return HTTP code 200');
     }
@@ -42,13 +48,15 @@ class TicketCommentsTest extends BasicTest {
     /*
      * Test make private
      */
-    public function testMakePrivate() {
+    public function testMakePrivate()
+    {
         $comment_id = $this->client->ticket($this->ticket_id)->comments()->findAll()->comments[0]->id;
         $comments = $this->client->ticket($this->ticket_id)->comments($comment_id)->makePrivate();
         $this->assertEquals($this->client->getDebug()->lastResponseCode, '200', 'Does not return HTTP code 200');
     }
 
-    public function tearDown(){
+    public function tearDown()
+    {
         $this->client->tickets($this->ticket_id)->delete();
     }
 

--- a/tests/Zendesk/API/LiveTests/TicketFieldsTest.php
+++ b/tests/Zendesk/API/LiveTests/TicketFieldsTest.php
@@ -7,19 +7,23 @@ use Zendesk\API\Client;
 /**
  * Ticket Audits test class
  */
-class TicketFieldsTest extends BasicTest {
+class TicketFieldsTest extends BasicTest
+{
 
-    public function testCredentials() {
+    public function testCredentials()
+    {
         parent::credentialsTest();
     }
 
-    public function testAuthToken() {
+    public function testAuthToken()
+    {
         parent::authTokenTest();
     }
 
     protected $id;
 
-    public function setUp() {
+    public function setUp()
+    {
         $field = $this->client->ticketFields()->create(array(
             'type' => 'text',
             'title' => 'Age'
@@ -33,15 +37,18 @@ class TicketFieldsTest extends BasicTest {
         $this->id = $field->ticket_field->id;
     }
 
-    public function testAll() {
+    public function testAll()
+    {
         $fields = $this->client->ticketFields()->findAll();
         $this->assertEquals(is_object($fields), true, 'Should return an object');
-        $this->assertEquals(is_array($fields->ticket_fields), true, 'Should return an object containing an array called "ticket_fields"');
+        $this->assertEquals(is_array($fields->ticket_fields), true,
+            'Should return an object containing an array called "ticket_fields"');
         $this->assertGreaterThan(0, $fields->ticket_fields[0]->id, 'Returns a non-numeric id in first ticket field');
         $this->assertEquals($this->client->getDebug()->lastResponseCode, '200', 'Does not return HTTP code 200');
     }
 
-    public function testFind() {
+    public function testFind()
+    {
         $fields = $this->client->ticketField($this->id)->find();
         $this->assertEquals(is_object($fields), true, 'Should return an object');
         $this->assertEquals(is_object($fields->ticket_field), true, 'Should return an object called "ticket_field"');
@@ -49,7 +56,8 @@ class TicketFieldsTest extends BasicTest {
         $this->assertEquals($this->client->getDebug()->lastResponseCode, '200', 'Does not return HTTP code 200');
     }
 
-    public function testUpdate() {
+    public function testUpdate()
+    {
         $field = $this->client->ticketField($this->id)->update(array(
             'title' => 'Another value'
         ));
@@ -61,7 +69,8 @@ class TicketFieldsTest extends BasicTest {
         $this->assertEquals($this->client->getDebug()->lastResponseCode, '200', 'Does not return HTTP code 200');
     }
 
-    public function tearDown() {
+    public function tearDown()
+    {
         $field = $this->client->ticketField($this->id)->delete();
         $this->assertEquals($this->client->getDebug()->lastResponseCode, '200', 'Does not return HTTP code 200');
     }

--- a/tests/Zendesk/API/LiveTests/TicketFormsTest.php
+++ b/tests/Zendesk/API/LiveTests/TicketFormsTest.php
@@ -7,19 +7,23 @@ use Zendesk\API\Client;
 /**
  * Ticket Audits test class
  */
-class TicketFormsTest extends BasicTest {
+class TicketFormsTest extends BasicTest
+{
 
-    public function testCredentials() {
+    public function testCredentials()
+    {
         parent::credentialsTest();
     }
 
-    public function testAuthToken() {
+    public function testAuthToken()
+    {
         parent::authTokenTest();
     }
 
     protected $id;
 
-    public function setUP() {
+    public function setUP()
+    {
         $form = $this->client->ticketForms()->create(array(
             'name' => 'Snowboard Problem',
             'end_user_visible' => true,
@@ -32,30 +36,36 @@ class TicketFormsTest extends BasicTest {
         $this->assertEquals(is_object($form->ticket_form), true, 'Should return an object called "ticket_form"');
         $this->assertGreaterThan(0, $form->ticket_form->id, 'Returns a non-numeric id for ticket_form');
         $this->assertEquals($form->ticket_form->name, 'Snowboard Problem', 'Name of test ticket form does not match');
-        $this->assertEquals($form->ticket_form->display_name, 'Snowboard Damage', 'Display name of test ticket form does not match');
+        $this->assertEquals($form->ticket_form->display_name, 'Snowboard Damage',
+            'Display name of test ticket form does not match');
         $this->assertEquals($this->client->getDebug()->lastResponseCode, '201', 'Does not return HTTP code 201');
         $this->id = $form->ticket_form->id;
     }
 
-    public function tearDown() {
+    public function tearDown()
+    {
         /*
          * First deactivate, then delete
          */
         $response = $this->client->ticketForm($this->id)->deactivate();
-        $this->assertEquals($this->client->getDebug()->lastResponseCode, '200', 'Deactivate does not return HTTP code 200');
+        $this->assertEquals($this->client->getDebug()->lastResponseCode, '200',
+            'Deactivate does not return HTTP code 200');
         $form = $this->client->ticketForm($this->id)->delete();
         $this->assertEquals($this->client->getDebug()->lastResponseCode, '200', 'Delete does not return HTTP code 200');
     }
 
-    public function testAll() {
+    public function testAll()
+    {
         $forms = $this->client->ticketForms()->findAll();
         $this->assertEquals(is_object($forms), true, 'Should return an object');
-        $this->assertEquals(is_array($forms->ticket_forms), true, 'Should return an object containing an array called "ticket_forms"');
+        $this->assertEquals(is_array($forms->ticket_forms), true,
+            'Should return an object containing an array called "ticket_forms"');
         $this->assertGreaterThan(0, $forms->ticket_forms[0]->id, 'Returns a non-numeric id in first ticket form');
         $this->assertEquals($this->client->getDebug()->lastResponseCode, '200', 'Does not return HTTP code 200');
     }
 
-    public function testFind() {
+    public function testFind()
+    {
         $forms = $this->client->ticketForm($this->id)->find(); // ticket form #9881 must never be deleted
         $this->assertEquals(is_object($forms), true, 'Should return an object');
         $this->assertEquals(is_object($forms->ticket_form), true, 'Should return an object called "ticket_form"');
@@ -63,7 +73,8 @@ class TicketFormsTest extends BasicTest {
         $this->assertEquals($this->client->getDebug()->lastResponseCode, '200', 'Does not return HTTP code 200');
     }
 
-    public function testUpdate() {
+    public function testUpdate()
+    {
         $form = $this->client->ticketForm($this->id)->update(array(
             'name' => 'Snowboard Fixed',
             'display_name' => 'Snowboard has been fixed'
@@ -72,17 +83,20 @@ class TicketFormsTest extends BasicTest {
         $this->assertEquals(is_object($form->ticket_form), true, 'Should return an object called "ticket_form"');
         $this->assertGreaterThan(0, $form->ticket_form->id, 'Returns a non-numeric id for ticket_form');
         $this->assertEquals($form->ticket_form->name, 'Snowboard Fixed', 'Name of test ticket form does not match');
-        $this->assertEquals($form->ticket_form->display_name, 'Snowboard has been fixed', 'Display name of test ticket form does not match');
+        $this->assertEquals($form->ticket_form->display_name, 'Snowboard has been fixed',
+            'Display name of test ticket form does not match');
         $this->assertEquals($this->client->getDebug()->lastResponseCode, '200', 'Does not return HTTP code 200');
         $id = $form->ticket_form->id;
         $stack = array($id);
+
         return $stack;
     }
 
-    public function testReorder() {
+    public function testReorder()
+    {
         $allForms = $this->client->ticketForms()->findAll();
         $allIds = array();
-        while(list($k, $form) = each($allForms->ticket_forms)) {
+        while (list($k, $form) = each($allForms->ticket_forms)) {
             $allIds[] = $form->id;
         }
         array_unshift($allIds, array_pop($allIds));
@@ -90,17 +104,20 @@ class TicketFormsTest extends BasicTest {
         $this->assertEquals($this->client->getDebug()->lastResponseCode, '200', 'Does not return HTTP code 200');
     }
 
-    public function testClone() {
+    public function testClone()
+    {
         $form = $this->client->ticketForm($this->id)->cloneForm();
         $this->assertEquals(is_object($form), true, 'Should return an object');
         $this->assertEquals(is_object($form->ticket_form), true, 'Should return an object called "ticket_form"');
         $this->assertGreaterThan(0, $form->ticket_form->id, 'Returns a non-numeric id for ticket_form');
         $this->assertEquals($form->ticket_form->name, 'Snowboard Problem', 'Name of test ticket form does not match');
-        $this->assertEquals($form->ticket_form->display_name, 'Snowboard Damage', 'Display name of test ticket form does not match');
+        $this->assertEquals($form->ticket_form->display_name, 'Snowboard Damage',
+            'Display name of test ticket form does not match');
         $this->assertEquals($this->client->getDebug()->lastResponseCode, '201', 'Does not return HTTP code 201');
         $id = $form->ticket_form->id;
         $response = $this->client->ticketForm($id)->deactivate();
-        $this->assertEquals($this->client->getDebug()->lastResponseCode, '200', 'Deactivate does not return HTTP code 200');
+        $this->assertEquals($this->client->getDebug()->lastResponseCode, '200',
+            'Deactivate does not return HTTP code 200');
         $form = $this->client->ticketForm($id)->delete();
         $this->assertEquals($this->client->getDebug()->lastResponseCode, '200', 'Delete does not return HTTP code 200');
     }

--- a/tests/Zendesk/API/LiveTests/TicketImportTest.php
+++ b/tests/Zendesk/API/LiveTests/TicketImportTest.php
@@ -7,17 +7,21 @@ use Zendesk\API\Client;
 /**
  * Ticket Imports test class
  */
-class TicketImportTest extends BasicTest {
+class TicketImportTest extends BasicTest
+{
 
-    public function testCredentials() {
+    public function testCredentials()
+    {
         parent::credentialsTest();
     }
 
-    public function testAuthToken() {
+    public function testAuthToken()
+    {
         parent::authTokenTest();
     }
 
-    public function testImport() {
+    public function testImport()
+    {
         /*
          * Create the user first, and we'll delete it later
          */
@@ -40,7 +44,8 @@ class TicketImportTest extends BasicTest {
         $this->assertEquals(is_object($confirm->ticket), true, 'Should return an object called "ticket"');
         $this->assertGreaterThan(0, $confirm->ticket->id, 'Returns a non-numeric id for ticket');
         $this->assertEquals($confirm->ticket->subject, 'Help', 'Subject of test ticket does not match');
-        $this->assertEquals($confirm->ticket->description, 'A description', 'Description of test ticket does not match');
+        $this->assertEquals($confirm->ticket->description, 'A description',
+            'Description of test ticket does not match');
         $this->assertEquals($this->client->getDebug()->lastResponseCode, '201', 'Does not return HTTP code 201');
 
         $this->client->user($author_id)->delete();

--- a/tests/Zendesk/API/LiveTests/TicketMetricsTest.php
+++ b/tests/Zendesk/API/LiveTests/TicketMetricsTest.php
@@ -7,22 +7,26 @@ use Zendesk\API\Client;
 /**
  * Ticket Metrics test class
  */
-class TicketMetricsTest extends BasicTest {
+class TicketMetricsTest extends BasicTest
+{
 
-    public function testCredentials() {
+    public function testCredentials()
+    {
         parent::credentialsTest();
     }
 
-    public function testAuthToken() {
+    public function testAuthToken()
+    {
         parent::authTokenTest();
     }
 
     protected $ticket_id;
 
-    public function setUP(){
+    public function setUP()
+    {
         $testTicket = array(
             'subject' => 'Ticket Metrics test',
-            'comment' => array (
+            'comment' => array(
                 'body' => 'Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.'
             ),
             'priority' => 'normal'
@@ -31,19 +35,23 @@ class TicketMetricsTest extends BasicTest {
         $this->ticket_id = $ticket->ticket->id;
     }
 
-    public function tearDown(){
+    public function tearDown()
+    {
         $this->client->ticket($this->ticket_id)->delete();
     }
 
-    public function testAll() {
+    public function testAll()
+    {
         $metrics = $this->client->tickets()->metrics()->findAll();
         $this->assertEquals(is_object($metrics), true, 'Should return an object');
-        $this->assertEquals(is_array($metrics->ticket_metrics), true, 'Should return an object containing an array called "ticket_metrics"');
+        $this->assertEquals(is_array($metrics->ticket_metrics), true,
+            'Should return an object containing an array called "ticket_metrics"');
         $this->assertGreaterThan(0, $metrics->ticket_metrics[0]->id, 'Returns a non-numeric id for ticket_metrics[0]');
         $this->assertEquals($this->client->getDebug()->lastResponseCode, '200', 'Does not return HTTP code 200');
     }
 
-    public function testFind() {
+    public function testFind()
+    {
         $metrics_id = $this->client->tickets()->metrics()->findAll()->ticket_metrics[0]->id;
         $metric = $this->client->tickets()->metric($metrics_id)->find();
         $this->assertEquals(is_object($metric), true, 'Should return an object');

--- a/tests/Zendesk/API/LiveTests/TicketsTest.php
+++ b/tests/Zendesk/API/LiveTests/TicketsTest.php
@@ -7,25 +7,31 @@ use Zendesk\API\Client;
 /**
  * Tickets test class
  */
-class TicketsTest extends BasicTest {
+class TicketsTest extends BasicTest
+{
 
-    public function testCredentials() {
+    public function testCredentials()
+    {
         parent::credentialsTest();
-        $this->assertEquals($this->password != '', true, 'Expecting $this->password parameter; does phpunit.xml exist?');
+        $this->assertEquals($this->password != '', true,
+            'Expecting $this->password parameter; does phpunit.xml exist?');
         //$this->assertEquals($_ENV['OAUTH_TOKEN'] != '', true, 'Expecting _ENV[OAUTH_TOKEN] parameter; does phpunit.xml exist?');
     }
 
-    public function testAuthToken() {
+    public function testAuthToken()
+    {
         parent::authTokenTest();
     }
 
-    public function testAuthPassword() {
+    public function testAuthPassword()
+    {
         $this->client->setAuth('password', $this->password);
         $tickets = $this->client->tickets()->findAll();
         $this->assertEquals($this->client->getDebug()->lastResponseCode, '200', 'Does not return HTTP code 200');
     }
 
-    public function testAuthOAuth() {
+    public function testAuthOAuth()
+    {
         $this->markTestSkipped(
             'Sskip this test first, because it needs an OAth Token'
         );
@@ -36,10 +42,11 @@ class TicketsTest extends BasicTest {
 
     protected $testTicket;
 
-    public function setUP() {
+    public function setUP()
+    {
         $this->testTicket = array(
             'subject' => 'The quick brown fox jumps over the lazy dog',
-            'comment' => array (
+            'comment' => array(
                 'body' => 'Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.'
             ),
             'priority' => 'normal'
@@ -48,48 +55,62 @@ class TicketsTest extends BasicTest {
         $this->assertEquals(is_object($ticket), true, 'Should return an object');
         $this->assertEquals(is_object($ticket->ticket), true, 'Should return an object called "ticket"');
         $this->assertGreaterThan(0, $ticket->ticket->id, 'Returns a non-numeric id for ticket');
-        $this->assertEquals($ticket->ticket->subject, $this->testTicket['subject'], 'Subject of test ticket does not match');
-        $this->assertEquals($ticket->ticket->description, $this->testTicket['comment']['body'], 'Description of test ticket does not match');
-        $this->assertEquals($ticket->ticket->priority, $this->testTicket['priority'], 'Priority of test ticket does not match');
+        $this->assertEquals($ticket->ticket->subject, $this->testTicket['subject'],
+            'Subject of test ticket does not match');
+        $this->assertEquals($ticket->ticket->description, $this->testTicket['comment']['body'],
+            'Description of test ticket does not match');
+        $this->assertEquals($ticket->ticket->priority, $this->testTicket['priority'],
+            'Priority of test ticket does not match');
         $this->assertEquals($this->client->getDebug()->lastResponseCode, '201', 'Does not return HTTP code 201');
         $this->testTicket['id'] = $ticket->ticket->id;
     }
 
-    public function testAll() {
+    public function testAll()
+    {
         $tickets = $this->client->tickets()->findAll();
         $this->assertEquals(is_object($tickets), true, 'Should return an object');
-        $this->assertEquals(is_array($tickets->tickets), true, 'Should return an object containing an array called "tickets"');
+        $this->assertEquals(is_array($tickets->tickets), true,
+            'Should return an object containing an array called "tickets"');
         $this->assertGreaterThan(0, $tickets->tickets[0]->id, 'Returns a non-numeric id in first ticket');
-        $this->assertContains($tickets->tickets[0]->priority, array (null, 'low', 'normal', 'high', 'urgent'), 'Returns an invalid priority in first ticket');
+        $this->assertContains($tickets->tickets[0]->priority, array(null, 'low', 'normal', 'high', 'urgent'),
+            'Returns an invalid priority in first ticket');
         $this->assertEquals($this->client->getDebug()->lastResponseCode, '200', 'Does not return HTTP code 200');
     }
 
-    public function testAllSideLoadedMethod() {
+    public function testAllSideLoadedMethod()
+    {
         $tickets = $this->client->tickets()->sideload(array('users', 'groups'))->findAll();
         $this->assertEquals(is_object($tickets), true, 'Should return an object');
-        $this->assertEquals(is_array($tickets->users), true, 'Should return an object containing an array called "users"');
-        $this->assertEquals(is_array($tickets->groups), true, 'Should return an object containing an array called "groups"');
+        $this->assertEquals(is_array($tickets->users), true,
+            'Should return an object containing an array called "users"');
+        $this->assertEquals(is_array($tickets->groups), true,
+            'Should return an object containing an array called "groups"');
         $this->assertEquals($this->client->getDebug()->lastResponseCode, '200', 'Does not return HTTP code 200');
     }
 
-    public function testAllSideLoadedParameter() {
+    public function testAllSideLoadedParameter()
+    {
         $tickets = $this->client->tickets()->findAll(array('sideload' => array('users', 'groups')));
         $this->assertEquals(is_object($tickets), true, 'Should return an object');
-        $this->assertEquals(is_array($tickets->users), true, 'Should return an object containing an array called "users"');
-        $this->assertEquals(is_array($tickets->groups), true, 'Should return an object containing an array called "groups"');
+        $this->assertEquals(is_array($tickets->users), true,
+            'Should return an object containing an array called "users"');
+        $this->assertEquals(is_array($tickets->groups), true,
+            'Should return an object containing an array called "groups"');
         $this->assertEquals($this->client->getDebug()->lastResponseCode, '200', 'Does not return HTTP code 200');
     }
 
-    public function testFindSingle() {
+    public function testFindSingle()
+    {
         $tickets = $this->client->ticket($this->testTicket['id'])->find();
         $this->assertEquals(is_object($tickets->ticket), true, 'Should return an object called "ticket"');
         $this->assertEquals($this->client->getDebug()->lastResponseCode, '200', 'Does not return HTTP code 200');
     }
 
-    public function testFindMultiple() {
+    public function testFindMultiple()
+    {
         $testTicket = array(
             'subject' => 'The second ticket',
-            'comment' => array (
+            'comment' => array(
                 'body' => 'Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.'
             ),
             'priority' => 'normal'
@@ -99,12 +120,14 @@ class TicketsTest extends BasicTest {
         $tickets = $this->client->tickets(array($this->testTicket['id'], $ticket2->ticket->id))->find();
         $this->assertEquals(is_object($tickets), true, 'Should return an object');
         $this->assertEquals(is_array($tickets->tickets), true, 'Should return an array called "tickets"');
-        $this->assertEquals(is_object($tickets->tickets[0]), true, 'Should return an object as first "tickets" array element');
+        $this->assertEquals(is_object($tickets->tickets[0]), true,
+            'Should return an object as first "tickets" array element');
         $this->assertEquals($this->client->getDebug()->lastResponseCode, '200', 'Does not return HTTP code 200');
         $this->client->ticket($ticket2->ticket->id)->delete();
     }
 
-    public function testUpdate() {
+    public function testUpdate()
+    {
         $testTicket = $this->testTicket;
         $this->assertGreaterThan(0, $testTicket['id'], 'Cannot find a ticket id to test with. Did setUp fail?');
         $testTicket['subject'] = 'Updated subject';
@@ -113,16 +136,19 @@ class TicketsTest extends BasicTest {
         $this->assertEquals(is_object($ticket->ticket), true, 'Should return an object called "ticket"');
         $this->assertGreaterThan(0, $ticket->ticket->id, 'Returns a non-numeric id for ticket');
         $this->assertEquals($ticket->ticket->subject, $testTicket['subject'], 'Subject of test ticket does not match');
-        $this->assertEquals($ticket->ticket->description, $testTicket['comment']['body'], 'Description of test ticket does not match');
-        $this->assertEquals($ticket->ticket->priority, $testTicket['priority'], 'Priority of test ticket does not match');
+        $this->assertEquals($ticket->ticket->description, $testTicket['comment']['body'],
+            'Description of test ticket does not match');
+        $this->assertEquals($ticket->ticket->priority, $testTicket['priority'],
+            'Priority of test ticket does not match');
         $this->assertEquals($this->client->getDebug()->lastResponseCode, '200', 'Does not return HTTP code 200');
     }
 
-    public function testDeleteMultiple() {
+    public function testDeleteMultiple()
+    {
         // Assume setUp works so we can go ahead and create two new tickets
         $testTicket = array(
             'subject' => 'The quick brown fox jumps over the lazy dog',
-            'comment' => array (
+            'comment' => array(
                 'body' => 'Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.'
             ),
             'priority' => 'normal'
@@ -140,37 +166,43 @@ class TicketsTest extends BasicTest {
         $this->assertEquals($this->client->getDebug()->lastResponseCode, '200', 'Does not return HTTP code 200');
     }
 
-    public function testCreateWithAttachment() {
+    public function testCreateWithAttachment()
+    {
         $testTicket = array(
             'subject' => 'The quick brown fox jumps over the lazy dog',
-            'comment' => array (
+            'comment' => array(
                 'body' => 'Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.'
             ),
             'priority' => 'normal'
         );
         $ticket = $this->client->tickets()->attach(array(
-            'file' => getcwd().'/tests/assets/UK.png',
+            'file' => getcwd() . '/tests/assets/UK.png',
             'name' => 'UK test non-alpha chars.png'
         ))->create($testTicket);
         $this->assertEquals(is_object($ticket), true, 'Should return an object');
         $this->assertEquals(is_object($ticket->ticket), true, 'Should return an object called "ticket"');
         $this->assertGreaterThan(0, $ticket->ticket->id, 'Returns a non-numeric id for ticket');
         $this->assertEquals(is_array($ticket->audit->events), true, 'Should return an array called "audit->events"');
-        $this->assertEquals(is_array($ticket->audit->events[0]->attachments), true, 'Should return an array called "audit->events->attachments"');
-        $this->assertGreaterThan(0, count($ticket->audit->events[0]->attachments), 'Attachment count should be above zero');
+        $this->assertEquals(is_array($ticket->audit->events[0]->attachments), true,
+            'Should return an array called "audit->events->attachments"');
+        $this->assertGreaterThan(0, count($ticket->audit->events[0]->attachments),
+            'Attachment count should be above zero');
         $this->assertEquals($this->client->getDebug()->lastResponseCode, '201', 'Create does not return HTTP code 201');
         $this->client->ticket($ticket->ticket->id)->delete();
         $this->assertEquals($this->client->getDebug()->lastResponseCode, '200', 'Delete does not return HTTP code 200');
     }
 
-    public function testExport() {
+    public function testExport()
+    {
         $tickets = $this->client->tickets()->export(array('start_time' => '1332034771'));
         $this->assertEquals(is_object($tickets), true, 'Should return an object');
-        $this->assertEquals(is_array($tickets->results), true, 'Should return an object containing an array called "results"');
+        $this->assertEquals(is_array($tickets->results), true,
+            'Should return an object containing an array called "results"');
         $this->assertEquals($this->client->getDebug()->lastResponseCode, '200', 'Does not return HTTP code 200');
     }
 
-    public function testCreateFromTweet() {
+    public function testCreateFromTweet()
+    {
         $this->markTestSkipped(
             'Skipped for now because it requires a new (unique) twitter id for each test'
         );
@@ -188,7 +220,8 @@ class TicketsTest extends BasicTest {
         $this->assertEquals($this->client->getDebug()->lastResponseCode, '200', 'Delete does not return HTTP code 200');
     }
 
-    public function tearDown() {
+    public function tearDown()
+    {
         $testTicket = $this->testTicket;
         $this->assertGreaterThan(0, $testTicket['id'], 'Cannot find a ticket id to test with. Did setUp fail?');
         $ticket = $this->client->ticket($testTicket['id'])->delete();

--- a/tests/Zendesk/API/LiveTests/TopicCommentsTest.php
+++ b/tests/Zendesk/API/LiveTests/TopicCommentsTest.php
@@ -7,19 +7,23 @@ use Zendesk\API\Client;
 /**
  * TopicComments test class
  */
-class TopicCommentsTest extends BasicTest {
+class TopicCommentsTest extends BasicTest
+{
 
-    public function testCredentials() {
+    public function testCredentials()
+    {
         parent::credentialsTest();
     }
 
-    public function testAuthToken() {
+    public function testAuthToken()
+    {
         parent::authTokenTest();
     }
 
     protected $id, $topic_id, $forum_id;
 
-    public function setUP() {
+    public function setUP()
+    {
         /*
          * First start by creating a forum and a topic (we'll delete them later)
          */
@@ -43,40 +47,50 @@ class TopicCommentsTest extends BasicTest {
             'body' => 'A man walks into a bar'
         ));
         $this->assertEquals(is_object($topicComment), true, 'Should return an object');
-        $this->assertEquals(is_object($topicComment->topic_comment), true, 'Should return an object called "topic_comment"');
+        $this->assertEquals(is_object($topicComment->topic_comment), true,
+            'Should return an object called "topic_comment"');
         $this->assertGreaterThan(0, $topicComment->topic_comment->id, 'Returns a non-numeric id for topic_comment');
-        $this->assertEquals($topicComment->topic_comment->body, 'A man walks into a bar', 'Body of test comment does not match');
+        $this->assertEquals($topicComment->topic_comment->body, 'A man walks into a bar',
+            'Body of test comment does not match');
         $this->assertEquals($this->client->getDebug()->lastResponseCode, '201', 'Does not return HTTP code 201');
         $this->id = $topicComment->topic_comment->id;
     }
 
-    public function testAll() {
+    public function testAll()
+    {
         $topicComments = $this->client->topic($this->topic_id)->comments()->findAll();
         $this->assertEquals(is_object($topicComments), true, 'Should return an object');
-        $this->assertEquals(is_array($topicComments->topic_comments), true, 'Should return an object containing an array called "topic_comments"');
-        $this->assertGreaterThan(0, $topicComments->topic_comments[0]->id, 'Returns a non-numeric id for topic_comments[0]');
+        $this->assertEquals(is_array($topicComments->topic_comments), true,
+            'Should return an object containing an array called "topic_comments"');
+        $this->assertGreaterThan(0, $topicComments->topic_comments[0]->id,
+            'Returns a non-numeric id for topic_comments[0]');
         $this->assertEquals($this->client->getDebug()->lastResponseCode, '200', 'Does not return HTTP code 200');
     }
 
-    public function testFind() {
+    public function testFind()
+    {
         $topicComment = $this->client->topic($this->topic_id)->comment($this->id)->find();
         $this->assertEquals(is_object($topicComment), true, 'Should return an object');
         $this->assertGreaterThan(0, $topicComment->topic_comment->id, 'Returns a non-numeric id for topic');
         $this->assertEquals($this->client->getDebug()->lastResponseCode, '200', 'Does not return HTTP code 200');
     }
 
-    public function testUpdate() {
+    public function testUpdate()
+    {
         $topicComment = $this->client->topic($this->topic_id)->comment($this->id)->update(array(
             'body' => 'A man walks into a different bar'
         ));
         $this->assertEquals(is_object($topicComment), true, 'Should return an object');
-        $this->assertEquals(is_object($topicComment->topic_comment), true, 'Should return an object called "topic_comment"');
+        $this->assertEquals(is_object($topicComment->topic_comment), true,
+            'Should return an object called "topic_comment"');
         $this->assertGreaterThan(0, $topicComment->topic_comment->id, 'Returns a non-numeric id for topic_comment');
-        $this->assertEquals($topicComment->topic_comment->body, 'A man walks into a different bar', 'Name of test topic does not match');
+        $this->assertEquals($topicComment->topic_comment->body, 'A man walks into a different bar',
+            'Name of test topic does not match');
         $this->assertEquals($this->client->getDebug()->lastResponseCode, '200', 'Does not return HTTP code 200');
     }
 
-    public function teardown() {
+    public function teardown()
+    {
         $this->assertGreaterThan(0, $this->id, 'Cannot find a topic comment id to test with. Did setUp fail?');
         $view = $this->client->topic($this->topic_id)->comment($this->id)->delete();
         $this->assertEquals($this->client->getDebug()->lastResponseCode, '200', 'Does not return HTTP code 200');

--- a/tests/Zendesk/API/LiveTests/TopicSubscriptionsTest.php
+++ b/tests/Zendesk/API/LiveTests/TopicSubscriptionsTest.php
@@ -7,22 +7,26 @@ use Zendesk\API\Client;
 /**
  * TopicSubscriptions test class
  */
-class TopicSubscriptionsTest extends BasicTest {
+class TopicSubscriptionsTest extends BasicTest
+{
 
-    public function testCredentials() {
+    public function testCredentials()
+    {
         parent::credentialsTest();
     }
 
-    public function testAuthToken() {
+    public function testAuthToken()
+    {
         parent::authTokenTest();
     }
 
     protected $id, $topic_id, $forum_id, $user_id, $number;
 
-    public function setUp() {
-         /*
-         * First start by creating a forum and a topic (we'll delete them later)
-         */
+    public function setUp()
+    {
+        /*
+        * First start by creating a forum and a topic (we'll delete them later)
+        */
         $this->number = strval(time());
         $forum = $this->client->forums()->create(array(
             'name' => 'My Forum',
@@ -32,8 +36,8 @@ class TopicSubscriptionsTest extends BasicTest {
         $this->forum_id = $forum->forum->id;
 
         $user = $this->client->users()->create(array(
-            'name' => 'Roger Wilco'.$this->number,
-            'email' => 'roge'.$this->number.'@example.org',
+            'name' => 'Roger Wilco' . $this->number,
+            'email' => 'roge' . $this->number . '@example.org',
             'verified' => true
         ));
         $this->user_id = $user->user->id;
@@ -51,28 +55,35 @@ class TopicSubscriptionsTest extends BasicTest {
             'user_id' => $this->user_id
         ));
         $this->assertEquals(is_object($topicSubscription), true, 'Should return an object');
-        $this->assertEquals(is_object($topicSubscription->topic_subscription), true, 'Should return an object called "topic_subscription"');
-        $this->assertGreaterThan(0, $topicSubscription->topic_subscription->id, 'Returns a non-numeric id for topic_subscription');
+        $this->assertEquals(is_object($topicSubscription->topic_subscription), true,
+            'Should return an object called "topic_subscription"');
+        $this->assertGreaterThan(0, $topicSubscription->topic_subscription->id,
+            'Returns a non-numeric id for topic_subscription');
         $this->assertEquals($this->client->getDebug()->lastResponseCode, '201', 'Does not return HTTP code 201');
         $this->id = $topicSubscription->topic_subscription->id;
     }
 
-    public function testAll() {
+    public function testAll()
+    {
         $topicSubscriptions = $this->client->topic($this->topic_id)->subscriptions()->findAll();
         $this->assertEquals(is_object($topicSubscriptions), true, 'Should return an object');
-        $this->assertEquals(is_array($topicSubscriptions->topic_subscriptions), true, 'Should return an object containing an array called "topic_subscriptions"');
-        $this->assertGreaterThan(0, $topicSubscriptions->topic_subscriptions[0]->id, 'Returns a non-numeric id for topic_subscriptions[0]');
+        $this->assertEquals(is_array($topicSubscriptions->topic_subscriptions), true,
+            'Should return an object containing an array called "topic_subscriptions"');
+        $this->assertGreaterThan(0, $topicSubscriptions->topic_subscriptions[0]->id,
+            'Returns a non-numeric id for topic_subscriptions[0]');
         $this->assertEquals($this->client->getDebug()->lastResponseCode, '200', 'Does not return HTTP code 200');
     }
 
-    public function testFind() {
+    public function testFind()
+    {
         $topicSubscription = $this->client->topic($this->topic_id)->subscription($this->id)->find();
         $this->assertEquals(is_object($topicSubscription), true, 'Should return an object');
         $this->assertGreaterThan(0, $topicSubscription->topic_subscription->id, 'Returns a non-numeric id for topic');
         $this->assertEquals($this->client->getDebug()->lastResponseCode, '200', 'Does not return HTTP code 200');
     }
 
-    public function teardown() {
+    public function teardown()
+    {
         $this->assertGreaterThan(0, $this->id, 'Cannot find a topic subscription id to test with. Did setUp fail?');
         $topicSubscription = $this->client->topic($this->topic_id)->subscription($this->id)->delete();
         $this->assertEquals($this->client->getDebug()->lastResponseCode, '200', 'Does not return HTTP code 200');

--- a/tests/Zendesk/API/LiveTests/TopicVotesTest.php
+++ b/tests/Zendesk/API/LiveTests/TopicVotesTest.php
@@ -7,19 +7,23 @@ use Zendesk\API\Client;
 /**
  * TopicVotes test class
  */
-class TopicVotesTest extends BasicTest {
+class TopicVotesTest extends BasicTest
+{
 
-    public function testCredentials() {
+    public function testCredentials()
+    {
         parent::credentialsTest();
     }
 
-    public function testAuthToken() {
+    public function testAuthToken()
+    {
         parent::authTokenTest();
     }
 
     protected $id, $forum_id, $topic_id;
 
-    public function setUp() {
+    public function setUp()
+    {
         /*
          * First start by creating forum and a topic (we'll delete it later)
          */
@@ -42,8 +46,7 @@ class TopicVotesTest extends BasicTest {
         /*
          * Continue with the rest of the test...
          */
-        $topicVote = $this->client->topic($this->topic_id)->votes()->create(array(
-           // 'user_id' => $user_id
+        $topicVote = $this->client->topic($this->topic_id)->votes()->create(array(// 'user_id' => $user_id
         ));
         $this->assertEquals(is_object($topicVote), true, 'Should return an object');
         $this->assertEquals(is_object($topicVote->topic_vote), true, 'Should return an object called "topic_vote"');
@@ -52,22 +55,26 @@ class TopicVotesTest extends BasicTest {
         $this->id = $topicVote->topic_vote->id;
     }
 
-    public function testAll() {
+    public function testAll()
+    {
         $topicVotes = $this->client->topic($this->topic_id)->votes()->findAll();
         $this->assertEquals(is_object($topicVotes), true, 'Should return an object');
-        $this->assertEquals(is_array($topicVotes->topic_votes), true, 'Should return an object containing an array called "topic_votes"');
+        $this->assertEquals(is_array($topicVotes->topic_votes), true,
+            'Should return an object containing an array called "topic_votes"');
         $this->assertGreaterThan(0, $topicVotes->topic_votes[0]->id, 'Returns a non-numeric id for topic_votes[0]');
         $this->assertEquals($this->client->getDebug()->lastResponseCode, '200', 'Does not return HTTP code 200');
     }
 
-    public function testFind() {
+    public function testFind()
+    {
         $topicVote = $this->client->topic($this->topic_id)->vote($this->id)->find();
         $this->assertEquals(is_object($topicVote), true, 'Should return an object');
         $this->assertGreaterThan(0, $topicVote->topic_vote->id, 'Returns a non-numeric id for topic_vote');
         $this->assertEquals($this->client->getDebug()->lastResponseCode, '200', 'Does not return HTTP code 200');
     }
 
-    public function tearDown() {
+    public function tearDown()
+    {
         $this->assertGreaterThan(0, $this->id, 'Cannot find a topic vote id to test with. Did setUp fail?');
         $topicSubscription = $this->client->topic($this->topic_id)->votes()->delete(); // oddly enough, delete works by topic_id not vote_id
         $this->assertEquals($this->client->getDebug()->lastResponseCode, '200', 'Does not return HTTP code 200');

--- a/tests/Zendesk/API/LiveTests/TopicsTest.php
+++ b/tests/Zendesk/API/LiveTests/TopicsTest.php
@@ -7,19 +7,23 @@ use Zendesk\API\Client;
 /**
  * Topics test class
  */
-class TopicsTest extends BasicTest {
+class TopicsTest extends BasicTest
+{
 
-    public function testCredentials() {
+    public function testCredentials()
+    {
         parent::credentialsTest();
     }
 
-    public function testAuthToken() {
+    public function testAuthToken()
+    {
         parent::authTokenTest();
     }
 
     protected $id, $forum_id;
 
-    public function setUP() {
+    public function setUP()
+    {
         /*
          * First start by creating a forum and a topic (we'll delete them later)
          */
@@ -45,22 +49,26 @@ class TopicsTest extends BasicTest {
         $this->id = $topic->topic->id;
     }
 
-    public function testAll() {
+    public function testAll()
+    {
         $topics = $this->client->topics()->findAll();
         $this->assertEquals(is_object($topics), true, 'Should return an object');
-        $this->assertEquals(is_array($topics->topics), true, 'Should return an object containing an array called "topics"');
+        $this->assertEquals(is_array($topics->topics), true,
+            'Should return an object containing an array called "topics"');
         $this->assertGreaterThan(0, $topics->topics[0]->id, 'Returns a non-numeric id for topics[0]');
         $this->assertEquals($this->client->getDebug()->lastResponseCode, '200', 'Does not return HTTP code 200');
     }
 
-    public function testFind() {
+    public function testFind()
+    {
         $topic = $this->client->topic($this->id)->find();
         $this->assertEquals(is_object($topic), true, 'Should return an object');
         $this->assertGreaterThan(0, $topic->topic->id, 'Returns a non-numeric id for topic');
         $this->assertEquals($this->client->getDebug()->lastResponseCode, '200', 'Does not return HTTP code 200');
     }
 
-    public function testUpdate() {
+    public function testUpdate()
+    {
         $topic = $this->client->topic($this->id)->update(array(
             'title' => 'My Topic II'
         ));
@@ -71,7 +79,8 @@ class TopicsTest extends BasicTest {
         $this->assertEquals($this->client->getDebug()->lastResponseCode, '200', 'Does not return HTTP code 200');
     }
 
-    public function tearDown() {
+    public function tearDown()
+    {
         $this->assertGreaterThan(0, $this->id, 'Cannot find a topic id to test with. Did setUp fail?');
         $topic = $this->client->topic($this->id)->delete();
         $this->assertEquals($this->client->getDebug()->lastResponseCode, '200', 'Does not return HTTP code 200');

--- a/tests/Zendesk/API/LiveTests/TriggersTest.php
+++ b/tests/Zendesk/API/LiveTests/TriggersTest.php
@@ -7,19 +7,23 @@ use Zendesk\API\Client;
 /**
  * Triggers test class
  */
-class TriggersTest extends BasicTest {
+class TriggersTest extends BasicTest
+{
 
-    public function testCredentials() {
+    public function testCredentials()
+    {
         parent::credentialsTest();
     }
 
-    public function testAuthToken() {
+    public function testAuthToken()
+    {
         parent::authTokenTest();
     }
 
     protected $id, $group_id;
 
-    public function setUp() {
+    public function setUp()
+    {
         // Prep:
         $group = $this->client->groups()->create(array(
             'name' => 'New Group'
@@ -55,30 +59,36 @@ class TriggersTest extends BasicTest {
         $this->id = $trigger->trigger->id;
     }
 
-    public function testAll() {
+    public function testAll()
+    {
         $triggers = $this->client->triggers()->findAll();
         $this->assertEquals(is_object($triggers), true, 'Should return an object');
-        $this->assertEquals(is_array($triggers->triggers), true, 'Should return an object containing an array called "triggers"');
+        $this->assertEquals(is_array($triggers->triggers), true,
+            'Should return an object containing an array called "triggers"');
         $this->assertGreaterThan(0, $triggers->triggers[0]->id, 'Returns a non-numeric id for triggers[0]');
         $this->assertEquals($this->client->getDebug()->lastResponseCode, '200', 'Does not return HTTP code 200');
     }
 
-    public function testActive() {
+    public function testActive()
+    {
         $triggers = $this->client->triggers()->active();
         $this->assertEquals(is_object($triggers), true, 'Should return an object');
-        $this->assertEquals(is_array($triggers->triggers), true, 'Should return an object containing an array called "triggers"');
+        $this->assertEquals(is_array($triggers->triggers), true,
+            'Should return an object containing an array called "triggers"');
         $this->assertGreaterThan(0, $triggers->triggers[0]->id, 'Returns a non-numeric id for triggers[0]');
         $this->assertEquals($this->client->getDebug()->lastResponseCode, '200', 'Does not return HTTP code 200');
     }
 
-    public function testFind() {
+    public function testFind()
+    {
         $trigger = $this->client->trigger($this->id)->find();
         $this->assertEquals(is_object($trigger), true, 'Should return an object');
         $this->assertGreaterThan(0, $trigger->trigger->id, 'Returns a non-numeric id for trigger');
         $this->assertEquals($this->client->getDebug()->lastResponseCode, '200', 'Does not return HTTP code 200');
     }
 
-    public function testUpdate() {
+    public function testUpdate()
+    {
         $trigger = $this->client->trigger($this->id)->update(array(
             'title' => 'Roger Wilco II'
         ));
@@ -89,10 +99,12 @@ class TriggersTest extends BasicTest {
         $this->assertEquals($this->client->getDebug()->lastResponseCode, '200', 'Does not return HTTP code 200');
     }
 
-    public function tearDown() {
+    public function tearDown()
+    {
         $this->assertGreaterThan(0, $this->id, 'Cannot find a trigger id to test with. Did setUp fail?');
         $result = $this->client->trigger($this->id)->delete();
-        $this->assertEquals($this->client->getDebug()->lastResponseCode, '200', 'Delete trigger does not return HTTP code 200');
+        $this->assertEquals($this->client->getDebug()->lastResponseCode, '200',
+            'Delete trigger does not return HTTP code 200');
         // Clean-up
         $result = $this->client->group($this->group_id)->delete();
     }

--- a/tests/Zendesk/API/LiveTests/TwitterTest.php
+++ b/tests/Zendesk/API/LiveTests/TwitterTest.php
@@ -7,27 +7,33 @@ use Zendesk\API\Client;
 /**
  * Twitter test class
  */
-class TwitterTest extends BasicTest {
+class TwitterTest extends BasicTest
+{
 
-    public function testAuthToken() {
+    public function testAuthToken()
+    {
         parent::authTokenTest();
     }
 
-    public function testGetHandles() {
+    public function testGetHandles()
+    {
         $handles = $this->client->twitter()->handles();
         $this->assertEquals($this->client->getDebug()->lastResponseCode, '200', 'Does not return HTTP code 200');
         $this->assertEquals(is_object($handles), true, 'Should return an object');
-        $this->assertEquals(is_array($handles->monitored_twitter_handles), true, 'Should return an array called "monitored_twitter_handles"');
+        $this->assertEquals(is_array($handles->monitored_twitter_handles), true,
+            'Should return an array called "monitored_twitter_handles"');
     }
 
-    public function testGetHandleById() {
+    public function testGetHandleById()
+    {
         $id = $this->client->twitter()->handles()->monitored_twitter_handles[0]->id;
         $handles = $this->client->twitter()->handleById(array(
             'id' => $id
         ));
         $this->assertEquals($this->client->getDebug()->lastResponseCode, '200', 'Does not return HTTP code 200');
         $this->assertEquals(is_object($handles), true, 'Should return an object');
-        $this->assertEquals(is_object($handles->monitored_twitter_handle), true, 'Should return an object called "monitored_twitter_handles"');
+        $this->assertEquals(is_object($handles->monitored_twitter_handle), true,
+            'Should return an object called "monitored_twitter_handles"');
     }
 
 }

--- a/tests/Zendesk/API/LiveTests/UserFieldsTest.php
+++ b/tests/Zendesk/API/LiveTests/UserFieldsTest.php
@@ -7,45 +7,53 @@ use Zendesk\API\Client;
 /**
  * UserFields test class
  */
-class UserFieldsTest extends BasicTest {
+class UserFieldsTest extends BasicTest
+{
 
-    public function testCredentials() {
+    public function testCredentials()
+    {
         parent::credentialsTest();
     }
 
-    public function testAuthToken() {
+    public function testAuthToken()
+    {
         parent::authTokenTest();
     }
 
     protected $id, $number;
 
-    public function setUp() {
+    public function setUp()
+    {
         $this->number = strval(time());
         $userField = $this->client->userFields()->create(array(
             'type' => 'text',
-            'title' => 'Support description'.$this->number,
+            'title' => 'Support description' . $this->number,
             'description' => 'This field describes the support plan this user has',
             'position' => 0,
             'active' => true,
-            'key' => 'support_description'.date("YmdHis")
+            'key' => 'support_description' . date("YmdHis")
         ));
         $this->assertEquals(is_object($userField), true, 'Should return an object');
         $this->assertEquals(is_object($userField->user_field), true, 'Should return an object called "user field"');
         $this->assertGreaterThan(0, $userField->user_field->id, 'Returns a non-numeric id for user field');
-        $this->assertEquals($userField->user_field->title, 'Support description'.$this->number, 'Title of test user field does not match');
+        $this->assertEquals($userField->user_field->title, 'Support description' . $this->number,
+            'Title of test user field does not match');
         $this->assertEquals($this->client->getDebug()->lastResponseCode, '201', 'Does not return HTTP code 201');
         $this->id = $userField->user_field->id;
     }
 
-    public function testAll() {
+    public function testAll()
+    {
         $userFields = $this->client->userFields()->findAll();
         $this->assertEquals(is_object($userFields), true, 'Should return an object');
-        $this->assertEquals(is_array($userFields->user_fields), true, 'Should return an object containing an array called "user_fields"');
+        $this->assertEquals(is_array($userFields->user_fields), true,
+            'Should return an object containing an array called "user_fields"');
         $this->assertGreaterThan(0, $userFields->user_fields[0]->id, 'Returns a non-numeric id for user_fields[0]');
         $this->assertEquals($this->client->getDebug()->lastResponseCode, '200', 'Does not return HTTP code 200');
     }
 
-    public function testFind() {
+    public function testFind()
+    {
         $userField = $this->client->userField($this->id)->find();
         $this->assertEquals(is_object($userField), true, 'Should return an object');
         $this->assertEquals(is_object($userField->user_field), true, 'Should return an object called "view"');
@@ -53,23 +61,27 @@ class UserFieldsTest extends BasicTest {
         $this->assertEquals($this->client->getDebug()->lastResponseCode, '200', 'Does not return HTTP code 200');
     }
 
-    public function testUpdate() {
+    public function testUpdate()
+    {
         $userField = $this->client->userField($this->id)->update(array(
-            'title' => 'Support description II'.$this->number
+            'title' => 'Support description II' . $this->number
         ));
         $this->assertEquals(is_object($userField), true, 'Should return an object');
         $this->assertEquals(is_object($userField->user_field), true, 'Should return an object called "user_field"');
         $this->assertGreaterThan(0, $userField->user_field->id, 'Returns a non-numeric id for user_field');
-        $this->assertEquals($userField->user_field->title, 'Support description II'.$this->number, 'Name of test user field does not match');
+        $this->assertEquals($userField->user_field->title, 'Support description II' . $this->number,
+            'Name of test user field does not match');
         $this->assertEquals($this->client->getDebug()->lastResponseCode, '200', 'Does not return HTTP code 200');
     }
 
-    public function testReorder() {
+    public function testReorder()
+    {
         $view = $this->client->userFields()->reorder(array($this->id));
         $this->assertEquals($this->client->getDebug()->lastResponseCode, '200', 'Does not return HTTP code 200');
     }
 
-    public function tearDown() {
+    public function tearDown()
+    {
         $this->assertGreaterThan(0, $this->id, 'Cannot find a user field id to test with. Did setUp fail?');
         $view = $this->client->userField($this->id)->delete();
         $this->assertEquals($this->client->getDebug()->lastResponseCode, '200', 'Does not return HTTP code 200');

--- a/tests/Zendesk/API/LiveTests/UserIdentitiesTest.php
+++ b/tests/Zendesk/API/LiveTests/UserIdentitiesTest.php
@@ -7,24 +7,28 @@ use Zendesk\API\Client;
 /**
  * UserIdentities test class
  */
-class UserIdentitiesTest extends BasicTest {
+class UserIdentitiesTest extends BasicTest
+{
 
-    public function testCredentials() {
+    public function testCredentials()
+    {
         parent::credentialsTest();
     }
 
-    public function testAuthToken() {
+    public function testAuthToken()
+    {
         parent::authTokenTest();
     }
 
     protected $id, $user_id, $number;
 
-    public function setUp() {
+    public function setUp()
+    {
         $this->number = strval(time());
 
         $user = $this->client->users()->create(array(
-            'name' => 'Roger Wilco'.$this->number,
-            'email' => 'roge'.$this->number.'@example.org',
+            'name' => 'Roger Wilco' . $this->number,
+            'email' => 'roge' . $this->number . '@example.org',
             'role' => 'agent',
             'verified' => true
         ));
@@ -32,20 +36,22 @@ class UserIdentitiesTest extends BasicTest {
 
         $identity = $this->client->user($this->user_id)->identities()->create(array(
             'type' => 'email',
-            'value' => 'devaris.brown'.$this->number.'@zendesk.com'
+            'value' => 'devaris.brown' . $this->number . '@zendesk.com'
         ));
         $this->assertEquals(is_object($identity), true, 'Should return an object');
         $this->assertEquals(is_object($identity->identity), true, 'Should return an object called "identity"');
         $this->assertGreaterThan(0, $identity->identity->id, 'Returns a non-numeric id for user field');
-        $this->assertEquals($identity->identity->value, 'devaris.brown'.$this->number.'@zendesk.com', 'Title of test identity does not match');
+        $this->assertEquals($identity->identity->value, 'devaris.brown' . $this->number . '@zendesk.com',
+            'Title of test identity does not match');
         $this->assertEquals($this->client->getDebug()->lastResponseCode, '201', 'Does not return HTTP code 201');
         $this->id = $identity->identity->id;
     }
 
-    public function testCreateAsEndUser() {
+    public function testCreateAsEndUser()
+    {
 
         $user = $this->client->users()->create(array(
-            'name' => 'Roger EndUser'.$this->number,
+            'name' => 'Roger EndUser' . $this->number,
             'email' => 'roge2@example.org',
             'role' => 'end-user',
             'verified' => true
@@ -66,29 +72,34 @@ class UserIdentitiesTest extends BasicTest {
         $this->client->user($user->user->id)->delete();
     }
 
-    public function testAll() {
+    public function testAll()
+    {
         $identities = $this->client->user($this->user_id)->identities()->findAll();
         $this->assertEquals(is_object($identities), true, 'Should return an object');
-        $this->assertEquals(is_array($identities->identities), true, 'Should return an object containing an array called "identities"');
+        $this->assertEquals(is_array($identities->identities), true,
+            'Should return an object containing an array called "identities"');
         $this->assertGreaterThan(0, $identities->identities[0]->id, 'Returns a non-numeric id for identities[0]');
         $this->assertEquals($this->client->getDebug()->lastResponseCode, '200', 'Does not return HTTP code 200');
     }
 
-    public function testFind() {
+    public function testFind()
+    {
         $identity = $this->client->user($this->user_id)->identity($this->id)->find();
         $this->assertEquals(is_object($identity), true, 'Should return an object');
         $this->assertGreaterThan(0, $identity->identity->id, 'Returns a non-numeric id for identity');
         $this->assertEquals($this->client->getDebug()->lastResponseCode, '200', 'Does not return HTTP code 200');
     }
 
-    public function testMarkAsVerified() {
+    public function testMarkAsVerified()
+    {
         $identity = $this->client->user($this->user_id)->identity($this->id)->markAsVerified();
         $this->assertEquals(is_object($identity), true, 'Should return an object');
         $this->assertGreaterThan(0, $identity->identity->id, 'Returns a non-numeric id for identity');
         $this->assertEquals($this->client->getDebug()->lastResponseCode, '200', 'Does not return HTTP code 200');
     }
 
-    public function testMakePrimary() {
+    public function testMakePrimary()
+    {
         $identities = $this->client->user($this->user_id)->identity($this->id)->makePrimary();
         $this->assertEquals(is_object($identities), true, 'Should return an object');
         $this->assertGreaterThan(0, $identities->identities[0]->id, 'Returns a non-numeric id for identities[0]');
@@ -96,12 +107,14 @@ class UserIdentitiesTest extends BasicTest {
         $id = $identities->identities[0]->id;
     }
 
-    public function testRequestVerification() {
+    public function testRequestVerification()
+    {
         $identity = $this->client->user($this->user_id)->identity($this->id)->requestVerification();
         $this->assertEquals($this->client->getDebug()->lastResponseCode, '200', 'Does not return HTTP code 200');
     }
 
-    public function tearDown() {
+    public function tearDown()
+    {
         $this->assertGreaterThan(0, $this->id, 'Cannot find a identity id to test with. Did setUp fail?');
         $view = $this->client->user($this->user_id)->identity($this->id)->delete();
         $this->assertEquals($this->client->getDebug()->lastResponseCode, '200', 'Does not return HTTP code 200');

--- a/tests/Zendesk/API/LiveTests/UsersTest.php
+++ b/tests/Zendesk/API/LiveTests/UsersTest.php
@@ -7,24 +7,28 @@ use Zendesk\API\Client;
 /**
  * Users test class
  */
-class UsersTest extends BasicTest {
+class UsersTest extends BasicTest
+{
 
-    public function testCredentials() {
+    public function testCredentials()
+    {
         parent::credentialsTest();
     }
 
-    public function testAuthToken() {
+    public function testAuthToken()
+    {
         parent::authTokenTest();
     }
 
     protected $id, $id_s, $ticket_id, $number, $external_id, $external_id_s;
 
-    public function setUp() {
+    public function setUp()
+    {
         $this->number = strval(time());
 
         $user = $this->client->users()->create(array(
-            'name' => 'Roger Wilco'.$this->number,
-            'email' => 'roge'.$this->number.'@example.org',
+            'name' => 'Roger Wilco' . $this->number,
+            'email' => 'roge' . $this->number . '@example.org',
             'role' => 'agent',
             'verified' => true,
             'external_id' => '3000'
@@ -34,7 +38,7 @@ class UsersTest extends BasicTest {
 
         $testTicket = array(
             'subject' => 'User Test',
-            'comment' => array (
+            'comment' => array(
                 'body' => 'Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.'
             ),
             'priority' => 'normal',
@@ -45,8 +49,8 @@ class UsersTest extends BasicTest {
         $this->ticket_id = $ticket->ticket->id;
 
         $user_s = $this->client->users()->create(array(
-            'name' => 'Roger Wilco2'.$this->number,
-            'email' => 'roge2'.$this->number.'@example.org',
+            'name' => 'Roger Wilco2' . $this->number,
+            'email' => 'roge2' . $this->number . '@example.org',
             'role' => 'agent',
             'verified' => true,
             'external_id' => '3001'
@@ -57,20 +61,24 @@ class UsersTest extends BasicTest {
         $this->assertEquals(is_object($user), true, 'Should return an object');
         $this->assertEquals(is_object($user->user), true, 'Should return an object called "user"');
         $this->assertGreaterThan(0, $user->user->id, 'Returns a non-numeric id for user');
-        $this->assertEquals($user->user->name, 'Roger Wilco'.$this->number, 'Name of test user does not match');
-        $this->assertEquals($user->user->email, 'roge'.$this->number.'@example.org', 'Email of test user does not match');
+        $this->assertEquals($user->user->name, 'Roger Wilco' . $this->number, 'Name of test user does not match');
+        $this->assertEquals($user->user->email, 'roge' . $this->number . '@example.org',
+            'Email of test user does not match');
         $this->assertEquals($this->client->getDebug()->lastResponseCode, '201', 'Does not return HTTP code 201');
     }
 
-    public function testAll() {
+    public function testAll()
+    {
         $users = $this->client->users()->findAll();
         $this->assertEquals(is_object($users), true, 'Should return an object');
-        $this->assertEquals(is_array($users->users), true, 'Should return an object containing an array called "users"');
+        $this->assertEquals(is_array($users->users), true,
+            'Should return an object containing an array called "users"');
         $this->assertGreaterThan(0, $users->users[0]->id, 'Returns a non-numeric id for requests[0]');
         $this->assertEquals($this->client->getDebug()->lastResponseCode, '200', 'Does not return HTTP code 200');
     }
 
-    public function testFind() {
+    public function testFind()
+    {
         $user = $this->client->user($this->id)->find();
         $this->assertEquals(is_object($user), true, 'Should return an object');
         $this->assertEquals(is_object($user->user), true, 'Should return an object called "user"');
@@ -78,55 +86,69 @@ class UsersTest extends BasicTest {
         $this->assertEquals($this->client->getDebug()->lastResponseCode, '200', 'Does not return HTTP code 200');
     }
 
-    public function testFindMultiple() {
+    public function testFindMultiple()
+    {
         $users = $this->client->users(array($this->id, $this->id_s))->find();
         $this->assertEquals(is_object($users), true, 'Should return an object');
         $this->assertEquals(is_array($users->users), true, 'Should return an array called "users"');
-        $this->assertEquals(is_object($users->users[0]), true, 'Should return an object as first "users" array element');
+        $this->assertEquals(is_object($users->users[0]), true,
+            'Should return an object as first "users" array element');
     }
 
-    public function testShowManyUsingIds() {
+    public function testShowManyUsingIds()
+    {
         $users = $this->client->users()->showMany(array('ids' => array($this->id, $this->id_s)));
         $this->assertEquals(is_object($users), true, 'Should return an object');
         $this->assertEquals(is_array($users->users), true, 'Should return an array called "users"');
-        $this->assertEquals(is_object($users->users[0]), true, 'Should return an object as first "users" array element');
+        $this->assertEquals(is_object($users->users[0]), true,
+            'Should return an object as first "users" array element');
     }
 
-    public function testShowManyUsingExternalIds() {
-        $users = $this->client->users()->showMany(array('external_ids' => array($this->external_id, $this->external_id_s)));
+    public function testShowManyUsingExternalIds()
+    {
+        $users = $this->client->users()->showMany(array(
+            'external_ids' => array(
+                $this->external_id,
+                $this->external_id_s
+            )
+        ));
         $this->assertEquals(is_object($users), true, 'Should return an object');
         $this->assertEquals(is_array($users->users), true, 'Should return an array called "users"');
-        $this->assertEquals(is_object($users->users[0]), true, 'Should return an object as first "users" array element');
+        $this->assertEquals(is_object($users->users[0]), true,
+            'Should return an object as first "users" array element');
     }
 
-    public function testRelated() {
+    public function testRelated()
+    {
         $related = $this->client->user($this->id)->related();
         $this->assertEquals(is_object($related), true, 'Should return an object');
         $this->assertEquals(is_object($related->user_related), true, 'Should return an object called "user_related"');
-        $this->assertGreaterThan(0, $related->user_related->requested_tickets, 'Returns a non-numeric requested_tickets for user');
+        $this->assertGreaterThan(0, $related->user_related->requested_tickets,
+            'Returns a non-numeric requested_tickets for user');
         $this->assertEquals($this->client->getDebug()->lastResponseCode, '200', 'Does not return HTTP code 200');
     }
 
-    public function testMerge() {
+    public function testMerge()
+    {
         // create users to merge
-        $mergeFrom1Email = 'mergefrom1.'.$this->number.'@example.org';
+        $mergeFrom1Email = 'mergefrom1.' . $this->number . '@example.org';
         $user_m = $this->client->users()->create(array(
-            'name' => 'Merge From1'.$this->number,
+            'name' => 'Merge From1' . $this->number,
             'email' => $mergeFrom1Email,
             'role' => 'end-user',
             'verified' => true
         ));
         $mergeFrom1 = $user_m->user->id;
         $user_m = $this->client->users()->create(array(
-            'name' => 'Merge From2'.$this->number,
-            'email' => 'mergefrom2.'.$this->number.'@example.org',
+            'name' => 'Merge From2' . $this->number,
+            'email' => 'mergefrom2.' . $this->number . '@example.org',
             'role' => 'end-user',
             'verified' => true
         ));
         $mergeFrom2 = $user_m->user->id;
-        $mergeToEmail = 'mergeto.'.$this->number.'@example.org';
+        $mergeToEmail = 'mergeto.' . $this->number . '@example.org';
         $user_m = $this->client->users()->create(array(
-            'name' => 'Merge To'.$this->number,
+            'name' => 'Merge To' . $this->number,
             'email' => $mergeToEmail,
             'role' => 'end-user',
             'verified' => true
@@ -166,29 +188,33 @@ class UsersTest extends BasicTest {
         $this->assertEquals('200', $this->client->getDebug()->lastResponseCode, 'Does not return HTTP code 200');
     }
 
-    public function testCreateMany() {
+    public function testCreateMany()
+    {
         $this->markTestSkipped(
             'Skipped for now because we have no way of cleaning up.'
         );
         $jobStatus = $this->client->users()->createMany(array(
-            array(
-                'name' => 'Roger Wilco 3',
-                'email' => 'roge3@example.org',
-                'verified' => true
-            ),
-            array(
-                'name' => 'Roger Wilco 4',
-                'email' => 'roge4@example.org',
-                'verified' => true
-            ))
+                array(
+                    'name' => 'Roger Wilco 3',
+                    'email' => 'roge3@example.org',
+                    'verified' => true
+                ),
+                array(
+                    'name' => 'Roger Wilco 4',
+                    'email' => 'roge4@example.org',
+                    'verified' => true
+                )
+            )
         );
         $this->assertEquals(is_object($jobStatus), true, 'Should return an object');
         $this->assertEquals(is_object($jobStatus->job_status), true, 'Should return an object called "job_status"');
         $this->assertGreaterThan(0, $jobStatus->job_status->id, 'Returns a non-numeric id for users[0]');
-        $this->assertEquals($this->client->getDebug()->lastResponseCode, '200', 'CreateMany does not return HTTP code 200');
+        $this->assertEquals($this->client->getDebug()->lastResponseCode, '200',
+            'CreateMany does not return HTTP code 200');
     }
 
-    public function testUpdate() {
+    public function testUpdate()
+    {
         $user = $this->client->user($this->id)->update(array(
             'name' => 'Joe Soap'
         ));
@@ -199,20 +225,23 @@ class UsersTest extends BasicTest {
         $this->assertEquals($this->client->getDebug()->lastResponseCode, '200', 'Does not return HTTP code 200');
     }
 
-    public function testUpdateMany() {
+    public function testUpdateMany()
+    {
         $jobStatus = $this->client->users()->updateMany(array(
-            'ids' => $this->id.','.$this->id_s,
+            'ids' => $this->id . ',' . $this->id_s,
             'phone' => '1234567890'
-            ));
+        ));
         $this->assertEquals(is_object($jobStatus), true, 'Should return an array');
         $this->assertEquals(is_object($jobStatus->job_status), true, 'Should return an object called "job_status"');
         $this->assertGreaterThan(0, $jobStatus->job_status->id, 'Returns a non-numeric id for users[0]');
-        $this->assertEquals($this->client->getDebug()->lastResponseCode, '200', 'CreateMany does not return HTTP code 200');
+        $this->assertEquals($this->client->getDebug()->lastResponseCode, '200',
+            'CreateMany does not return HTTP code 200');
     }
 
-   public function testUpdateManyIndividualUsers() {
+    public function testUpdateManyIndividualUsers()
+    {
         $jobStatus = $this->client->users()->updateManyIndividualUsers(array(
-            array( 
+            array(
                 'id' => $this->id,
                 'phone' => '1234567890'
             ),
@@ -220,14 +249,16 @@ class UsersTest extends BasicTest {
                 'id' => $this->id_s,
                 'phone' => '0987654321'
             )
-            ));
+        ));
         $this->assertEquals(is_object($jobStatus), true, 'Should return an array');
         $this->assertEquals(is_object($jobStatus->job_status), true, 'Should return an object called "job_status"');
         $this->assertGreaterThan(0, $jobStatus->job_status->id, 'Returns a non-numeric id for users[0]');
-        $this->assertEquals($this->client->getDebug()->lastResponseCode, '200', 'CreateMany does not return HTTP code 200');
+        $this->assertEquals($this->client->getDebug()->lastResponseCode, '200',
+            'CreateMany does not return HTTP code 200');
     }
 
-    public function testSuspend() {
+    public function testSuspend()
+    {
         $user = $this->client->user($this->id)->suspend();
         $this->assertEquals(is_object($user), true, 'Should return an object');
         $this->assertEquals(is_object($user->user), true, 'Should return an object called "user"');
@@ -235,10 +266,12 @@ class UsersTest extends BasicTest {
         $this->assertEquals($this->client->getDebug()->lastResponseCode, '200', 'Does not return HTTP code 200');
     }
 
-    public function testSearch() {
+    public function testSearch()
+    {
         $users = $this->client->users()->search(array('query' => 'Roger'));
         $this->assertEquals(is_object($users), true, 'Should return an object');
-        $this->assertEquals(is_array($users->users), true, 'Should return an object containing an array called "users"');
+        $this->assertEquals(is_array($users->users), true,
+            'Should return an object containing an array called "users"');
         $this->assertGreaterThan(0, $users->users[0]->id, 'Returns a non-numeric id for user');
         $this->assertEquals($this->client->getDebug()->lastResponseCode, '200', 'Does not return HTTP code 200');
     }
@@ -246,17 +279,20 @@ class UsersTest extends BasicTest {
     /*
      * Needs an existed User with specified query 'name' keyword to run this function
      */
-    public function testAutocomplete() {
+    public function testAutocomplete()
+    {
         $users = $this->client->users()->autocomplete(array('name' => 'joh'));
         $this->assertEquals(is_object($users), true, 'Should return an object');
-        $this->assertEquals(is_array($users->users), true, 'Should return an object containing an array called "users"');
+        $this->assertEquals(is_array($users->users), true,
+            'Should return an object containing an array called "users"');
         $this->assertGreaterThan(0, $users->users[0]->id, 'Returns a non-numeric id for user');
         $this->assertEquals($this->client->getDebug()->lastResponseCode, '200', 'Does not return HTTP code 200');
     }
 
-    public function testUpdateProfileImage() {
+    public function testUpdateProfileImage()
+    {
         $user = $this->client->user($this->id)->updateProfileImage(array(
-            'file' => getcwd().'/tests/assets/UK.png'
+            'file' => getcwd() . '/tests/assets/UK.png'
         ));
         $this->assertEquals(is_object($user), true, 'Should return an object');
         $this->assertEquals(is_object($user->user), true, 'Should return an object called "user"');
@@ -264,7 +300,8 @@ class UsersTest extends BasicTest {
         $this->assertEquals($this->client->getDebug()->lastResponseCode, '200', 'Does not return HTTP code 200');
     }
 
-    public function testAuthenticatedUser() {
+    public function testAuthenticatedUser()
+    {
         $user = $this->client->users()->me();
         $this->assertEquals(is_object($user), true, 'Should return an object');
         $this->assertEquals(is_object($user->user), true, 'Should return an object called "user"');
@@ -272,20 +309,26 @@ class UsersTest extends BasicTest {
         $this->assertEquals($this->client->getDebug()->lastResponseCode, '200', 'Does not return HTTP code 200');
     }
 
-    public function testSetPassword() {
+    public function testSetPassword()
+    {
         $user = $this->client->user($this->id)->setPassword(array('password' => "aBc12345"));
         $this->assertEquals($this->client->getDebug()->lastResponseCode, '200', 'Does not return HTTP code 200');
     }
 
-    public function testChangePassword() {
+    public function testChangePassword()
+    {
         $this->markTestSkipped(
             'Skipped for now because you can only change password of your own account.'
         );
-        $user = $this->client->user(421450109)->changePassword(array('previous_password' => '12346', 'password' => '12345'));
+        $user = $this->client->user(421450109)->changePassword(array(
+            'previous_password' => '12346',
+            'password' => '12345'
+        ));
         $this->assertEquals($this->client->getDebug()->lastResponseCode, '200', 'Does not return HTTP code 200');
     }
 
-    public function tearDown() {
+    public function tearDown()
+    {
         $this->client->ticket($this->ticket_id)->delete();
 
         $user = $this->client->user($this->id)->delete();

--- a/tests/Zendesk/API/LiveTests/ViewsTest.php
+++ b/tests/Zendesk/API/LiveTests/ViewsTest.php
@@ -7,19 +7,23 @@ use Zendesk\API\Client;
 /**
  * Views test class
  */
-class ViewsTest extends BasicTest {
+class ViewsTest extends BasicTest
+{
 
-    public function testCredentials() {
+    public function testCredentials()
+    {
         parent::credentialsTest();
     }
 
-    public function testAuthToken() {
+    public function testAuthToken()
+    {
         parent::authTokenTest();
     }
 
     protected $id;
 
-    public function setUp() {
+    public function setUp()
+    {
         $view = $this->client->views()->create(array(
             'title' => 'Roger Wilco',
             'active' => true,
@@ -51,31 +55,38 @@ class ViewsTest extends BasicTest {
         $this->id = $view->view->id;
     }
 
-    public function testAll() {
+    public function testAll()
+    {
         $views = $this->client->views()->findAll();
         $this->assertEquals(is_object($views), true, 'Should return an object');
-        $this->assertEquals(is_array($views->views), true, 'Should return an object containing an array called "views"');
+        $this->assertEquals(is_array($views->views), true,
+            'Should return an object containing an array called "views"');
         $this->assertGreaterThan(0, $views->views[0]->id, 'Returns a non-numeric id for views[0]');
         $this->assertEquals($this->client->getDebug()->lastResponseCode, '200', 'Does not return HTTP code 200');
     }
 
-    public function testActive() {
+    public function testActive()
+    {
         $views = $this->client->views()->findAll(array('active' => true));
         $this->assertEquals(is_object($views), true, 'Should return an object');
-        $this->assertEquals(is_array($views->views), true, 'Should return an object containing an array called "views"');
+        $this->assertEquals(is_array($views->views), true,
+            'Should return an object containing an array called "views"');
         $this->assertGreaterThan(0, $views->views[0]->id, 'Returns a non-numeric id for views[0]');
         $this->assertEquals($this->client->getDebug()->lastResponseCode, '200', 'Does not return HTTP code 200');
     }
 
-    public function testCompact() {
+    public function testCompact()
+    {
         $views = $this->client->views()->findAll(array('compact' => true));
         $this->assertEquals(is_object($views), true, 'Should return an object');
-        $this->assertEquals(is_array($views->views), true, 'Should return an object containing an array called "views"');
+        $this->assertEquals(is_array($views->views), true,
+            'Should return an object containing an array called "views"');
         $this->assertGreaterThan(0, $views->views[0]->id, 'Returns a non-numeric id for views[0]');
         $this->assertEquals($this->client->getDebug()->lastResponseCode, '200', 'Does not return HTTP code 200');
     }
 
-    public function testFind() {
+    public function testFind()
+    {
         $view = $this->client->view($this->id)->find();
         $this->assertEquals(is_object($view), true, 'Should return an object');
         $this->assertEquals(is_object($view->view), true, 'Should return an object called "view"');
@@ -83,7 +94,8 @@ class ViewsTest extends BasicTest {
         $this->assertEquals($this->client->getDebug()->lastResponseCode, '200', 'Does not return HTTP code 200');
     }
 
-    public function testUpdate() {
+    public function testUpdate()
+    {
         $view = $this->client->view($this->id)->update(array(
             'title' => 'Roger Wilco II'
         ));
@@ -94,7 +106,8 @@ class ViewsTest extends BasicTest {
         $this->assertEquals($this->client->getDebug()->lastResponseCode, '200', 'Does not return HTTP code 200');
     }
 
-    public function testExecute() {
+    public function testExecute()
+    {
         $view = $this->client->view($this->id)->execute();
         $this->assertEquals(is_object($view), true, 'Should return an object');
         $this->assertEquals(is_object($view->view), true, 'Should return an object called "view"');
@@ -102,7 +115,8 @@ class ViewsTest extends BasicTest {
         $this->assertEquals($this->client->getDebug()->lastResponseCode, '200', 'Does not return HTTP code 200');
     }
 
-    public function testCount() {
+    public function testCount()
+    {
         $counts = $this->client->view($this->id)->count();
         $this->assertEquals(is_object($counts), true, 'Should return an object');
         $this->assertEquals(is_object($counts->view_count), true, 'Should return an object called "view_count"');
@@ -110,22 +124,27 @@ class ViewsTest extends BasicTest {
         $this->assertEquals($this->client->getDebug()->lastResponseCode, '200', 'Does not return HTTP code 200');
     }
 
-    public function testCountMany() {
+    public function testCountMany()
+    {
         $counts = $this->client->view(array($this->id, 38568252))->count();
         $this->assertEquals(is_object($counts), true, 'Should return an object');
-        $this->assertEquals(is_array($counts->view_counts), true, 'Should return an array of objects called "view_counts"');
-        $this->assertGreaterThan(0, $counts->view_counts[0]->view_id, 'Returns a non-numeric view_id for view_counts[0]');
+        $this->assertEquals(is_array($counts->view_counts), true,
+            'Should return an array of objects called "view_counts"');
+        $this->assertGreaterThan(0, $counts->view_counts[0]->view_id,
+            'Returns a non-numeric view_id for view_counts[0]');
         $this->assertEquals($this->client->getDebug()->lastResponseCode, '200', 'Does not return HTTP code 200');
     }
 
-    public function testExport() {
+    public function testExport()
+    {
         $export = $this->client->view($this->id)->export();
         $this->assertEquals(is_object($export), true, 'Should return an object');
         $this->assertGreaterThan(0, $export->export->view_id, 'Returns a non-numeric view_id for export');
         $this->assertEquals($this->client->getDebug()->lastResponseCode, '200', 'Does not return HTTP code 200');
     }
 
-    public function testPreview() {
+    public function testPreview()
+    {
         $preview = $this->client->views()->preview(array(
             'all' => array(
                 array(
@@ -144,7 +163,8 @@ class ViewsTest extends BasicTest {
         $this->assertEquals($this->client->getDebug()->lastResponseCode, '200', 'Does not return HTTP code 200');
     }
 
-    public function testPreviewCount() {
+    public function testPreviewCount()
+    {
         $preview = $this->client->views()->previewCount(array(
             'all' => array(
                 array(
@@ -162,7 +182,8 @@ class ViewsTest extends BasicTest {
         $this->assertEquals($this->client->getDebug()->lastResponseCode, '200', 'Does not return HTTP code 200');
     }
 
-    public function tearDown() {
+    public function tearDown()
+    {
         $this->assertGreaterThan(0, $this->id, 'Cannot find a view id to test with. Did setUp fail?');
         $view = $this->client->view($this->id)->delete();
         $this->assertEquals($this->client->getDebug()->lastResponseCode, '200', 'Does not return HTTP code 200');

--- a/tests/Zendesk/API/LiveTests/VoiceIntegrationTest.php
+++ b/tests/Zendesk/API/LiveTests/VoiceIntegrationTest.php
@@ -7,13 +7,16 @@ use Zendesk\API\Client;
 /**
  * VoiceIntegration test class
  */
-class VoiceIntegrationTest extends BasicTest {
+class VoiceIntegrationTest extends BasicTest
+{
 
-    public function testCredentials() {
+    public function testCredentials()
+    {
         parent::credentialsTest();
     }
 
-    public function testAuthToken() {
+    public function testAuthToken()
+    {
         parent::authTokenTest();
     }
 
@@ -33,7 +36,8 @@ class VoiceIntegrationTest extends BasicTest {
     //     $this->assertEquals($this->client->getDebug()->lastResponseCode, '200', 'Does not return HTTP code 200');
     // }
 
-    public function testCreateVoiceTicket() {
+    public function testCreateVoiceTicket()
+    {
         $ticket = $this->client->voice()->tickets()->create(array(
             'ticket' => array(
                 'via_id' => 44,
@@ -47,11 +51,13 @@ class VoiceIntegrationTest extends BasicTest {
         $this->assertEquals(is_object($ticket), true, 'Should return an object');
         $this->assertEquals(is_object($ticket->ticket), true, 'Should return an object called "ticket"');
         $this->assertGreaterThan(0, $ticket->ticket->id, 'Returns a non-numeric id for ticket');
-        $this->assertEquals($ticket->ticket->subject, 'My printer is on fire!', 'Subject of test ticket does not match');
+        $this->assertEquals($ticket->ticket->subject, 'My printer is on fire!',
+            'Subject of test ticket does not match');
         $this->assertEquals($this->client->getDebug()->lastResponseCode, '201', 'Does not return HTTP code 201');
     }
 
-    public function testCreateVoicemailTicket() {
+    public function testCreateVoicemailTicket()
+    {
         $ticket = $this->client->voice()->tickets()->create(array(
             'ticket' => array(
                 'via_id' => 45,
@@ -71,7 +77,8 @@ class VoiceIntegrationTest extends BasicTest {
         $this->assertEquals(is_object($ticket), true, 'Should return an object');
         $this->assertEquals(is_object($ticket->ticket), true, 'Should return an object called "ticket"');
         $this->assertGreaterThan(0, $ticket->ticket->id, 'Returns a non-numeric id for ticket');
-        $this->assertEquals($ticket->ticket->description, 'Incoming phone call from: +16617480240', 'Description of test voicemail does not match');
+        $this->assertEquals($ticket->ticket->description, 'Incoming phone call from: +16617480240',
+            'Description of test voicemail does not match');
         $this->assertEquals($this->client->getDebug()->lastResponseCode, '201', 'Does not return HTTP code 201');
     }
 

--- a/tests/Zendesk/API/LiveTests/VoiceTest.php
+++ b/tests/Zendesk/API/LiveTests/VoiceTest.php
@@ -7,24 +7,30 @@ use Zendesk\API\Client;
 /**
  * Voice test class
  */
-class VoiceTest extends BasicTest {
+class VoiceTest extends BasicTest
+{
 
-    public function testCredentials() {
+    public function testCredentials()
+    {
         parent::credentialsTest();
     }
 
-    public function testAuthToken() {
+    public function testAuthToken()
+    {
         parent::authTokenTest();
     }
 
-    public function testCreatePhoneNumber() {
+    public function testCreatePhoneNumber()
+    {
         // First we need to search for an available phone number
         $numbers = $this->client->voice()->phoneNumbers()->search(array(
             'country' => 'US'
         ));
         $this->assertEquals(is_object($numbers), true, 'Should return an object');
-        $this->assertEquals(is_array($numbers->phone_numbers), true, 'Should return an object containing an array called "phone_numbers"');
-        $this->assertEquals(is_string($numbers->phone_numbers[0]->token), true, 'No string token found for first phone number');
+        $this->assertEquals(is_array($numbers->phone_numbers), true,
+            'Should return an object containing an array called "phone_numbers"');
+        $this->assertEquals(is_string($numbers->phone_numbers[0]->token), true,
+            'No string token found for first phone number');
         // Now we assign it to our account
         $number = $this->client->voice()->phoneNumbers()->create(array(
             'token' => $numbers->phone_numbers[0]->token
@@ -32,53 +38,65 @@ class VoiceTest extends BasicTest {
         $this->assertEquals(is_object($number), true, 'Should return an object');
         $this->assertEquals(is_object($number->phone_number), true, 'Should return an object called "phone_number"');
         $this->assertGreaterThan(0, $number->phone_number->id, 'Returns a non-numeric id for trigger');
-        $this->assertEquals($number->phone_number->number, $numbers->phone_numbers[0]->number, 'Value of test phone number does not match');
+        $this->assertEquals($number->phone_number->number, $numbers->phone_numbers[0]->number,
+            'Value of test phone number does not match');
         $this->assertEquals($this->client->getDebug()->lastResponseCode, '200', 'Does not return HTTP code 200');
         $id = $number->phone_number->id;
         $stack = array($id);
+
         return $stack;
     }
 
     /**
      * @depends testCreatePhoneNumber
      */
-    public function testAllPhoneNumber($stack) {
+    public function testAllPhoneNumber($stack)
+    {
         $numbers = $this->client->voice()->phoneNumbers()->findAll();
         $this->assertEquals(is_object($numbers), true, 'Should return an object');
-        $this->assertEquals(is_array($numbers->phone_numbers), true, 'Should return an object containing an array called "phone_numbers"');
+        $this->assertEquals(is_array($numbers->phone_numbers), true,
+            'Should return an object containing an array called "phone_numbers"');
         $this->assertGreaterThan(0, $numbers->phone_numbers[0]->id, 'Returns a non-numeric id for phone_numbers[0]');
         $this->assertEquals($this->client->getDebug()->lastResponseCode, '200', 'Does not return HTTP code 200');
+
         return $stack;
     }
 
     /**
      * @depends testCreatePhoneNumber
      */
-    public function testSearchPhoneNumber($stack) {
+    public function testSearchPhoneNumber($stack)
+    {
         $numbers = $this->client->voice()->phoneNumbers()->search(array('country' => 'US'));
         $this->assertEquals(is_object($numbers), true, 'Should return an object');
-        $this->assertEquals(is_array($numbers->phone_numbers), true, 'Should return an object containing an array called "phone_numbers"');
-        $this->assertEquals(is_string($numbers->phone_numbers[0]->token), true, 'No string token found for first phone number');
+        $this->assertEquals(is_array($numbers->phone_numbers), true,
+            'Should return an object containing an array called "phone_numbers"');
+        $this->assertEquals(is_string($numbers->phone_numbers[0]->token), true,
+            'No string token found for first phone number');
         $this->assertEquals($this->client->getDebug()->lastResponseCode, '200', 'Does not return HTTP code 200');
+
         return $stack;
     }
 
     /**
      * @depends testCreatePhoneNumber
      */
-    public function testFindPhoneNumber($stack) {
+    public function testFindPhoneNumber($stack)
+    {
         $id = array_pop($stack);
         $number = $this->client->voice()->phoneNumber($id)->find();
         $this->assertGreaterThan(0, $number->phone_number->id, 'Returns a non-numeric id for phone_number');
         $this->assertEquals($this->client->getDebug()->lastResponseCode, '200', 'Does not return HTTP code 200');
         $stack = array($id);
+
         return $stack;
     }
 
     /**
      * @depends testCreatePhoneNumber
      */
-    public function testUpdatePhoneNumber(array $stack) {
+    public function testUpdatePhoneNumber(array $stack)
+    {
         $id = array_pop($stack);
         $number = $this->client->voice()->phoneNumber($id)->update(array(
             'nickname' => 'Awesome support line'
@@ -86,23 +104,28 @@ class VoiceTest extends BasicTest {
         $this->assertEquals(is_object($number), true, 'Should return an object');
         $this->assertEquals(is_object($number->phone_number), true, 'Should return an object called "phone_number"');
         $this->assertGreaterThan(0, $number->phone_number->id, 'Returns a non-numeric id for phone_number');
-        $this->assertEquals($number->phone_number->nickname, 'Awesome support line', 'Nickname of test phone number does not match');
+        $this->assertEquals($number->phone_number->nickname, 'Awesome support line',
+            'Nickname of test phone number does not match');
         $this->assertEquals($this->client->getDebug()->lastResponseCode, '200', 'Does not return HTTP code 200');
         $stack = array($id);
+
         return $stack;
     }
 
     /**
      * @depends testCreatePhoneNumber
      */
-    public function testDeletePhoneNumber(array $stack) {
+    public function testDeletePhoneNumber(array $stack)
+    {
         $id = array_pop($stack);
         $this->assertGreaterThan(0, $id, 'Cannot find a phone number id to test with. Did testCreate fail?');
         $result = $this->client->voice()->phoneNumber($id)->delete();
-        $this->assertEquals($this->client->getDebug()->lastResponseCode, '200', 'Delete trigger does not return HTTP code 200');
+        $this->assertEquals($this->client->getDebug()->lastResponseCode, '200',
+            'Delete trigger does not return HTTP code 200');
     }
 
-    public function testCreateGreeting() {
+    public function testCreateGreeting()
+    {
         $greeting = $this->client->voice()->greetings()->create(array(
             'name' => 'Hello',
             'type' => 'Voicemail',
@@ -115,37 +138,44 @@ class VoiceTest extends BasicTest {
         $this->assertEquals($this->client->getDebug()->lastResponseCode, '201', 'Does not return HTTP code 201');
         $id = $greeting->greeting->id;
         $stack = array($id);
+
         return $stack;
     }
 
     /**
      * @depends testCreateGreeting
      */
-    public function testAllGreeting($stack) {
+    public function testAllGreeting($stack)
+    {
         $greetings = $this->client->voice()->greetings()->findAll();
         $this->assertEquals(is_object($greetings), true, 'Should return an object');
-        $this->assertEquals(is_array($greetings->greetings), true, 'Should return an object containing an array called "greetings"');
+        $this->assertEquals(is_array($greetings->greetings), true,
+            'Should return an object containing an array called "greetings"');
         $this->assertGreaterThan(0, $greetings->greetings[0]->id, 'Returns a non-numeric id for greetings[0]');
         $this->assertEquals($this->client->getDebug()->lastResponseCode, '200', 'Does not return HTTP code 200');
+
         return $stack;
     }
 
     /**
      * @depends testCreateGreeting
      */
-    public function testFindGreeting($stack) {
+    public function testFindGreeting($stack)
+    {
         $id = array_pop($stack);
         $greeting = $this->client->voice()->greeting($id)->find();
         $this->assertGreaterThan(0, $greeting->greeting->id, 'Returns a non-numeric id for greeting');
         $this->assertEquals($this->client->getDebug()->lastResponseCode, '200', 'Does not return HTTP code 200');
         $stack = array($id);
+
         return $stack;
     }
 
     /**
      * @depends testCreateGreeting
      */
-    public function testUpdateGreeting(array $stack) {
+    public function testUpdateGreeting(array $stack)
+    {
         $id = array_pop($stack);
         $greeting = $this->client->voice()->greeting($id)->update(array(
             'name' => 'Premium support'
@@ -156,37 +186,46 @@ class VoiceTest extends BasicTest {
         $this->assertEquals($greeting->greeting->name, 'Premium support', 'Name of test greeting does not match');
         $this->assertEquals($this->client->getDebug()->lastResponseCode, '200', 'Does not return HTTP code 200');
         $stack = array($id);
+
         return $stack;
     }
 
     /**
      * @depends testCreateGreeting
      */
-    public function testDeleteGreeting(array $stack) {
+    public function testDeleteGreeting(array $stack)
+    {
         $id = array_pop($stack);
         $this->assertGreaterThan(0, $id, 'Cannot find a greeting id to test with. Did testCreate fail?');
         $result = $this->client->voice()->greeting($id)->delete();
-        $this->assertEquals($this->client->getDebug()->lastResponseCode, '200', 'Delete trigger does not return HTTP code 200');
+        $this->assertEquals($this->client->getDebug()->lastResponseCode, '200',
+            'Delete trigger does not return HTTP code 200');
     }
 
-    public function testCurrentQueueActivity() {
+    public function testCurrentQueueActivity()
+    {
         $stats = $this->client->voice()->stats()->findAll(array('current_queue_activity' => true));
         $this->assertEquals(is_object($stats), true, 'Should return an object');
-        $this->assertEquals(is_object($stats->current_queue_activity), true, 'Should return an object called "current_queue_activity"');
+        $this->assertEquals(is_object($stats->current_queue_activity), true,
+            'Should return an object called "current_queue_activity"');
         $this->assertEquals($this->client->getDebug()->lastResponseCode, '200', 'Does not return HTTP code 200');
     }
 
-    public function testHistoricalQueueActivity() {
+    public function testHistoricalQueueActivity()
+    {
         $stats = $this->client->voice()->stats()->findAll(array('historical_queue_activity' => true));
         $this->assertEquals(is_object($stats), true, 'Should return an object');
-        $this->assertEquals(is_object($stats->historical_queue_activity), true, 'Should return an object called "historical_queue_activity"');
+        $this->assertEquals(is_object($stats->historical_queue_activity), true,
+            'Should return an object called "historical_queue_activity"');
         $this->assertEquals($this->client->getDebug()->lastResponseCode, '200', 'Does not return HTTP code 200');
     }
 
-    public function testAgentsActivity() {
+    public function testAgentsActivity()
+    {
         $stats = $this->client->voice()->stats()->findAll(array('agents_activity' => true));
         $this->assertEquals(is_object($stats), true, 'Should return an object');
-        $this->assertEquals(is_array($stats->agents_activity), true, 'Should return an object containing an array called "agents_activity"');
+        $this->assertEquals(is_array($stats->agents_activity), true,
+            'Should return an object containing an array called "agents_activity"');
         $this->assertEquals($this->client->getDebug()->lastResponseCode, '200', 'Does not return HTTP code 200');
     }
 

--- a/tests/Zendesk/API/UnitTests/BasicTest.php
+++ b/tests/Zendesk/API/UnitTests/BasicTest.php
@@ -7,7 +7,8 @@ use Zendesk\API\Client;
 /**
  * Basic test class
  */
-abstract class BasicTest extends \PHPUnit_Framework_TestCase {
+abstract class BasicTest extends \PHPUnit_Framework_TestCase
+{
 
     protected $client;
     protected $subdomain;
@@ -15,7 +16,8 @@ abstract class BasicTest extends \PHPUnit_Framework_TestCase {
     protected $token;
     protected $oAuthToken;
 
-    public function __construct() {
+    public function __construct()
+    {
         $this->subdomain = getenv('SUBDOMAIN');
         $this->username = getenv('USERNAME');
         $this->password = getenv('PASSWORD');
@@ -25,14 +27,18 @@ abstract class BasicTest extends \PHPUnit_Framework_TestCase {
         $this->client->setAuth('token', $this->token);
     }
 
-    public function authTokenTest() {
+    public function authTokenTest()
+    {
         $tickets = $this->client->tickets()->findAll();
         $this->assertEquals($this->client->getDebug()->lastResponseCode, '200', 'Does not return HTTP code 200');
     }
 
-    public function credentialsTest() {
-        $this->assertEquals($this->subdomain != '', true, 'Expecting $this->subdomain parameter; does phpunit.xml exist?');
+    public function credentialsTest()
+    {
+        $this->assertEquals($this->subdomain != '', true,
+            'Expecting $this->subdomain parameter; does phpunit.xml exist?');
         $this->assertEquals($this->token != '', true, 'Expecting $this->token parameter; does phpunit.xml exist?');
-        $this->assertEquals($this->username != '', true, 'Expecting $this->username parameter; does phpunit.xml exist?');
+        $this->assertEquals($this->username != '', true,
+            'Expecting $this->username parameter; does phpunit.xml exist?');
     }
 }

--- a/tests/Zendesk/API/UnitTests/GroupMembershipsTest.php
+++ b/tests/Zendesk/API/UnitTests/GroupMembershipsTest.php
@@ -7,24 +7,26 @@ use Zendesk\API\Client;
 /**
  * GroupMemberships test class
  */
-class GroupMembershipsTest extends BasicTest {
+class GroupMembershipsTest extends BasicTest
+{
 
-    public function setUp() {
-        
+    public function setUp()
+    {
+
         // Create Group Membership Mock Object
         $membership_mock_object = new \stdClass();
         $membership_mock_object->user_id = 123456;
         $membership_mock_object->group_id = 123456;
         $membership_mock_object->id = 123456;
-        
+
         // Create Group Membership Mock Object for Find/Create/MakeDefault Method
         $find_membership_mock_object = new \stdClass();
         $find_membership_mock_object->group_membership = $membership_mock_object;
-                
+
         // Create Group Memberships Mock Object
         $memberships_mock_object = new \stdClass();
         $memberships_mock_object->group_memberships = Array($membership_mock_object);
-        
+
         // Set Variables that will be used in tests
         $this->mock = $this->getMock('GroupMemberships', array('findAll', 'find', 'create', 'delete', 'makeDefault'));
         $this->group_memberships = $memberships_mock_object;
@@ -32,70 +34,92 @@ class GroupMembershipsTest extends BasicTest {
         $this->find_membership = $find_membership_mock_object;
     }
 
-    public function testFindAll() {
+    public function testFindAll()
+    {
         // Test for FindAll Method - optionally accepts User_id, Group_id, or assignable as parameter
-        $this->mock->expects($this->any())->method('findAll')->withConsecutive(array(),array($this->greaterThan(0)), array($this->greaterThan(0)), array($this->arrayHasKey('assignable')))->will($this->returnValue($this->group_memberships));
-        
+        $this->mock->expects($this->any())->method('findAll')->withConsecutive(array(), array($this->greaterThan(0)),
+            array($this->greaterThan(0)),
+            array($this->arrayHasKey('assignable')))->will($this->returnValue($this->group_memberships));
+
         // Run Test with No parameter
-        $groupMemberships = $this->mock->findAll();    
+        $groupMemberships = $this->mock->findAll();
         $this->assertEquals(is_object($groupMemberships), true, 'Should return an object');
-        $this->assertEquals(is_array($groupMemberships->group_memberships), true, 'Should return an object containing an array called "group_memberships"');
-        $this->assertGreaterThan(0, $groupMemberships->group_memberships[0]->id, 'Returns a non-numeric id for groups[0]');
-        
+        $this->assertEquals(is_array($groupMemberships->group_memberships), true,
+            'Should return an object containing an array called "group_memberships"');
+        $this->assertGreaterThan(0, $groupMemberships->group_memberships[0]->id,
+            'Returns a non-numeric id for groups[0]');
+
         // Run Test with User ID parameter set
         $groupMemberships = $this->mock->findAll($this->group_membership->user_id);
         $this->assertEquals(is_object($groupMemberships), true, 'Should return an object');
-        $this->assertEquals(is_array($groupMemberships->group_memberships), true, 'Should return an object containing an array called "group_memberships"');
-        $this->assertGreaterThan(0, $groupMemberships->group_memberships[0]->id, 'Returns a non-numeric id for groups[0]');
-        
+        $this->assertEquals(is_array($groupMemberships->group_memberships), true,
+            'Should return an object containing an array called "group_memberships"');
+        $this->assertGreaterThan(0, $groupMemberships->group_memberships[0]->id,
+            'Returns a non-numeric id for groups[0]');
+
         // Run Test with Group ID parameter set
         $groupMemberships = $this->mock->findAll($this->group_membership->group_id);
         $this->assertEquals(is_object($groupMemberships), true, 'Should return an object');
-        $this->assertEquals(is_array($groupMemberships->group_memberships), true, 'Should return an object containing an array called "group_memberships"');
-        $this->assertGreaterThan(0, $groupMemberships->group_memberships[0]->id, 'Returns a non-numeric id for groups[0]');
-        
+        $this->assertEquals(is_array($groupMemberships->group_memberships), true,
+            'Should return an object containing an array called "group_memberships"');
+        $this->assertGreaterThan(0, $groupMemberships->group_memberships[0]->id,
+            'Returns a non-numeric id for groups[0]');
+
         // Run Test with Assignable parameter set
-        $groupMemberships = $this->mock->findAll(array("assignable"=>true));
+        $groupMemberships = $this->mock->findAll(array("assignable" => true));
         $this->assertEquals(is_object($groupMemberships), true, 'Should return an object');
-        $this->assertEquals(is_array($groupMemberships->group_memberships), true, 'Should return an object containing an array called "group_memberships"');
-        $this->assertGreaterThan(0, $groupMemberships->group_memberships[0]->id, 'Returns a non-numeric id for groups[0]');
+        $this->assertEquals(is_array($groupMemberships->group_memberships), true,
+            'Should return an object containing an array called "group_memberships"');
+        $this->assertGreaterThan(0, $groupMemberships->group_memberships[0]->id,
+            'Returns a non-numeric id for groups[0]');
     }
 
-    public function testFind() {
+    public function testFind()
+    {
         // Test for Find Method
         $this->mock->expects($this->any())->method('find')->with($this->greaterThan(0))->will($this->returnValue($this->find_membership));
-        
+
         $groupMembership = $this->mock->find($this->find_membership->group_membership->id);
         $this->assertEquals(is_object($groupMembership), true, 'Should return an object');
-        $this->assertEquals(is_object($groupMembership->group_membership), true, 'Should return an object containing an object called "group_membership"');
+        $this->assertEquals(is_object($groupMembership->group_membership), true,
+            'Should return an object containing an object called "group_membership"');
         $this->assertGreaterThan(0, $groupMembership->group_membership->id, 'Returns a non-numeric id for group');
     }
-    
-    public function create() {
+
+    public function create()
+    {
         // Test for Create Method
-        $this->mock->expects($this->any())->method('create')->with($this->greaterThan(0), $this->greaterThan(0))->will($this->returnValue($this->group_membership));
-        
+        $this->mock->expects($this->any())->method('create')->with($this->greaterThan(0),
+            $this->greaterThan(0))->will($this->returnValue($this->group_membership));
+
         $groupMembership = $this->mock->create($this->group_membership->user_id, $this->group_membership->group_id);
         $this->assertEquals(is_object($groupMembership), true, 'Should return an object');
-        $this->assertEquals(is_object($groupMembership->group_membership), true, 'Should return an object called "group_membership"');
-        $this->assertGreaterThan(0, $groupMembership->group_membership->id, 'Returns a non-numeric id for group_membership');
+        $this->assertEquals(is_object($groupMembership->group_membership), true,
+            'Should return an object called "group_membership"');
+        $this->assertGreaterThan(0, $groupMembership->group_membership->id,
+            'Returns a non-numeric id for group_membership');
     }
 
-    public function testDelete() {
+    public function testDelete()
+    {
         // Test for Delete Method
         $this->mock->expects($this->any())->method('delete')->with($this->greaterThan(0))->will($this->returnValue(null));
-        
+
         $groupMembership = $this->mock->delete($this->group_membership->id);
         $this->assertEquals(null, $groupMembership, 'Does not return a null object');
     }
-    
-    public function testMakeDefault() {
+
+    public function testMakeDefault()
+    {
         // Test for MakeDefault Method
-        $this->mock->expects($this->any())->method('makeDefault')->with($this->greaterThan(0), $this->greaterThan(0))->will($this->returnValue($this->group_memberships));
-        
+        $this->mock->expects($this->any())->method('makeDefault')->with($this->greaterThan(0),
+            $this->greaterThan(0))->will($this->returnValue($this->group_memberships));
+
         $groupMemberships = $this->mock->makeDefault($this->group_membership->user_id, $this->group_membership->id);
         $this->assertEquals(is_object($groupMemberships), true, 'Should return an object');
-        $this->assertEquals(is_array($groupMemberships->group_memberships), true, 'Should return an object containing an array called "group_memberships"');
-        $this->assertGreaterThan(0, $groupMemberships->group_memberships[0]->id, 'Returns a non-numeric id for groups[0]');
+        $this->assertEquals(is_array($groupMemberships->group_memberships), true,
+            'Should return an object containing an array called "group_memberships"');
+        $this->assertGreaterThan(0, $groupMemberships->group_memberships[0]->id,
+            'Returns a non-numeric id for groups[0]');
     }
 }

--- a/tests/Zendesk/API/UnitTests/GroupsTest.php
+++ b/tests/Zendesk/API/UnitTests/GroupsTest.php
@@ -7,61 +7,69 @@ use Zendesk\API\Client;
 /**
  * Groups test class
  */
-class GroupsTest extends BasicTest {
+class GroupsTest extends BasicTest
+{
 
-    public function setUP() {
+    public function setUP()
+    {
         // Create Group Mock Object
         $group_mock_object = new \stdClass();
         $group_mock_object->group = new \stdClass();
         $group_mock_object->group->name = 'New Group';
         $group_mock_object->group->id = 123456;
-        
+
         // Set Variables that will be used in other tests
         $this->mock = $this->getMock('Groups', array('create', 'findAll', 'find', 'update', 'delete'));
-        $this->group = $group_mock_object;        
+        $this->group = $group_mock_object;
     }
-    
-    public function create() {
+
+    public function create()
+    {
         // Test for Create Method
         $this->mock->expects($this->any())->method('create')->will($this->returnValue($this->returnArgument(0)));
         $group = $this->mock->create($this->group);
-        
+
         $this->assertEquals(is_object($group), true, 'Should return an object');
         $this->assertEquals(is_object($group->group), true, 'Should return an object called "group"');
         $this->assertGreaterThan(0, $group->group->id, 'Returns a non-numeric id for group');
         $this->assertEquals($group->group->name, 'New Group', 'Name of test group does not match');
     }
 
-    public function testAll() {
+    public function testAll()
+    {
         // Test for FindAll Method
-        $this->mock->expects($this->any())->method('findAll')->will($this->returnValue($this->group)); 
+        $this->mock->expects($this->any())->method('findAll')->will($this->returnValue($this->group));
         $groups = $this->mock->findAll();
- 
+
         $this->assertEquals(is_object($groups), true, 'Should return an object');
         $this->assertEquals(is_object($groups->group), true, 'Should return an object called "group"');
         $this->assertGreaterThan(0, $groups->group->id, 'Returns a non-numeric id for groups[0]');
     }
 
-    public function testAssignable() {
+    public function testAssignable()
+    {
         // Test for FindAll Method with 'assignable' parameter
         $this->mock->expects($this->any())->method('findAll')->will($this->returnValue($this->group));
         $groups = $this->mock->findAll(array('assignable' => true));
 
         $this->assertEquals(is_object($groups), true, 'Should return an object');
-        $this->assertEquals(is_object($groups->group), true, 'Should return an object containing an array called "groups"');
+        $this->assertEquals(is_object($groups->group), true,
+            'Should return an object containing an array called "groups"');
         $this->assertGreaterThan(0, $groups->group->id, 'Returns a non-numeric id for groups[0]');
     }
 
-    public function testFind() {
+    public function testFind()
+    {
         // Test for Find Method
         $this->mock->expects($this->any())->method('find')->will($this->returnValue($this->group));
         $group = $this->mock->find($this->group->group->id);
-        
+
         $this->assertEquals(is_object($group), true, 'Should return an object');
         $this->assertGreaterThan(0, $group->group->id, 'Returns a non-numeric id for group');
     }
 
-    public function testUpdate() {
+    public function testUpdate()
+    {
         // Test for Update Method
         $this->mock->expects($this->any())->method('update')->will($this->returnArgument(0));
         $this->group->group->name = "New Group II";
@@ -73,7 +81,8 @@ class GroupsTest extends BasicTest {
         $this->assertEquals($group->group->name, 'New Group II', 'Name of test group does not match');
     }
 
-    public function tearDown() {
+    public function tearDown()
+    {
         // Test for Delete Method
         $this->mock->expects($this->any())->method('delete')->will($this->returnValue(null));
         $group = $this->mock->delete($this->group->group->id);

--- a/tests/Zendesk/API/UnitTests/HttpTest.php
+++ b/tests/Zendesk/API/UnitTests/HttpTest.php
@@ -1,6 +1,7 @@
 <?php
 
 namespace Zendesk\API\UnitTests;
+
 use Zendesk\API\Client;
 use Zendesk\API\Http;
 
@@ -9,108 +10,148 @@ use Zendesk\API\Http;
 /**
  * Http test class
  */
-class HttpTest extends BasicTest {
-    public function setUp() {
+class HttpTest extends BasicTest
+{
+    public function setUp()
+    {
         Http::$curl = new MockCurlRequest();
     }
 
-    public function testGetRequest() {
+    public function testGetRequest()
+    {
         $response = Http::send($this->client, 'tickets.json');
 
         $this->assertEquals(is_object($response), true, 'Should return an object');
-        $this->assertEquals($response->{CURLOPT_URL}, $this->client->getApiUrl() . Http::prepare('tickets.json') . '?', 'Should be the correct url');
+        $this->assertEquals($response->{CURLOPT_URL}, $this->client->getApiUrl() . Http::prepare('tickets.json') . '?',
+            'Should be the correct url');
         $this->assertEquals($response->{CURLOPT_CUSTOMREQUEST}, 'GET', 'Should be a GET');
-        $this->assertContains('Accept: application/json', $response->{CURLOPT_HTTPHEADER}, 'Should contain a Accept header');
-        $this->assertContains('Content-Type: application/json', $response->{CURLOPT_HTTPHEADER}, 'Should contain a Content-Type header');
+        $this->assertContains('Accept: application/json', $response->{CURLOPT_HTTPHEADER},
+            'Should contain a Accept header');
+        $this->assertContains('Content-Type: application/json', $response->{CURLOPT_HTTPHEADER},
+            'Should contain a Content-Type header');
     }
 
-    public function testGetRequestWithQuery() {
+    public function testGetRequestWithQuery()
+    {
         $response = Http::send($this->client, 'tickets.json', ['check' => 1]);
 
         $this->assertEquals(is_object($response), true, 'Should return an object');
-        $this->assertEquals($response->{CURLOPT_URL}, $this->client->getApiUrl() . Http::prepare('tickets.json') . '?check=1', 'Should be the correct url');
+        $this->assertEquals($response->{CURLOPT_URL},
+            $this->client->getApiUrl() . Http::prepare('tickets.json') . '?check=1', 'Should be the correct url');
         $this->assertEquals($response->{CURLOPT_CUSTOMREQUEST}, 'GET', 'Should be a GET');
-        $this->assertContains('Accept: application/json', $response->{CURLOPT_HTTPHEADER}, 'Should contain a Accept header');
-        $this->assertContains('Content-Type: application/json', $response->{CURLOPT_HTTPHEADER}, 'Should contain a Content-Type header');
+        $this->assertContains('Accept: application/json', $response->{CURLOPT_HTTPHEADER},
+            'Should contain a Accept header');
+        $this->assertContains('Content-Type: application/json', $response->{CURLOPT_HTTPHEADER},
+            'Should contain a Content-Type header');
     }
 
-    public function testGetRequestWithContentType() {
+    public function testGetRequestWithContentType()
+    {
         $response = Http::send($this->client, 'tickets.json', [], 'GET', 'application/x-www-form-urlencoded');
 
         $this->assertEquals(is_object($response), true, 'Should return an object');
-        $this->assertEquals($response->{CURLOPT_URL}, $this->client->getApiUrl() . Http::prepare('tickets.json') . '?', 'Should be the correct url');
+        $this->assertEquals($response->{CURLOPT_URL}, $this->client->getApiUrl() . Http::prepare('tickets.json') . '?',
+            'Should be the correct url');
         $this->assertEquals($response->{CURLOPT_CUSTOMREQUEST}, 'GET', 'Should be a GET');
-        $this->assertContains('Accept: application/json', $response->{CURLOPT_HTTPHEADER}, 'Should contain a Accept header');
-        $this->assertContains('Content-Type: application/x-www-form-urlencoded', $response->{CURLOPT_HTTPHEADER}, 'Should contain a Content-Type header');
+        $this->assertContains('Accept: application/json', $response->{CURLOPT_HTTPHEADER},
+            'Should contain a Accept header');
+        $this->assertContains('Content-Type: application/x-www-form-urlencoded', $response->{CURLOPT_HTTPHEADER},
+            'Should contain a Content-Type header');
     }
 
-    public function testPostRequest() {
+    public function testPostRequest()
+    {
         $response = Http::send($this->client, 'tickets.json', [], 'POST');
 
         $this->assertEquals(is_object($response), true, 'Should return an object');
-        $this->assertEquals($response->{CURLOPT_URL}, $this->client->getApiUrl() . Http::prepare('tickets.json'), 'Should be the correct url');
+        $this->assertEquals($response->{CURLOPT_URL}, $this->client->getApiUrl() . Http::prepare('tickets.json'),
+            'Should be the correct url');
         $this->assertEquals($response->{CURLOPT_POST}, true, 'Should be a POST');
-        $this->assertContains('Accept: application/json', $response->{CURLOPT_HTTPHEADER}, 'Should contain a Accept header');
-        $this->assertContains('Content-Type: application/json', $response->{CURLOPT_HTTPHEADER}, 'Should contain a Content-Type header');
+        $this->assertContains('Accept: application/json', $response->{CURLOPT_HTTPHEADER},
+            'Should contain a Accept header');
+        $this->assertContains('Content-Type: application/json', $response->{CURLOPT_HTTPHEADER},
+            'Should contain a Content-Type header');
     }
 
-    public function testPostRequestWithData() {
+    public function testPostRequestWithData()
+    {
         $response = Http::send($this->client, 'tickets.json', ['check' => 1], 'POST');
 
         $this->assertEquals(is_object($response), true, 'Should return an object');
-        $this->assertEquals($response->{CURLOPT_URL}, $this->client->getApiUrl() . Http::prepare('tickets.json'), 'Should be the correct url');
+        $this->assertEquals($response->{CURLOPT_URL}, $this->client->getApiUrl() . Http::prepare('tickets.json'),
+            'Should be the correct url');
         $this->assertEquals($response->{CURLOPT_POST}, true, 'Should be a POST');
         $this->assertEquals($response->{CURLOPT_POSTFIELDS}, '{"check":1}', 'Should have POST data');
-        $this->assertContains('Accept: application/json', $response->{CURLOPT_HTTPHEADER}, 'Should contain a Accept header');
-        $this->assertContains('Content-Type: application/json', $response->{CURLOPT_HTTPHEADER}, 'Should contain a Content-Type header');
+        $this->assertContains('Accept: application/json', $response->{CURLOPT_HTTPHEADER},
+            'Should contain a Accept header');
+        $this->assertContains('Content-Type: application/json', $response->{CURLOPT_HTTPHEADER},
+            'Should contain a Content-Type header');
     }
 
-    public function testPostRequestWithContentType() {
-        $response = Http::send($this->client, 'tickets.json', ['check' => 1], 'POST', 'application/x-www-form-urlencoded');
+    public function testPostRequestWithContentType()
+    {
+        $response = Http::send($this->client, 'tickets.json', ['check' => 1], 'POST',
+            'application/x-www-form-urlencoded');
 
         $data = new \StdClass;
         $data->check = 1;
 
         $this->assertEquals(is_object($response), true, 'Should return an object');
-        $this->assertEquals($response->{CURLOPT_URL}, $this->client->getApiUrl() . Http::prepare('tickets.json'), 'Should be the correct url');
+        $this->assertEquals($response->{CURLOPT_URL}, $this->client->getApiUrl() . Http::prepare('tickets.json'),
+            'Should be the correct url');
         $this->assertEquals($response->{CURLOPT_POST}, true, 'Should be a POST');
         $this->assertEquals($response->{CURLOPT_POSTFIELDS}, $data, 'Should have POST data');
-        $this->assertContains('Accept: application/json', $response->{CURLOPT_HTTPHEADER}, 'Should contain a Accept header');
-        $this->assertContains('Content-Type: application/x-www-form-urlencoded', $response->{CURLOPT_HTTPHEADER}, 'Should contain a Content-Type header');
+        $this->assertContains('Accept: application/json', $response->{CURLOPT_HTTPHEADER},
+            'Should contain a Accept header');
+        $this->assertContains('Content-Type: application/x-www-form-urlencoded', $response->{CURLOPT_HTTPHEADER},
+            'Should contain a Content-Type header');
     }
 
-    public function testPutRequest() {
+    public function testPutRequest()
+    {
         $response = Http::send($this->client, 'tickets.json', [], 'PUT');
 
         $this->assertEquals(is_object($response), true, 'Should return an object');
-        $this->assertEquals($response->{CURLOPT_URL}, $this->client->getApiUrl() . Http::prepare('tickets.json'), 'Should be the correct url');
+        $this->assertEquals($response->{CURLOPT_URL}, $this->client->getApiUrl() . Http::prepare('tickets.json'),
+            'Should be the correct url');
         $this->assertEquals($response->{CURLOPT_CUSTOMREQUEST}, 'PUT', 'Should be a PUT');
-        $this->assertContains('Accept: application/json', $response->{CURLOPT_HTTPHEADER}, 'Should contain a Accept header');
-        $this->assertContains('Content-Type: application/json', $response->{CURLOPT_HTTPHEADER}, 'Should contain a Content-Type header');
+        $this->assertContains('Accept: application/json', $response->{CURLOPT_HTTPHEADER},
+            'Should contain a Accept header');
+        $this->assertContains('Content-Type: application/json', $response->{CURLOPT_HTTPHEADER},
+            'Should contain a Content-Type header');
     }
 
-    public function testPutRequestWithData() {
+    public function testPutRequestWithData()
+    {
         $response = Http::send($this->client, 'tickets.json', ['check' => 1], 'PUT');
 
         $this->assertEquals(is_object($response), true, 'Should return an object');
-        $this->assertEquals($response->{CURLOPT_URL}, $this->client->getApiUrl() . Http::prepare('tickets.json'), 'Should be the correct url');
+        $this->assertEquals($response->{CURLOPT_URL}, $this->client->getApiUrl() . Http::prepare('tickets.json'),
+            'Should be the correct url');
         $this->assertEquals($response->{CURLOPT_CUSTOMREQUEST}, 'PUT', 'Should be a PUT');
         $this->assertEquals($response->{CURLOPT_POSTFIELDS}, '{"check":1}', 'Should have PUT data');
-        $this->assertContains('Accept: application/json', $response->{CURLOPT_HTTPHEADER}, 'Should contain a Accept header');
-        $this->assertContains('Content-Type: application/json', $response->{CURLOPT_HTTPHEADER}, 'Should contain a Content-Type header');
+        $this->assertContains('Accept: application/json', $response->{CURLOPT_HTTPHEADER},
+            'Should contain a Accept header');
+        $this->assertContains('Content-Type: application/json', $response->{CURLOPT_HTTPHEADER},
+            'Should contain a Content-Type header');
     }
 
-    public function testPutRequestWithContentType() {
-        $response = Http::send($this->client, 'tickets.json', ['check' => 1], 'PUT', 'application/x-www-form-urlencoded');
+    public function testPutRequestWithContentType()
+    {
+        $response = Http::send($this->client, 'tickets.json', ['check' => 1], 'PUT',
+            'application/x-www-form-urlencoded');
 
         $data = new \StdClass;
         $data->check = 1;
 
         $this->assertEquals(is_object($response), true, 'Should return an object');
-        $this->assertEquals($response->{CURLOPT_URL}, $this->client->getApiUrl() . Http::prepare('tickets.json'), 'Should be the correct url');
+        $this->assertEquals($response->{CURLOPT_URL}, $this->client->getApiUrl() . Http::prepare('tickets.json'),
+            'Should be the correct url');
         $this->assertEquals($response->{CURLOPT_CUSTOMREQUEST}, 'PUT', 'Should be a PUT');
         $this->assertEquals($response->{CURLOPT_POSTFIELDS}, $data, 'Should have POST data');
-        $this->assertContains('Accept: application/json', $response->{CURLOPT_HTTPHEADER}, 'Should contain a Accept header');
-        $this->assertContains('Content-Type: application/x-www-form-urlencoded', $response->{CURLOPT_HTTPHEADER}, 'Should contain a Content-Type header');
+        $this->assertContains('Accept: application/json', $response->{CURLOPT_HTTPHEADER},
+            'Should contain a Accept header');
+        $this->assertContains('Content-Type: application/x-www-form-urlencoded', $response->{CURLOPT_HTTPHEADER},
+            'Should contain a Content-Type header');
     }
 }

--- a/tests/Zendesk/API/UnitTests/MockCurlRequest.php
+++ b/tests/Zendesk/API/UnitTests/MockCurlRequest.php
@@ -2,82 +2,203 @@
 
 namespace Zendesk\API\UnitTests;
 
-class MockCurlRequest {
+class MockCurlRequest
+{
     protected $handle = null;
     private $options = [];
     private $constants = [];
 
-    public function __construct($url = NULL) {
-        foreach (['CURLINFO_HEADER_OUT', 'CURLOPT_AUTOREFERER', 'CURLOPT_COOKIESESSION', 'CURLOPT_DNS_USE_GLOBAL_CACHE', 'CURLOPT_DNS_CACHE_TIMEOUT', 'CURLOPT_FTP_SSL', 'CURLOPT_PRIVATE', 'CURLOPT_FTPSSLAUTH', 'CURLOPT_PORT', 'CURLOPT_FILE', 'CURLOPT_INFILE', 'CURLOPT_INFILESIZE', 'CURLOPT_URL', 'CURLOPT_PROXY', 'CURLOPT_VERBOSE', 'CURLOPT_HEADER', 'CURLOPT_HTTPHEADER', 'CURLOPT_NOPROGRESS', 'CURLOPT_NOBODY', 'CURLOPT_FAILONERROR', 'CURLOPT_UPLOAD', 'CURLOPT_POST', 'CURLOPT_FTPLISTONLY', 'CURLOPT_FTPAPPEND', 'CURLOPT_FTP_CREATE_MISSING_DIRS', 'CURLOPT_NETRC', 'CURLOPT_FOLLOWLOCATION', 'CURLOPT_PUT', 'CURLOPT_USERPWD', 'CURLOPT_PROXYUSERPWD', 'CURLOPT_RANGE', 'CURLOPT_TIMEOUT', 'CURLOPT_TIMEOUT_MS', 'CURLOPT_TCP_NODELAY', 'CURLOPT_POSTFIELDS', 'CURLOPT_PROGRESSFUNCTION', 'CURLOPT_REFERER', 'CURLOPT_USERAGENT', 'CURLOPT_FTPPORT', 'CURLOPT_FTP_USE_EPSV', 'CURLOPT_LOW_SPEED_LIMIT', 'CURLOPT_LOW_SPEED_TIME', 'CURLOPT_RESUME_FROM', 'CURLOPT_COOKIE', 'CURLOPT_SSLCERT', 'CURLOPT_SSLCERTPASSWD', 'CURLOPT_WRITEHEADER', 'CURLOPT_SSL_VERIFYHOST', 'CURLOPT_COOKIEFILE', 'CURLOPT_SSLVERSION', 'CURLOPT_TIMECONDITION', 'CURLOPT_TIMEVALUE', 'CURLOPT_CUSTOMREQUEST', 'CURLOPT_STDERR', 'CURLOPT_TRANSFERTEXT', 'CURLOPT_RETURNTRANSFER', 'CURLOPT_QUOTE', 'CURLOPT_POSTQUOTE', 'CURLOPT_INTERFACE', 'CURLOPT_KRB4LEVEL', 'CURLOPT_HTTPPROXYTUNNEL', 'CURLOPT_FILETIME', 'CURLOPT_WRITEFUNCTION', 'CURLOPT_READFUNCTION', 'CURLOPT_HEADERFUNCTION', 'CURLOPT_MAXREDIRS', 'CURLOPT_MAXCONNECTS', 'CURLOPT_CLOSEPOLICY', 'CURLOPT_FRESH_CONNECT', 'CURLOPT_FORBID_REUSE', 'CURLOPT_RANDOM_FILE', 'CURLOPT_EGDSOCKET', 'CURLOPT_CONNECTTIMEOUT', 'CURLOPT_CONNECTTIMEOUT_MS', 'CURLOPT_SSL_VERIFYPEER', 'CURLOPT_CAINFO', 'CURLOPT_CAPATH', 'CURLOPT_COOKIEJAR', 'CURLOPT_SSL_CIPHER_LIST', 'CURLOPT_BINARYTRANSFER', 'CURLOPT_NOSIGNAL', 'CURLOPT_PROXYTYPE', 'CURLOPT_BUFFERSIZE', 'CURLOPT_HTTPGET', 'CURLOPT_HTTP_VERSION', 'CURLOPT_SSLKEY', 'CURLOPT_SSLKEYTYPE', 'CURLOPT_SSLENGINE', 'CURLOPT_SSLENGINE_DEFAULT', 'CURLOPT_SSLCERTTYPE', 'CURLOPT_CRLF', 'CURLOPT_ENCODING', 'CURLOPT_PROXYPORT', 'CURLOPT_UNRESTRICTED_AUTH', 'CURLOPT_FTP_USE_EPRT', 'CURLOPT_HTTP200ALIASES', 'CURLOPT_HTTPAUTH', 'CURLOPT_PROXYAUTH', 'CURLOPT_MAX_RECV_SPEED_LARGE', 'CURLOPT_MAX_SEND_SPEED_LARGE'] as $k) {
+    public function __construct($url = null)
+    {
+        foreach ([
+                     'CURLINFO_HEADER_OUT',
+                     'CURLOPT_AUTOREFERER',
+                     'CURLOPT_COOKIESESSION',
+                     'CURLOPT_DNS_USE_GLOBAL_CACHE',
+                     'CURLOPT_DNS_CACHE_TIMEOUT',
+                     'CURLOPT_FTP_SSL',
+                     'CURLOPT_PRIVATE',
+                     'CURLOPT_FTPSSLAUTH',
+                     'CURLOPT_PORT',
+                     'CURLOPT_FILE',
+                     'CURLOPT_INFILE',
+                     'CURLOPT_INFILESIZE',
+                     'CURLOPT_URL',
+                     'CURLOPT_PROXY',
+                     'CURLOPT_VERBOSE',
+                     'CURLOPT_HEADER',
+                     'CURLOPT_HTTPHEADER',
+                     'CURLOPT_NOPROGRESS',
+                     'CURLOPT_NOBODY',
+                     'CURLOPT_FAILONERROR',
+                     'CURLOPT_UPLOAD',
+                     'CURLOPT_POST',
+                     'CURLOPT_FTPLISTONLY',
+                     'CURLOPT_FTPAPPEND',
+                     'CURLOPT_FTP_CREATE_MISSING_DIRS',
+                     'CURLOPT_NETRC',
+                     'CURLOPT_FOLLOWLOCATION',
+                     'CURLOPT_PUT',
+                     'CURLOPT_USERPWD',
+                     'CURLOPT_PROXYUSERPWD',
+                     'CURLOPT_RANGE',
+                     'CURLOPT_TIMEOUT',
+                     'CURLOPT_TIMEOUT_MS',
+                     'CURLOPT_TCP_NODELAY',
+                     'CURLOPT_POSTFIELDS',
+                     'CURLOPT_PROGRESSFUNCTION',
+                     'CURLOPT_REFERER',
+                     'CURLOPT_USERAGENT',
+                     'CURLOPT_FTPPORT',
+                     'CURLOPT_FTP_USE_EPSV',
+                     'CURLOPT_LOW_SPEED_LIMIT',
+                     'CURLOPT_LOW_SPEED_TIME',
+                     'CURLOPT_RESUME_FROM',
+                     'CURLOPT_COOKIE',
+                     'CURLOPT_SSLCERT',
+                     'CURLOPT_SSLCERTPASSWD',
+                     'CURLOPT_WRITEHEADER',
+                     'CURLOPT_SSL_VERIFYHOST',
+                     'CURLOPT_COOKIEFILE',
+                     'CURLOPT_SSLVERSION',
+                     'CURLOPT_TIMECONDITION',
+                     'CURLOPT_TIMEVALUE',
+                     'CURLOPT_CUSTOMREQUEST',
+                     'CURLOPT_STDERR',
+                     'CURLOPT_TRANSFERTEXT',
+                     'CURLOPT_RETURNTRANSFER',
+                     'CURLOPT_QUOTE',
+                     'CURLOPT_POSTQUOTE',
+                     'CURLOPT_INTERFACE',
+                     'CURLOPT_KRB4LEVEL',
+                     'CURLOPT_HTTPPROXYTUNNEL',
+                     'CURLOPT_FILETIME',
+                     'CURLOPT_WRITEFUNCTION',
+                     'CURLOPT_READFUNCTION',
+                     'CURLOPT_HEADERFUNCTION',
+                     'CURLOPT_MAXREDIRS',
+                     'CURLOPT_MAXCONNECTS',
+                     'CURLOPT_CLOSEPOLICY',
+                     'CURLOPT_FRESH_CONNECT',
+                     'CURLOPT_FORBID_REUSE',
+                     'CURLOPT_RANDOM_FILE',
+                     'CURLOPT_EGDSOCKET',
+                     'CURLOPT_CONNECTTIMEOUT',
+                     'CURLOPT_CONNECTTIMEOUT_MS',
+                     'CURLOPT_SSL_VERIFYPEER',
+                     'CURLOPT_CAINFO',
+                     'CURLOPT_CAPATH',
+                     'CURLOPT_COOKIEJAR',
+                     'CURLOPT_SSL_CIPHER_LIST',
+                     'CURLOPT_BINARYTRANSFER',
+                     'CURLOPT_NOSIGNAL',
+                     'CURLOPT_PROXYTYPE',
+                     'CURLOPT_BUFFERSIZE',
+                     'CURLOPT_HTTPGET',
+                     'CURLOPT_HTTP_VERSION',
+                     'CURLOPT_SSLKEY',
+                     'CURLOPT_SSLKEYTYPE',
+                     'CURLOPT_SSLENGINE',
+                     'CURLOPT_SSLENGINE_DEFAULT',
+                     'CURLOPT_SSLCERTTYPE',
+                     'CURLOPT_CRLF',
+                     'CURLOPT_ENCODING',
+                     'CURLOPT_PROXYPORT',
+                     'CURLOPT_UNRESTRICTED_AUTH',
+                     'CURLOPT_FTP_USE_EPRT',
+                     'CURLOPT_HTTP200ALIASES',
+                     'CURLOPT_HTTPAUTH',
+                     'CURLOPT_PROXYAUTH',
+                     'CURLOPT_MAX_RECV_SPEED_LARGE',
+                     'CURLOPT_MAX_SEND_SPEED_LARGE'
+                 ] as $k) {
             $this->constants[constant($k)] = $k;
         }
         $this->handle = curl_init($url);
     }
 
-    public function close() {
+    public function close()
+    {
         return curl_close($this->handle);
     }
 
-    public function copy_handle() {
+    public function copy_handle()
+    {
         return curl_copy_handle($this->handle);
     }
 
-    public function errno() {
+    public function errno()
+    {
         return curl_errno($this->handle);
     }
 
-    public function error() {
+    public function error()
+    {
         return curl_error($this->handle);
     }
 
-    public function escape($str) {
+    public function escape($str)
+    {
         return curl_escape($this->handle, $str);
     }
 
-    public function exec() {
+    public function exec()
+    {
         return json_encode($this->getopt_array());
     }
 
-    public function file_create($filename, $mimetype = NULL, $postname = NULL) {
+    public function file_create($filename, $mimetype = null, $postname = null)
+    {
         return curl_file_create($filename, $mimetype, $postname);
     }
 
-    public function getinfo($opt = 0) {
+    public function getinfo($opt = 0)
+    {
         return curl_getinfo($this->handle, $opt);
     }
 
-    public function pause($bitmask) {
+    public function pause($bitmask)
+    {
         return curl_pause($this->handle, $bitmask);
     }
 
-    public function reset() {
+    public function reset()
+    {
         return curl_reset($this->handle);
     }
 
-    public function setopt_array($options) {
+    public function setopt_array($options)
+    {
         $this->options = $options;
+
         return curl_setopt_array($this->handle, $options);
     }
 
-    public function setopt($option, $value) {
+    public function setopt($option, $value)
+    {
         //$this->options[ (isset($this->constants[$option]) ? $this->constants[$option] : $option) ] = $value;
-        $this->options[ $option ] = $value;
+        $this->options[$option] = $value;
+
         return curl_setopt($this->handle, $option, $value);
     }
 
-    public function getopt_array() {
+    public function getopt_array()
+    {
         return $this->options;
     }
 
-    public function strerror($errornum ) {
+    public function strerror($errornum)
+    {
         return curl_strerror($errornum);
     }
 
-    public function unescape($str) {
+    public function unescape($str)
+    {
         return curl_unescape($this->handle, $str);
     }
 
-    public function version($age = CURLVERSION_NOW) {
+    public function version($age = CURLVERSION_NOW)
+    {
         return curl_version($age);
     }
 }

--- a/tests/Zendesk/API/UnitTests/OrganizationsTest.php
+++ b/tests/Zendesk/API/UnitTests/OrganizationsTest.php
@@ -7,9 +7,11 @@ use Zendesk\API\Client;
 /**
  * Organizations test class
  */
-class OrganizationsTest extends BasicTest {
+class OrganizationsTest extends BasicTest
+{
 
-    public function setUP() {
+    public function setUP()
+    {
         // Create Organizations Mock Object
         $organization_mock_object = new \stdClass();
         $organization_mock_object->organization = new \stdClass();
@@ -18,141 +20,176 @@ class OrganizationsTest extends BasicTest {
         $organization_mock_object->organization_related = new \stdClass();
         $organization_mock_object->job_status = new \stdClass();
         $organization_mock_object->job_status->id = 123456;
-        $organization_mock_object->organizations = Array($organization_mock_object->organization, clone $organization_mock_object->organization);
-                
+        $organization_mock_object->organizations = Array(
+            $organization_mock_object->organization,
+            clone $organization_mock_object->organization
+        );
+
         // Set Variables that will be used in other tests
-        $this->mock = $this->getMock('Organizations', array('findAll', 'find', 'create', 'createMany', 'update', 'delete', 'autocomplete', 'related', 'search'));
-        $this->organizations = $organization_mock_object;          
+        $this->mock = $this->getMock('Organizations',
+            array('findAll', 'find', 'create', 'createMany', 'update', 'delete', 'autocomplete', 'related', 'search'));
+        $this->organizations = $organization_mock_object;
     }
 
-    public function testFindAll() {
+    public function testFindAll()
+    {
         // Test for FindAll Method - optionally accepts User_id as parameter
         $this->mock->expects($this->any())
-                    ->method('findAll')
-                    ->withConsecutive(array(),array($this->greaterThan(0)))
-                    ->will($this->returnValue($this->organizations));
-        
+            ->method('findAll')
+            ->withConsecutive(array(), array($this->greaterThan(0)))
+            ->will($this->returnValue($this->organizations));
+
         // Run Test with No parameter
         $organizations = $this->mock->findAll();
         $this->assertEquals(is_object($organizations), true, 'Should return an object');
-        $this->assertEquals(is_array($organizations->organizations), true, 'Should return an object containing an array called "organizations"');
-        $this->assertGreaterThan(0, $organizations->organizations[0]->id, 'Returns a non-numeric id for organizations[0]');
-        
+        $this->assertEquals(is_array($organizations->organizations), true,
+            'Should return an object containing an array called "organizations"');
+        $this->assertGreaterThan(0, $organizations->organizations[0]->id,
+            'Returns a non-numeric id for organizations[0]');
+
         // Run Test with User ID parameter
         $organizations = $this->mock->findAll(123456);
         $this->assertEquals(is_object($organizations), true, 'Should return an object');
-        $this->assertEquals(is_array($organizations->organizations), true, 'Should return an object containing an array called "organizations"');
-        $this->assertGreaterThan(0, $organizations->organizations[0]->id, 'Returns a non-numeric id for organizations[0]');
+        $this->assertEquals(is_array($organizations->organizations), true,
+            'Should return an object containing an array called "organizations"');
+        $this->assertGreaterThan(0, $organizations->organizations[0]->id,
+            'Returns a non-numeric id for organizations[0]');
     }
 
-    public function testFind() {
+    public function testFind()
+    {
         // Test for Find Method - requires an Organization ID as parameter
         $this->mock->expects($this->any())
-                    ->method('find')
-                    ->with($this->greaterThan(0))
-                    ->will($this->returnValue($this->organizations));
-        
+            ->method('find')
+            ->with($this->greaterThan(0))
+            ->will($this->returnValue($this->organizations));
+
         // Run Test with Organization ID parameter
         $organization = $this->mock->find(123456);
         $this->assertEquals(is_object($organization), true, 'Should return an object');
-        $this->assertEquals(is_object($organization->organization), true, 'Should return an object containing an object called "organization"');
+        $this->assertEquals(is_object($organization->organization), true,
+            'Should return an object containing an object called "organization"');
         $this->assertGreaterThan(0, $organization->organization->id, 'Returns a non-numeric id for organization');
     }
-    
-    public function testCreate() {
+
+    public function testCreate()
+    {
         // Test for Create Method - requires an Organization Name as parameter
         $this->mock->expects($this->any())
-                    ->method('create')
-                    ->with($this->isType('string'))
-                    ->will($this->returnCallback(function($name) { $this->organizations->organization->name = $name;
-                                                                     return $this->organizations; }));
+            ->method('create')
+            ->with($this->isType('string'))
+            ->will($this->returnCallback(function ($name) {
+                $this->organizations->organization->name = $name;
+
+                return $this->organizations;
+            }));
 
         $organization = $this->mock->create('Test Organization');
         $this->assertEquals(is_object($organization), true, 'Should return an object');
-        $this->assertEquals(is_object($organization->organization), true, 'Should return an object containing an object called "organization"');
+        $this->assertEquals(is_object($organization->organization), true,
+            'Should return an object containing an object called "organization"');
         $this->assertGreaterThan(0, $organization->organization->id, 'Returns a non-numeric id for organization');
-        $this->assertEquals($organization->organization->name, 'Test Organization', 'Name of test organization does not match');
+        $this->assertEquals($organization->organization->name, 'Test Organization',
+            'Name of test organization does not match');
 
     }
-    
-    public function testCreateMany() {
+
+    public function testCreateMany()
+    {
         // Test for CreateMany Method - requires an Organization Name as parameter and should return a job status rather than an Organization object
         $this->mock->expects($this->any())
-                    ->method('createMany')
-                    ->with($this->isType('string'), $this->isType('string'))
-                    ->will($this->returnValue($this->organizations));
+            ->method('createMany')
+            ->with($this->isType('string'), $this->isType('string'))
+            ->will($this->returnValue($this->organizations));
 
         $organizations = $this->mock->createMany('Organization I', 'Organization II');
         $this->assertEquals(is_object($organizations), true, 'Should return an object');
-        $this->assertEquals(is_object($organizations->job_status), true, 'Should return an object containing an object called job_status"');
-        $this->assertGreaterThan(0, $organizations->job_status->id, 'Should return a non-numeric id for job status object');
+        $this->assertEquals(is_object($organizations->job_status), true,
+            'Should return an object containing an object called job_status"');
+        $this->assertGreaterThan(0, $organizations->job_status->id,
+            'Should return a non-numeric id for job status object');
     }
 
-    public function testUpdate() {
+    public function testUpdate()
+    {
         // Test for Update Method - requires an Organization ID and another value as parameters
         // Create a clone of the original object to ensure that the change results in a different object than the original
         $this->mock->expects($this->any())
-                    ->method('update')
-                    ->with($this->greaterThan(0), $this->isType('string'))
-                    ->will($this->returnCallback(function($name) { $update_organization = clone $this->organizations->organization; 
-                                                                    $update_organization->name = $name; 
-                                                                    return $update_organization; }));
-        
+            ->method('update')
+            ->with($this->greaterThan(0), $this->isType('string'))
+            ->will($this->returnCallback(function ($name) {
+                $update_organization = clone $this->organizations->organization;
+                $update_organization->name = $name;
+
+                return $update_organization;
+            }));
+
         $organization = $this->mock->update(123456, "Test Organization II");
         $this->assertEquals(is_object($organization), true, 'Should return an object');
-        $this->assertEquals(is_object($organization), true, 'Should return an object containing an object called "organization"');
+        $this->assertEquals(is_object($organization), true,
+            'Should return an object containing an object called "organization"');
         $this->assertGreaterThan(0, $organization->id, 'Returns a non-numeric id for organization');
-        $this->assertNotEquals($this->organizations->organization, $organization, 'Should return an organization that is not the same as the original');
+        $this->assertNotEquals($this->organizations->organization, $organization,
+            'Should return an organization that is not the same as the original');
     }
-    
-    public function testDelete() {
+
+    public function testDelete()
+    {
         // Test for Delete Method - requires an Organization ID as parameter
         $this->mock->expects($this->any())
-                    ->method('delete')
-                    ->with($this->greaterThan(0))
-                    ->will($this->returnValue(null));
- 
+            ->method('delete')
+            ->with($this->greaterThan(0))
+            ->will($this->returnValue(null));
+
         $organization = $this->mock->delete(123456);
         $this->assertEquals(null, $organization, 'Does not return a null object');
     }
-    
-    public function testAutocomplete() {
+
+    public function testAutocomplete()
+    {
         // Test for Autocomplete Method - requires a partial Organization Name as parameter
         $this->mock->expects($this->any())
-                    ->method('autocomplete')
-                    ->with($this->isType('string'))
-                    ->will($this->returnValue($this->organizations));
-        
+            ->method('autocomplete')
+            ->with($this->isType('string'))
+            ->will($this->returnValue($this->organizations));
+
         $organizations = $this->mock->autocomplete('New');
         $this->assertEquals(is_object($organizations), true, 'Should return an object');
-        $this->assertEquals(is_array($organizations->organizations), true, 'Should return an object containing an array called "organizations"');
+        $this->assertEquals(is_array($organizations->organizations), true,
+            'Should return an object containing an array called "organizations"');
         $this->assertGreaterThan(0, $organizations->organizations[0]->id, 'Returns a non-numeric id for organization');
-        $this->assertContains('New', $organizations->organizations[0]->name, 'Should return an string that contains the search term for organization name');
+        $this->assertContains('New', $organizations->organizations[0]->name,
+            'Should return an string that contains the search term for organization name');
     }
 
-    public function testRelated() {
+    public function testRelated()
+    {
         // Test for Related Method - requires an Organization ID as parameter
         $this->mock->expects($this->any())
-                    ->method('related')
-                    ->with($this->greaterThan(0))
-                    ->will($this->returnValue($this->organizations));
+            ->method('related')
+            ->with($this->greaterThan(0))
+            ->will($this->returnValue($this->organizations));
 
         $organization_related = $this->mock->related(123456);
         $this->assertEquals(is_object($organization_related), true, 'Should return an object');
-        $this->assertEquals(is_object($organization_related->organization_related), true, 'Should return an object containing an object called "organization_related"');
+        $this->assertEquals(is_object($organization_related->organization_related), true,
+            'Should return an object containing an object called "organization_related"');
     }
 
-    public function testSearch() {
+    public function testSearch()
+    {
         // Test for Search Method - requires an Organization External ID as parameter
         $this->mock->expects($this->any())
-                    ->method('search')
-                    ->with($this->isType('string'))
-                    ->will($this->returnValue($this->organizations));
+            ->method('search')
+            ->with($this->isType('string'))
+            ->will($this->returnValue($this->organizations));
 
         $organizations = $this->mock->search('12ef');
         $this->assertEquals(is_object($organizations), true, 'Should return an object');
-        $this->assertEquals(is_array($organizations->organizations), true, 'Should return an object containing an array called "organizations"');
-        $this->assertGreaterThan(0, $organizations->organizations[0]->id, 'Returns a non-numeric id for organizations[0]');
+        $this->assertEquals(is_array($organizations->organizations), true,
+            'Should return an object containing an array called "organizations"');
+        $this->assertGreaterThan(0, $organizations->organizations[0]->id,
+            'Returns a non-numeric id for organizations[0]');
     }
-    
+
 }


### PR DESCRIPTION
PHP has an accepted community style guide, so I've reformatted our source files (using PhpStorm) to match it. Seems to be mostly about spacing between operators and braces going on the next line.

/cc @miogalang @joseconsador 

### References
 - Jira link: 

### Risks
 - None