### PR TITLE
Print debug info on any failure

### DIFF
--- a/src/Zendesk/API/AuditLogs.php
+++ b/src/Zendesk/API/AuditLogs.php
@@ -56,9 +56,6 @@ class AuditLogs extends ClientAbstract
         }
         $endPoint = Http::prepare('audit_logs/' . $params['id'] . '.json');
         $response = Http::send($this->client, $endPoint);
-        if ((!is_object($response)) || ($this->client->getDebug()->lastResponseCode != 200)) {
-            throw new ResponseException(__METHOD__);
-        }
         $this->client->setSideload(null);
 
         return $response;

--- a/src/Zendesk/API/Http.php
+++ b/src/Zendesk/API/Http.php
@@ -142,6 +142,12 @@ class Http
             substr($response, 0, $headerSize),
             (isset($responseObject->error) ? $responseObject : null)
         );
+
+        if ($client->getDebug()->lastResponseCode >= 400) {
+            print($client->getDebug());
+            throw new ResponseException(__METHOD__);
+        }
+
         $curl->close();
         self::$curl = null;
 


### PR DESCRIPTION
Not ideal, but a quick win: whenever we get an error response from the API, print debug information and throw an exception. Previously every single time we made a call we were doing the error checking and not providing any information, now we can do it in one place.

Todo: remove manual error checking from every API call… (like I've done with AuditLogs)

cc @miogalang @joseconsador 
