### PR TITLE
Mock the API calls for ticket comments tests

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,5 +1,12 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<phpunit bootstrap="tests/bootstrap.php" colors="true">
+<phpunit
+        bootstrap="tests/bootstrap.php"
+        colors="true"
+        backupGlobals="false"
+        convertErrorsToExceptions="true"
+        convertNoticesToExceptions="true"
+        convertWarningsToExceptions="true"
+        >
     <php>
         <env name="SUBDOMAIN" value="" />
         <env name="USERNAME" value="blah@zendesk.com" />

--- a/tests/Zendesk/API/LiveTests/BasicTest.php
+++ b/tests/Zendesk/API/LiveTests/BasicTest.php
@@ -35,16 +35,20 @@ abstract class BasicTest extends \PHPUnit_Framework_TestCase
         $this->client->setAuth('token', $this->token);
     }
 
-    protected function mockApiCall($httpMethod, $path, $response, $code = 200, $timesCalled = 1)
+    protected function mockApiCall($httpMethod, $path, $response, $options = array())
     {
+        $options = array_merge(array(
+            'code' => 200,
+            'timesCalled' => 1
+        ), $options);
         $this->http->mock
-            ->exactly($timesCalled)
+            ->exactly($options['timesCalled'])
             ->when()
                 ->methodIs($httpMethod)
                 ->pathIs('/api/v2' . $path)
             ->then()
                 ->body(json_encode($response))
-                ->statusCode($code)
+                ->statusCode($options['code'])
             ->end();
         $this->http->setUp();
     }

--- a/tests/Zendesk/API/LiveTests/BasicTest.php
+++ b/tests/Zendesk/API/LiveTests/BasicTest.php
@@ -41,6 +41,7 @@ abstract class BasicTest extends \PHPUnit_Framework_TestCase
             'code' => 200,
             'timesCalled' => 1
         ), $options);
+
         $this->http->mock
             ->exactly($options['timesCalled'])
             ->when()

--- a/tests/Zendesk/API/LiveTests/BasicTest.php
+++ b/tests/Zendesk/API/LiveTests/BasicTest.php
@@ -35,9 +35,10 @@ abstract class BasicTest extends \PHPUnit_Framework_TestCase
         $this->client->setAuth('token', $this->token);
     }
 
-    protected function mockApiCall($httpMethod, $path, $response, $code = 200)
+    protected function mockApiCall($httpMethod, $path, $response, $code = 200, $timesCalled = 1)
     {
         $this->http->mock
+            ->exactly($timesCalled)
             ->when()
                 ->methodIs($httpMethod)
                 ->pathIs('/api/v2' . $path)

--- a/tests/Zendesk/API/LiveTests/TicketCommentsTest.php
+++ b/tests/Zendesk/API/LiveTests/TicketCommentsTest.php
@@ -2,41 +2,41 @@
 
 namespace Zendesk\API\LiveTests;
 
-use Zendesk\API\Client;
-
 /**
  * Ticket Comments test class
  */
 class TicketCommentsTest extends BasicTest
 {
-
-    public function testCredentials()
-    {
-        parent::credentialsTest();
-    }
-
-    public function testAuthToken()
-    {
-        parent::authTokenTest();
-    }
-
     protected $ticket_id;
 
     public function setUp()
     {
-        $testTicket = array(
+
+        $this->testTicket = array(
+            'id' => "12345",
             'subject' => 'Ticket comment test',
             'comment' => array(
                 'body' => 'Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.'
             ),
             'priority' => 'normal'
         );
-        $ticket = $this->client->tickets()->create($testTicket);
-        $this->ticket_id = $ticket->ticket->id;
+        $this->ticket_id = $this->testTicket['id'];
+
+        parent::setUp();
     }
 
     public function testAll()
     {
+        $this->mockApiCall('GET', '/tickets/12345/comments.json?',
+          array(
+            'comments' => array(
+                array(
+                    'id' => 1
+                )
+            )
+          )
+        );
+
         $comments = $this->client->ticket($this->ticket_id)->comments()->findAll();
         $this->assertEquals(is_object($comments), true, 'Should return an object');
         $this->assertEquals(is_array($comments->comments), true,
@@ -50,14 +50,19 @@ class TicketCommentsTest extends BasicTest
      */
     public function testMakePrivate()
     {
+        $this->mockApiCall('GET', '/tickets/12345/comments.json?',
+          array(
+            'comments' => array(
+              array(
+                'id' => 1
+              )
+            )
+          )
+        );
         $comment_id = $this->client->ticket($this->ticket_id)->comments()->findAll()->comments[0]->id;
+
+        $this->mockApiCall('PUT', '/tickets/12345/comments/1/make_private.json', array());
         $comments = $this->client->ticket($this->ticket_id)->comments($comment_id)->makePrivate();
         $this->assertEquals($this->client->getDebug()->lastResponseCode, '200', 'Does not return HTTP code 200');
     }
-
-    public function tearDown()
-    {
-        $this->client->tickets($this->ticket_id)->delete();
-    }
-
 }

--- a/tests/Zendesk/API/LiveTests/TicketCommentsTest.php
+++ b/tests/Zendesk/API/LiveTests/TicketCommentsTest.php
@@ -42,7 +42,6 @@ class TicketCommentsTest extends BasicTest
         $this->assertEquals(is_array($comments->comments), true,
             'Should return an object containing an array called "comments"');
         $this->assertGreaterThan(0, $comments->comments[0]->id, 'Returns a non-numeric id in first audit');
-        $this->assertEquals($this->client->getDebug()->lastResponseCode, '200', 'Does not return HTTP code 200');
     }
 
     /*
@@ -62,7 +61,6 @@ class TicketCommentsTest extends BasicTest
         $comment_id = $this->client->ticket($this->ticket_id)->comments()->findAll()->comments[0]->id;
 
         $this->mockApiCall('PUT', '/tickets/12345/comments/1/make_private.json', array());
-        $comments = $this->client->ticket($this->ticket_id)->comments($comment_id)->makePrivate();
-        $this->assertEquals($this->client->getDebug()->lastResponseCode, '200', 'Does not return HTTP code 200');
+        $this->client->ticket($this->ticket_id)->comments($comment_id)->makePrivate();
     }
 }

--- a/tests/Zendesk/API/LiveTests/TicketsTest.php
+++ b/tests/Zendesk/API/LiveTests/TicketsTest.php
@@ -119,9 +119,10 @@ class TicketsTest extends BasicTest
 
     public function testCreateWithAttachment()
     {
-        $this->mockApiCall("POST", "/uploads.json?filename=UK+test+non-alpha+chars.png", array("upload" => array("token" => "asdf")), 201);
+        $this->mockApiCall("POST", "/uploads.json?filename=UK+test+non-alpha+chars.png", array("upload" => array("token" => "asdf")),
+          array('code' => 201));
 
-        $this->mockApiCall("POST", "/tickets.json", array("ticket" => array("id" => "123")), 201);
+        $this->mockApiCall("POST", "/tickets.json", array("ticket" => array("id" => "123")), array('code' => 201));
 
         $ticket = $this->client->tickets()->attach(array(
             'file' => getcwd() . '/tests/assets/UK.png',


### PR DESCRIPTION
Mock the API calls for the Ticket Comment Test. 
Removed tests for checking credentials and auth because it is un needed for mocked calls.

Additionally added some options to make phpunit run a bit faster, and to easier debug errors on test. 

/cc @joseconsador @jwswj @mmolina @atroche 

### References
 - Jira link: 

### Risks
 - Unit Tests might not run properly (Low)