### PR TITLE
Change the way we instantiate resources. 

### DIFF
--- a/src/Zendesk/API/HttpClient.php
+++ b/src/Zendesk/API/HttpClient.php
@@ -7,6 +7,9 @@ namespace Zendesk\API;
  * spl_autoload_register(function($c){@include 'src/'.preg_replace('#\\\|_(?!.+\\\)#','/',$c).'.php';});
  */
 
+use Zendesk\API\Resources\Tickets;
+use Zendesk\API\Resources\Users;
+use Zendesk\API\Resources\Views;
 use Zendesk\API\UtilityTraits\InstantiatorTrait;
 
 /**
@@ -16,41 +19,8 @@ use Zendesk\API\UtilityTraits\InstantiatorTrait;
  * @method Debug debug()
  * @method Tickets ticket()
  * @method Tickets tickets()
- * @method TicketFields ticketFields()
- * @method TicketForms ticketForms()
- * @method Twitter twitter()
- * @method Attachments attachments()
- * @method Requests requests()
  * @method Views views()
  * @method Users users()
- * @method UserFields userFields()
- * @method Groups groups()
- * @method GroupMemberships groupMemberships()
- * @method CustomRoles customRoles()
- * @method Forums forums()
- * @method Categories categories()
- * @method Topics topics()
- * @method Settings settings()
- * @method ActivityStream activityStream()
- * @method AuditLogs auditLogs()
- * @method Autocomplete autocomplete()
- * @method Automations automations()
- * @method JobStatuses jobStatuses()
- * @method Macros macros()
- * @method DynamicContent dynamicContent()
- * @method OAuthClients oauthClients()
- * @method OAuthTokens oauthTokens()
- * @method OrganizationFields organizationFields()
- * @method Organizations organizations()
- * @method SatisfactionRatings satisfactionRatings()
- * @method SharingAgreements sharingAgreements()
- * @method SuspendedTickets suspendedTickets()
- * @method Tags tags()
- * @method Targets targets()
- * @method Triggers triggers()
- * @method Voice voice()
- * @method Locales locales()
- * @method PushNotificationDevices push_notification_devices()
  */
 class HttpClient
 {
@@ -101,156 +71,25 @@ class HttpClient
      */
     protected $sideload;
 
+    // Properties
     /**
      * @var Tickets
      */
     protected $tickets;
     /**
-     * @var TicketFields
-     */
-    protected $ticketFields;
-    /**
-     * @var TicketForms
-     */
-    protected $ticketForms;
-    /**
-     * @var Twitter
-     */
-    protected $twitter;
-    /**
-     * @var Attachments
-     */
-    protected $attachments;
-    /**
-     * @var Requests
-     */
-    protected $requests;
-    /**
      * @var Users
      */
     protected $users;
     /**
-     * @var UserFields
+     * @var Views
      */
-    protected $userFields;
-    /**
-     * @var Groups
-     */
-    protected $groups;
-    /**
-     * @var GroupMemberships
-     */
-    protected $groupMemberships;
-    /**
-     * @var CustomRoles
-     */
-    protected $customRoles;
-    /**
-     * @var Forums
-     */
-    protected $forums;
-    /**
-     * @var Categories
-     */
-    protected $categories;
-    /**
-     * @var Topics
-     */
-    protected $topics;
-    /**
-     * @var Settings
-     */
-    protected $settings;
-    /**
-     * @var ActivityStream
-     */
-    protected $activityStream;
-    /**
-     * @var AuditLogs
-     */
-    protected $auditLogs;
-    /**
-     * @var Autocomplete
-     */
-    protected $autocomplete;
-    /**
-     * @var Automations
-     */
-    protected $automations;
-    /**
-     * @var JobStatuses
-     */
-    protected $jobStatuses;
-    /**
-     * @var Macros
-     */
-    protected $macros;
-    /**
-     * @var DynamicContent
-     */
-    protected $dynamicContent;
-    /**
-     * @var OAuthClients
-     */
-    protected $oauthClients;
-    /**
-     * @var OAuthTokens
-     */
-    protected $oauthTokens;
-    /**
-     * @var OrganizationFields
-     */
-    protected $organizationFields;
-    /**
-     * @var Organizations
-     */
-    protected $organizations;
-    /**
-     * @var SatisfactionRatings
-     */
-    protected $satisfactionRatings;
-    /**
-     * @var Search
-     */
-    protected $search;
-    /**
-     * @var SharingAgreements
-     */
-    protected $sharingAgreements;
-    /**
-     * @var SuspendedTickets
-     */
-    protected $suspendedTickets;
-    /**
-     * @var Tags
-     */
-    protected $tags;
-    /**
-     * @var Targets
-     */
-    protected $targets;
-    /**
-     * @var Triggers
-     */
-    protected $triggers;
-    /**
-     * @var Voice
-     */
-    protected $voice;
-    /**
-     * @var Locales
-     */
-    protected $locales;
-    /**
-     * @var PushNotificationDevices
-     */
-    protected $push_notification_devices;
+    protected $views;
     /**
      * @var Debug
      */
     protected $debug;
     /**
-     * @var Guzzle
+     * @var \GuzzleHttp\Client
      */
     public $guzzle;
 
@@ -280,9 +119,14 @@ class HttpClient
         }
 
         $this->debug = new Debug();
-        $this->tickets = new Resources\Tickets($this);
-        $this->views = new Resources\Views($this);
-        $this->users = new Resources\Users($this);
+    }
+
+    public static function getValidRelations() {
+        return [
+            'tickets' => Tickets::class,
+            'users' => Users::class,
+            'views' => Views::class,
+        ];
     }
 
     /**

--- a/src/Zendesk/API/HttpClient.php
+++ b/src/Zendesk/API/HttpClient.php
@@ -105,8 +105,9 @@ class HttpClient
       $hostname = "zendesk.com",
       $port = 443,
       $guzzle = null
-    ) {
-        if (is_null( $guzzle )) {
+    )
+    {
+        if (is_null($guzzle)) {
             $this->guzzle = new \GuzzleHttp\Client();
         } else {
             $this->guzzle = $guzzle;
@@ -118,7 +119,7 @@ class HttpClient
         $this->scheme    = $scheme;
         $this->port      = $port;
 
-        if (empty( $subdomain )) {
+        if (empty($subdomain)) {
             $this->apiUrl = "$scheme://$hostname:$port/api/{$this->apiVer}/";
         } else {
             $this->apiUrl = "$scheme://$subdomain.$hostname:$port/api/{$this->apiVer}/";
@@ -142,7 +143,7 @@ class HttpClient
      * @param string $method
      * @param string $value
      */
-    public function setAuth( $method, $value )
+    public function setAuth($method, $value)
     {
         switch ($method) {
             case 'password':
@@ -190,7 +191,7 @@ class HttpClient
      */
     public function getAuthType()
     {
-        return ( $this->oAuthToken ? 'oauth_token' : ( $this->token ? 'token' : 'password' ) );
+        return ($this->oAuthToken ? 'oauth_token' : ($this->token ? 'token' : 'password'));
     }
 
     /**
@@ -200,7 +201,7 @@ class HttpClient
      */
     public function getAuthText()
     {
-        return ( $this->oAuthToken ? $this->oAuthToken : $this->username . ( $this->token ? '/token:' . $this->token : ':' . $this->password ) );
+        return ($this->oAuthToken ? $this->oAuthToken : $this->username . ($this->token ? '/token:' . $this->token : ':' . $this->password));
     }
 
     /**
@@ -211,7 +212,7 @@ class HttpClient
      * @param string $lastResponseHeaders
      * @param mixed $lastResponseError
      */
-    public function setDebug( $lastRequestHeaders, $lastResponseCode, $lastResponseHeaders, $lastResponseError )
+    public function setDebug($lastRequestHeaders, $lastResponseCode, $lastResponseHeaders, $lastResponseError)
     {
         $this->debug->lastRequestHeaders  = $lastRequestHeaders;
         $this->debug->lastResponseCode    = $lastResponseCode;
@@ -236,7 +237,7 @@ class HttpClient
      *
      * @return HttpClient
      */
-    public function setSideload( array $fields = null )
+    public function setSideload(array $fields = null)
     {
         $this->sideload = $fields;
 
@@ -250,9 +251,9 @@ class HttpClient
      *
      * @return array|null
      */
-    public function getSideload( array $params = null )
+    public function getSideload(array $params = null)
     {
-        return ( ( isset( $params['sideload'] ) ) && ( is_array( $params['sideload'] ) ) ? $params['sideload'] : $this->sideload );
+        return ((isset($params['sideload'])) && (is_array($params['sideload'])) ? $params['sideload'] : $this->sideload);
     }
 
     /*
@@ -264,9 +265,9 @@ class HttpClient
      *
      * @return $this
      */
-    public function category( $id )
+    public function category($id)
     {
-        return $this->categories->setLastId( $id );
+        return $this->categories->setLastId($id);
     }
 
     /**
@@ -274,9 +275,9 @@ class HttpClient
      *
      * @return ActivityStream
      */
-    public function activities( $id = null )
+    public function activities($id = null)
     {
-        return ( $id != null ? $this->activityStream()->setLastId( $id ) : $this->activityStream() );
+        return ($id != null ? $this->activityStream()->setLastId($id) : $this->activityStream());
     }
 
     /**
@@ -284,9 +285,9 @@ class HttpClient
      *
      * @return ActivityStream
      */
-    public function activity( $id )
+    public function activity($id)
     {
-        return $this->activityStream()->setLastId( $id );
+        return $this->activityStream()->setLastId($id);
     }
 
     /**
@@ -294,9 +295,9 @@ class HttpClient
      *
      * @return JobStatuses
      */
-    public function jobStatus( $id )
+    public function jobStatus($id)
     {
-        return $this->jobStatuses()->setLastId( $id );
+        return $this->jobStatuses()->setLastId($id);
     }
 
     /**
@@ -307,9 +308,9 @@ class HttpClient
      *
      * @return mixed
      */
-    public function search( array $params )
+    public function search(array $params)
     {
-        return $this->search->performSearch( $params );
+        return $this->search->performSearch($params);
     }
 
     /**
@@ -320,9 +321,9 @@ class HttpClient
      *
      * @return mixed
      */
-    public function anonymousSearch( array $params )
+    public function anonymousSearch(array $params)
     {
-        return $this->search->anonymousSearch( $params );
+        return $this->search->anonymousSearch($params);
     }
 
 }

--- a/src/Zendesk/API/HttpClient.php
+++ b/src/Zendesk/API/HttpClient.php
@@ -98,21 +98,27 @@ class HttpClient
      * @param string $username
      */
 
-    public function __construct($subdomain, $username, $scheme = "https", $hostname = "zendesk.com", $port = 443, $guzzle = null)
-    {
-        if (is_null($guzzle)) {
+    public function __construct(
+      $subdomain,
+      $username,
+      $scheme = "https",
+      $hostname = "zendesk.com",
+      $port = 443,
+      $guzzle = null
+    ) {
+        if (is_null( $guzzle )) {
             $this->guzzle = new \GuzzleHttp\Client();
         } else {
             $this->guzzle = $guzzle;
         }
 
         $this->subdomain = $subdomain;
-        $this->username = $username;
-        $this->hostname = $hostname;
-        $this->scheme = $scheme;
-        $this->port = $port;
+        $this->username  = $username;
+        $this->hostname  = $hostname;
+        $this->scheme    = $scheme;
+        $this->port      = $port;
 
-        if (empty($subdomain)) {
+        if (empty( $subdomain )) {
             $this->apiUrl = "$scheme://$hostname:$port/api/{$this->apiVer}/";
         } else {
             $this->apiUrl = "$scheme://$subdomain.$hostname:$port/api/{$this->apiVer}/";
@@ -121,11 +127,12 @@ class HttpClient
         $this->debug = new Debug();
     }
 
-    public static function getValidRelations() {
+    public static function getValidRelations()
+    {
         return [
-            'tickets' => Tickets::class,
-            'users' => Users::class,
-            'views' => Views::class,
+          'tickets' => Tickets::class,
+          'users'   => Users::class,
+          'views'   => Views::class,
         ];
     }
 
@@ -135,22 +142,22 @@ class HttpClient
      * @param string $method
      * @param string $value
      */
-    public function setAuth($method, $value)
+    public function setAuth( $method, $value )
     {
         switch ($method) {
             case 'password':
-                $this->password = $value;
-                $this->token = '';
+                $this->password   = $value;
+                $this->token      = '';
                 $this->oAuthToken = '';
                 break;
             case 'token':
-                $this->password = '';
-                $this->token = $value;
+                $this->password   = '';
+                $this->token      = $value;
                 $this->oAuthToken = '';
                 break;
             case 'oauth_token':
-                $this->password = '';
-                $this->token = '';
+                $this->password   = '';
+                $this->token      = '';
                 $this->oAuthToken = $value;
                 break;
         }
@@ -183,7 +190,7 @@ class HttpClient
      */
     public function getAuthType()
     {
-        return ($this->oAuthToken ? 'oauth_token' : ($this->token ? 'token' : 'password'));
+        return ( $this->oAuthToken ? 'oauth_token' : ( $this->token ? 'token' : 'password' ) );
     }
 
     /**
@@ -193,7 +200,7 @@ class HttpClient
      */
     public function getAuthText()
     {
-        return ($this->oAuthToken ? $this->oAuthToken : $this->username . ($this->token ? '/token:' . $this->token : ':' . $this->password));
+        return ( $this->oAuthToken ? $this->oAuthToken : $this->username . ( $this->token ? '/token:' . $this->token : ':' . $this->password ) );
     }
 
     /**
@@ -204,12 +211,12 @@ class HttpClient
      * @param string $lastResponseHeaders
      * @param mixed $lastResponseError
      */
-    public function setDebug($lastRequestHeaders, $lastResponseCode, $lastResponseHeaders, $lastResponseError)
+    public function setDebug( $lastRequestHeaders, $lastResponseCode, $lastResponseHeaders, $lastResponseError )
     {
-        $this->debug->lastRequestHeaders = $lastRequestHeaders;
-        $this->debug->lastResponseCode = $lastResponseCode;
+        $this->debug->lastRequestHeaders  = $lastRequestHeaders;
+        $this->debug->lastResponseCode    = $lastResponseCode;
         $this->debug->lastResponseHeaders = $lastResponseHeaders;
-        $this->debug->lastResponseError = $lastResponseError;
+        $this->debug->lastResponseError   = $lastResponseError;
     }
 
     /**
@@ -229,7 +236,7 @@ class HttpClient
      *
      * @return HttpClient
      */
-    public function setSideload(array $fields = null)
+    public function setSideload( array $fields = null )
     {
         $this->sideload = $fields;
 
@@ -243,9 +250,9 @@ class HttpClient
      *
      * @return array|null
      */
-    public function getSideload(array $params = null)
+    public function getSideload( array $params = null )
     {
-        return ((isset($params['sideload'])) && (is_array($params['sideload'])) ? $params['sideload'] : $this->sideload);
+        return ( ( isset( $params['sideload'] ) ) && ( is_array( $params['sideload'] ) ) ? $params['sideload'] : $this->sideload );
     }
 
     /*
@@ -257,9 +264,9 @@ class HttpClient
      *
      * @return $this
      */
-    public function category($id)
+    public function category( $id )
     {
-        return $this->categories->setLastId($id);
+        return $this->categories->setLastId( $id );
     }
 
     /**
@@ -267,9 +274,9 @@ class HttpClient
      *
      * @return ActivityStream
      */
-    public function activities($id = null)
+    public function activities( $id = null )
     {
-        return ($id != null ? $this->activityStream()->setLastId($id) : $this->activityStream());
+        return ( $id != null ? $this->activityStream()->setLastId( $id ) : $this->activityStream() );
     }
 
     /**
@@ -277,9 +284,9 @@ class HttpClient
      *
      * @return ActivityStream
      */
-    public function activity($id)
+    public function activity( $id )
     {
-        return $this->activityStream()->setLastId($id);
+        return $this->activityStream()->setLastId( $id );
     }
 
     /**
@@ -287,9 +294,9 @@ class HttpClient
      *
      * @return JobStatuses
      */
-    public function jobStatus($id)
+    public function jobStatus( $id )
     {
-        return $this->jobStatuses()->setLastId($id);
+        return $this->jobStatuses()->setLastId( $id );
     }
 
     /**
@@ -300,9 +307,9 @@ class HttpClient
      *
      * @return mixed
      */
-    public function search(array $params)
+    public function search( array $params )
     {
-        return $this->search->performSearch($params);
+        return $this->search->performSearch( $params );
     }
 
     /**
@@ -313,9 +320,9 @@ class HttpClient
      *
      * @return mixed
      */
-    public function anonymousSearch(array $params)
+    public function anonymousSearch( array $params )
     {
-        return $this->search->anonymousSearch($params);
+        return $this->search->anonymousSearch( $params );
     }
 
 }

--- a/src/Zendesk/API/Resources/ResourceAbstract.php
+++ b/src/Zendesk/API/Resources/ResourceAbstract.php
@@ -20,7 +20,7 @@ abstract class ResourceAbstract
     protected $endpoint;
 
     /**
-     * @var HttpClient
+     * @var \Zendesk\API\HttpClient
      */
     protected $client;
     /**
@@ -36,7 +36,7 @@ abstract class ResourceAbstract
     /**
      * @param \Zendesk\API\HttpClient $client
      */
-    public function __construct(\Zendesk\API\HttpClient $client)
+    public function __construct( \Zendesk\API\HttpClient $client )
     {
         $this->client = $client;
 
@@ -45,6 +45,7 @@ abstract class ResourceAbstract
 
     /**
      * This returns the valid relations of this resource. Definition of what is allowed to chain after this resource.
+     * Make sure to add in this method when adding new sub resources.
      * Example:
      *    $client->ticket()->comments();
      *    Where ticket would have a comments as a valid sub resource.
@@ -53,8 +54,9 @@ abstract class ResourceAbstract
      *
      * @return array
      */
-    public static function getValidSubResource() {
-        return [];
+    public static function getValidSubResource()
+    {
+        return [ ];
     }
 
     /**
@@ -65,27 +67,27 @@ abstract class ResourceAbstract
      */
     private function getResourceNameFromClass()
     {
-        $namespacedClassName = get_class($this);
-        $resourceName = join('', array_slice(explode('\\', $namespacedClassName), -1));
+        $namespacedClassName = get_class( $this );
+        $resourceName        = join( '', array_slice( explode( '\\', $namespacedClassName ), - 1 ) );
 
-        return strtolower($resourceName);
+        return strtolower( $resourceName );
     }
 
     protected function setUpRoutes()
     {
-        if (isset($this->endpoint)) {
+        if (isset( $this->endpoint )) {
             $resource = $this->endpoint;
         } else {
             $resource = $this->getResourceNameFromClass();
         }
 
-        $this->setRoutes([
-            'findAll' => "$resource.json",
-            'find'    => "$resource/{id}.json",
-            'create'  => "$resource.json",
-            'update'  => "$resource/{id}.json",
-            'delete'  => "$resource/{id}.json"
-        ]);
+        $this->setRoutes( [
+          'findAll' => "$resource.json",
+          'find'    => "$resource/{id}.json",
+          'create'  => "$resource.json",
+          'update'  => "$resource/{id}.json",
+          'delete'  => "$resource/{id}.json"
+        ] );
     }
 
     /**
@@ -95,7 +97,7 @@ abstract class ResourceAbstract
      *
      * @return $this
      */
-    public function setLastId($id)
+    public function setLastId( $id )
     {
         $this->lastId = $id;
 
@@ -120,10 +122,10 @@ abstract class ResourceAbstract
      *
      * @return bool
      */
-    public function hasKeys(array $params, array $mandatory)
+    public function hasKeys( array $params, array $mandatory )
     {
-        for ($i = 0; $i < count($mandatory); $i++) {
-            if (!array_key_exists($mandatory[$i], $params)) {
+        for ($i = 0; $i < count( $mandatory ); $i ++) {
+            if ( ! array_key_exists( $mandatory[$i], $params )) {
                 return false;
             }
         }
@@ -139,10 +141,10 @@ abstract class ResourceAbstract
      *
      * @return bool
      */
-    public function hasAnyKey(array $params, array $mandatory)
+    public function hasAnyKey( array $params, array $mandatory )
     {
-        for ($i = 0; $i < count($mandatory); $i++) {
-            if (array_key_exists($mandatory[$i], $params)) {
+        for ($i = 0; $i < count( $mandatory ); $i ++) {
+            if (array_key_exists( $mandatory[$i], $params )) {
                 return true;
             }
         }
@@ -157,30 +159,32 @@ abstract class ResourceAbstract
      *
      * @return $this
      */
-    public function sideload(array $fields = array())
+    public function sideload( array $fields = array() )
     {
-        $this->client->setSideload($fields);
+        $this->client->setSideload( $fields );
 
         return $this;
     }
 
     /**
      * Wrapper for adding multiple routes via setRoute
+     *
      * @param array $routes
      */
-    public function setRoutes(array $routes)
+    public function setRoutes( array $routes )
     {
         foreach ($routes as $name => $route) {
-            $this->setRoute($name, $route);
+            $this->setRoute( $name, $route );
         }
     }
 
     /**
      * Add or override an existing route
+     *
      * @param $name
      * @param $route
      */
-    public function setRoute($name, $route)
+    public function setRoute( $name, $route )
     {
         $this->routes[$name] = $route;
     }
@@ -197,22 +201,23 @@ abstract class ResourceAbstract
     /**
      * Returns a route and replaces tokenized parts of the string with
      * the passed params
+     *
      * @param       $name
      * @param array $params
      *
      * @return mixed
      * @throws \Exception
      */
-    public function getRoute($name, array $params = array())
+    public function getRoute( $name, array $params = array() )
     {
-        if (!isset($this->routes[$name])) {
-            throw new \Exception('Route not found.');
+        if ( ! isset( $this->routes[$name] )) {
+            throw new \Exception( 'Route not found.' );
         }
 
         $route = $this->routes[$name];
         foreach ($params as $name => $value) {
-            if (is_scalar($value)) {
-                $route = str_replace('{' . $name . '}', $value, $route);
+            if (is_scalar( $value )) {
+                $route = str_replace( '{' . $name . '}', $value, $route );
             }
         }
 
@@ -229,19 +234,19 @@ abstract class ResourceAbstract
      *
      * @return mixed
      */
-    public function findAll(array $params = array())
+    public function findAll( array $params = array() )
     {
-        $sideloads = $this->client->getSideload($params);
+        $sideloads = $this->client->getSideload( $params );
 
-        $queryParams = Http::prepareQueryParams($sideloads, $params);
+        $queryParams = Http::prepareQueryParams( $sideloads, $params );
 
         $response = Http::send_with_options(
-            $this->client,
-            $this->getRoute('findAll', $params),
-            ['queryParams' => $queryParams]
+          $this->client,
+          $this->getRoute( 'findAll', $params ),
+          [ 'queryParams' => $queryParams ]
         );
 
-        $this->client->setSideload(null);
+        $this->client->setSideload( null );
 
         return $response;
     }
@@ -257,24 +262,24 @@ abstract class ResourceAbstract
      * @throws \Exception
      *
      */
-    public function find($id = null, array $queryParams = array())
+    public function find( $id = null, array $queryParams = array() )
     {
-        if (empty($id)) {
+        if (empty( $id )) {
             $chainedParameters = $this->getChainedParameters();
-            $className = get_class($this);
-            $id = isset($chainedParameters[$className]) ? $chainedParameters[$className] : null;
+            $className         = get_class( $this );
+            $id                = isset( $chainedParameters[$className] ) ? $chainedParameters[$className] : null;
         }
 
-        if (empty($id)) {
-            throw new MissingParametersException(__METHOD__, array('id'));
+        if (empty( $id )) {
+            throw new MissingParametersException( __METHOD__, array( 'id' ) );
         }
 
         $response = Http::send_with_options(
-            $this->client,
-            $this->getRoute(__FUNCTION__, array('id' => $id)),
-            ['queryParams' => $queryParams]
+          $this->client,
+          $this->getRoute( __FUNCTION__, array( 'id' => $id ) ),
+          [ 'queryParams' => $queryParams ]
         );
-        $this->client->setSideload(null);
+        $this->client->setSideload( null );
 
         return $response;
     }
@@ -289,19 +294,19 @@ abstract class ResourceAbstract
      *
      * @return mixed
      */
-    public function create(array $params)
+    public function create( array $params )
     {
-        $class = get_class($this);
+        $class    = get_class( $this );
         $response = Http::send_with_options(
-            $this->client,
-            $this->getRoute('create'),
-            [
-                'postFields' => array($class::OBJ_NAME => $params),
-                'method' => 'POST'
-            ]
+          $this->client,
+          $this->getRoute( 'create' ),
+          [
+            'postFields' => array( $class::OBJ_NAME => $params ),
+            'method'     => 'POST'
+          ]
         );
 
-        $this->client->setSideload(null);
+        $this->client->setSideload( null );
 
         return $response;
     }
@@ -318,21 +323,22 @@ abstract class ResourceAbstract
      *
      * @return mixed
      */
-    public function update($id = null, array $updateResourceFields = [])
+    public function update( $id = null, array $updateResourceFields = [ ] )
     {
-        $class = get_class($this);
-        if (empty($id))
-            $id = $this->getChainedParameter($class);
+        $class = get_class( $this );
+        if (empty( $id )) {
+            $id = $this->getChainedParameter( $class );
+        }
 
-        $postFields = array($class::OBJ_NAME => $updateResourceFields);
+        $postFields = array( $class::OBJ_NAME => $updateResourceFields );
 
         $response = Http::send_with_options(
-            $this->client,
-            $this->getRoute(__FUNCTION__, array('id' => $id)),
-            ['postFields' => $postFields, 'method' => 'PUT']
+          $this->client,
+          $this->getRoute( __FUNCTION__, array( 'id' => $id ) ),
+          [ 'postFields' => $postFields, 'method' => 'PUT' ]
         );
 
-        $this->client->setSideload(null);
+        $this->client->setSideload( null );
 
         return $response;
     }
@@ -348,27 +354,27 @@ abstract class ResourceAbstract
      * @throws \Exception
      *
      */
-    public function delete($id = null)
+    public function delete( $id = null )
     {
-        if (empty($id)) {
+        if (empty( $id )) {
             $chainedParameters = $this->getChainedParameters();
-            if (array_key_exists(get_class($this), $chainedParameters)) {
-                $id = $chainedParameters[get_class($this)];
+            if (array_key_exists( get_class( $this ), $chainedParameters )) {
+                $id = $chainedParameters[get_class( $this )];
             }
         }
 
-        if (empty($id)) {
-            throw new MissingParametersException(__METHOD__, array('id'));
+        if (empty( $id )) {
+            throw new MissingParametersException( __METHOD__, array( 'id' ) );
         }
 
-        $route = $this->getRoute('find', array('id' => $id));
+        $route    = $this->getRoute( 'find', array( 'id' => $id ) );
         $response = Http::send_with_options(
-            $this->client,
-            $route,
-            ['method' => 'DELETE']
+          $this->client,
+          $route,
+          [ 'method' => 'DELETE' ]
         );
 
-        $this->client->setSideload(null);
+        $this->client->setSideload( null );
 
         return $response;
     }

--- a/src/Zendesk/API/Resources/ResourceAbstract.php
+++ b/src/Zendesk/API/Resources/ResourceAbstract.php
@@ -31,21 +31,30 @@ abstract class ResourceAbstract
     /**
      * @var array
      */
-//    protected $chainedParameters = [];
-
-    /**
-     * @var array
-     */
     protected $routes;
 
     /**
-     * @param HttpClient $client
+     * @param \Zendesk\API\HttpClient $client
      */
     public function __construct(\Zendesk\API\HttpClient $client)
     {
         $this->client = $client;
 
         $this->setUpRoutes();
+    }
+
+    /**
+     * This returns the valid relations of this resource. Definition of what is allowed to chain after this resource.
+     * Example:
+     *    $client->ticket()->comments();
+     *    Where ticket would have a comments as a valid sub resource.
+     *    The array would look like:
+     *      ['comments' => '\Zendesk\API\Resources\TicketComments']
+     *
+     * @return array
+     */
+    public static function getValidSubResource() {
+        return [];
     }
 
     /**
@@ -276,7 +285,6 @@ abstract class ResourceAbstract
      *
      * @param array $params
      *
-     * @throws ResponseException
      * @throws \Exception
      *
      * @return mixed

--- a/src/Zendesk/API/Resources/TicketComments.php
+++ b/src/Zendesk/API/Resources/TicketComments.php
@@ -19,10 +19,10 @@ class TicketComments extends ResourceAbstract
     protected function setUpRoutes()
     {
         $this->setRoutes(
-            [
-                'findAll' => 'tickets/{ticket_id}/comments.json',
-                'makePrivate' => 'tickets/{ticket_id}/comments/{id}/make_private.json'
-            ]
+          [
+            'findAll'     => 'tickets/{ticket_id}/comments.json',
+            'makePrivate' => 'tickets/{ticket_id}/comments/{id}/make_private.json'
+          ]
         );
     }
 
@@ -36,15 +36,15 @@ class TicketComments extends ResourceAbstract
      *
      * @return mixed
      */
-    public function findAll(array $queryParams = array())
+    public function findAll( array $queryParams = array() )
     {
-        $queryParams = $this->addChainedParametersToParams($queryParams, ['ticket_id' => Tickets::class]);
+        $queryParams = $this->addChainedParametersToParams( $queryParams, [ 'ticket_id' => Tickets::class ] );
 
-        if (!$this->hasKeys($queryParams, array('ticket_id'))) {
-            throw new MissingParametersException(__METHOD__, array('ticket_id'));
+        if ( ! $this->hasKeys( $queryParams, array( 'ticket_id' ) )) {
+            throw new MissingParametersException( __METHOD__, array( 'ticket_id' ) );
         }
 
-        return parent::findAll($queryParams);
+        return parent::findAll( $queryParams );
     }
 
     /**
@@ -57,21 +57,22 @@ class TicketComments extends ResourceAbstract
      *
      * @return mixed
      */
-    public function makePrivate(array $params = array())
+    public function makePrivate( array $params = array() )
     {
-        $params = $this->addChainedParametersToParams($params, ['id' => get_class($this), 'ticket_id' => Tickets::class]);
+        $params = $this->addChainedParametersToParams( $params,
+          [ 'id' => get_class( $this ), 'ticket_id' => Tickets::class ] );
 
-        if (!$this->hasKeys($params, array('id', 'ticket_id'))) {
-            throw new MissingParametersException(__METHOD__, array('id', 'ticket_id'));
+        if ( ! $this->hasKeys( $params, array( 'id', 'ticket_id' ) )) {
+            throw new MissingParametersException( __METHOD__, array( 'id', 'ticket_id' ) );
         }
 
         $response = Http::send_with_options(
           $this->client,
-          $this->getRoute(__FUNCTION__, $params),
-          ['method' => 'PUT']
+          $this->getRoute( __FUNCTION__, $params ),
+          [ 'method' => 'PUT' ]
         );
 
-        $this->client->setSideload(null);
+        $this->client->setSideload( null );
 
         return $response;
     }
@@ -87,9 +88,9 @@ class TicketComments extends ResourceAbstract
      * @return mixed|void
      * @throws CustomException
      */
-    public function find($id = null, array $queryQueryParams = array())
+    public function find( $id = null, array $queryQueryParams = array() )
     {
-        throw new CustomException('Method ' . __METHOD__ . ' does not exist. Try $client->ticket(ticket_id)->comments()->findAll() instead.');
+        throw new CustomException( 'Method ' . __METHOD__ . ' does not exist. Try $client->ticket(ticket_id)->comments()->findAll() instead.' );
     }
 
 }

--- a/src/Zendesk/API/Resources/Tickets.php
+++ b/src/Zendesk/API/Resources/Tickets.php
@@ -11,10 +11,7 @@ use Zendesk\API\UtilityTraits\InstantiatorTrait;
  * The Tickets class exposes key methods for reading and updating ticket data
  * @package Zendesk\API
  *
- * @method TicketAudits audits()
  * @method TicketComments comments()
- * @method TicketMetrics metrics()
- * @method SatisfactionRatings satisfactionRatings()
  */
 
 class Tickets extends ResourceAbstract
@@ -25,26 +22,11 @@ class Tickets extends ResourceAbstract
     const OBJ_NAME_PLURAL = 'tickets';
 
     /**
-     * @var TicketAudits
-     */
-    protected $audits;
-    /**
      * @var TicketComments
      */
     protected $comments;
+
     /**
-     * @var TicketMetrics
-     */
-    protected $metrics;
-    /**
-     * @var TicketImport
-     */
-    protected $import;
-    /**
-     * @var SatisfactionRatings
-     */
-    protected $satisfactionRatings;
-    /*
      * Helpers:
      */
 
@@ -54,12 +36,12 @@ class Tickets extends ResourceAbstract
     protected $lastAttachments = array();
 
     /**
-     * @param HttpClient $client
+     * {@inheritdoc}
      */
-    public function __construct(\Zendesk\API\HttpClient $client)
-    {
-        parent::__construct($client);
-        $this->comments = new TicketComments($client);
+    public static function getValidRelations() {
+        return [
+          'comments' => TicketComments::class,
+        ];
     }
 
     /**
@@ -68,6 +50,7 @@ class Tickets extends ResourceAbstract
      * @param       $route
      * @param array $params
      *
+     * @return array
      * @throws ResponseException
      * @throws \Exception
      */

--- a/src/Zendesk/API/Resources/Tickets.php
+++ b/src/Zendesk/API/Resources/Tickets.php
@@ -13,7 +13,6 @@ use Zendesk\API\UtilityTraits\InstantiatorTrait;
  *
  * @method TicketComments comments()
  */
-
 class Tickets extends ResourceAbstract
 {
     use InstantiatorTrait;
@@ -38,7 +37,8 @@ class Tickets extends ResourceAbstract
     /**
      * {@inheritdoc}
      */
-    public static function getValidRelations() {
+    public static function getValidRelations()
+    {
         return [
           'comments' => TicketComments::class,
         ];
@@ -54,23 +54,23 @@ class Tickets extends ResourceAbstract
      * @throws ResponseException
      * @throws \Exception
      */
-    private function _send_get_request($route, array $params = array())
+    private function _send_get_request( $route, array $params = array() )
     {
         $queryParams = Http::prepareQueryParams(
-            $this->client->getSideload($params), $params
+          $this->client->getSideload( $params ), $params
         );
-        $response = Http::send_with_options(
-            $this->client,
-            $this->getRoute($route, $params),
-            ['queryParams' => $queryParams]
+        $response    = Http::send_with_options(
+          $this->client,
+          $this->getRoute( $route, $params ),
+          [ 'queryParams' => $queryParams ]
         );
 
-        if ((!is_object($response))
-            || ($this->client->getDebug()->lastResponseCode != 200)
+        if (( ! is_object( $response ) )
+            || ( $this->client->getDebug()->lastResponseCode != 200 )
         ) {
-            throw new ResponseException(__METHOD__);
+            throw new ResponseException( __METHOD__ );
         }
-        $this->client->setSideload(null);
+        $this->client->setSideload( null );
 
         return $response;
     }
@@ -82,19 +82,19 @@ class Tickets extends ResourceAbstract
     {
         parent::setUpRoutes();
 
-        $this->setRoutes([
-            'findMany'            => 'tickets/show_many.json',
-            'updateMany'          => 'tickets/update_many.json',
-            'markAsSpam'          => 'tickets/{id}/mark_as_spam.json',
-            'markManyAsSpam'      => 'tickets/mark_many_as_spam.json',
-            'related'             => 'tickets/{id}/related.json',
-            'deleteMany'          => 'tickets/destroy_many.json',
-            'collaborators'       => 'tickets/{id}/collaborators.json',
-            'incidents'           => 'tickets/{id}/incidents.json',
-            'problems'            => 'problems.json',
-            'export'              => 'exports/tickets.json',
-            'problemAutoComplete' => 'problems/autocomplete.json'
-        ]);
+        $this->setRoutes( [
+          'findMany'            => 'tickets/show_many.json',
+          'updateMany'          => 'tickets/update_many.json',
+          'markAsSpam'          => 'tickets/{id}/mark_as_spam.json',
+          'markManyAsSpam'      => 'tickets/mark_many_as_spam.json',
+          'related'             => 'tickets/{id}/related.json',
+          'deleteMany'          => 'tickets/destroy_many.json',
+          'collaborators'       => 'tickets/{id}/collaborators.json',
+          'incidents'           => 'tickets/{id}/incidents.json',
+          'problems'            => 'problems.json',
+          'export'              => 'exports/tickets.json',
+          'problemAutoComplete' => 'problems/autocomplete.json'
+        ] );
     }
 
     /**
@@ -108,15 +108,16 @@ class Tickets extends ResourceAbstract
      *
      * @return mixed
      */
-    public function findMany(array $params = array())
+    public function findMany( array $params = array() )
     {
 
-        $queryParams = Http::prepareQueryParams($this->client->getSideload($params), $params);
-        $queryParams['ids'] = implode(",", $params['ids']);
+        $queryParams        = Http::prepareQueryParams( $this->client->getSideload( $params ), $params );
+        $queryParams['ids'] = implode( ",", $params['ids'] );
 
-        $response = Http::send_with_options($this->client, $this->getRoute('findMany'), ['queryParams' => $queryParams]);
+        $response = Http::send_with_options( $this->client, $this->getRoute( 'findMany' ),
+          [ 'queryParams' => $queryParams ] );
 
-        $this->client->setSideload(null);
+        $this->client->setSideload( null );
 
         return $response;
     }
@@ -132,20 +133,20 @@ class Tickets extends ResourceAbstract
      *
      * @return mixed
      */
-    public function findTwicket(array $params = array())
+    public function findTwicket( array $params = array() )
     {
-        $params = $this->addChainedParametersToParams($params, ['id' => get_class($this)]);
+        $params = $this->addChainedParametersToParams( $params, [ 'id' => get_class( $this ) ] );
 
-        if (!$this->hasKeys($params, array('id'))) {
-            throw new MissingParametersException(__METHOD__, array('id'));
+        if ( ! $this->hasKeys( $params, array( 'id' ) )) {
+            throw new MissingParametersException( __METHOD__, array( 'id' ) );
         }
-        $endPoint = Http::prepare('channels/twitter/tickets/' . $params['id'] . '/statuses.json' . (is_array($params['comment_ids']) ? '?' . implode(',',
-                    $params['comment_ids']) : ''), $this->client->getSideload($params));
-        $response = Http::send_with_options($this->client, $endPoint);
-        if ((!is_object($response)) || ($this->client->getDebug()->lastResponseCode != 200)) {
-            throw new ResponseException(__METHOD__);
+        $endPoint = Http::prepare( 'channels/twitter/tickets/' . $params['id'] . '/statuses.json' . ( is_array( $params['comment_ids'] ) ? '?' . implode( ',',
+              $params['comment_ids'] ) : '' ), $this->client->getSideload( $params ) );
+        $response = Http::send_with_options( $this->client, $endPoint );
+        if (( ! is_object( $response ) ) || ( $this->client->getDebug()->lastResponseCode != 200 )) {
+            throw new ResponseException( __METHOD__ );
         }
-        $this->client->setSideload(null);
+        $this->client->setSideload( null );
 
         return $response;
     }
@@ -160,14 +161,14 @@ class Tickets extends ResourceAbstract
      *
      * @return mixed
      */
-    public function create(array $params)
+    public function create( array $params )
     {
-        if (count($this->lastAttachments)) {
+        if (count( $this->lastAttachments )) {
             $params['comment']['uploads'] = $this->lastAttachments;
-            $this->lastAttachments = array();
+            $this->lastAttachments        = array();
         }
 
-        return parent::create($params);
+        return parent::create( $params );
     }
 
     /**
@@ -181,19 +182,19 @@ class Tickets extends ResourceAbstract
      *
      * @return mixed
      */
-    public function createFromTweet(array $params)
+    public function createFromTweet( array $params )
     {
-        if ((!$params['twitter_status_message_id']) || (!$params['monitored_twitter_handle_id'])) {
-            throw new MissingParametersException(__METHOD__,
-                array('twitter_status_message_id', 'monitored_twitter_handle_id'));
+        if (( ! $params['twitter_status_message_id'] ) || ( ! $params['monitored_twitter_handle_id'] )) {
+            throw new MissingParametersException( __METHOD__,
+              array( 'twitter_status_message_id', 'monitored_twitter_handle_id' ) );
         }
-        $endPoint = Http::prepare('channels/twitter/tickets.json');
-        $response = Http::send_with_options($this->client, $endPoint, array(self::OBJ_NAME => $params), 'POST');
-        if ((!is_object($response)) || ($this->client->getDebug()->lastResponseCode != 201)) {
-            throw new ResponseException(__METHOD__,
-                ($this->client->getDebug()->lastResponseCode == 422 ? ' (hint: you can\'t create two tickets from the same tweet)' : ''));
+        $endPoint = Http::prepare( 'channels/twitter/tickets.json' );
+        $response = Http::send_with_options( $this->client, $endPoint, array( self::OBJ_NAME => $params ), 'POST' );
+        if (( ! is_object( $response ) ) || ( $this->client->getDebug()->lastResponseCode != 201 )) {
+            throw new ResponseException( __METHOD__,
+              ( $this->client->getDebug()->lastResponseCode == 422 ? ' (hint: you can\'t create two tickets from the same tweet)' : '' ) );
         }
-        $this->client->setSideload(null);
+        $this->client->setSideload( null );
 
         return $response;
     }
@@ -209,14 +210,14 @@ class Tickets extends ResourceAbstract
      *
      * @return mixed
      */
-    public function update($id = null, array $updateResourceFields = [])
+    public function update( $id = null, array $updateResourceFields = [ ] )
     {
-        if (count($this->lastAttachments)) {
+        if (count( $this->lastAttachments )) {
             $updateResourceFields['comment']['uploads'] = $this->lastAttachments;
-            $this->lastAttachments = array();
+            $this->lastAttachments                      = array();
         }
 
-        return parent::update($id, $updateResourceFields);
+        return parent::update( $id, $updateResourceFields );
     }
 
     /**
@@ -230,30 +231,30 @@ class Tickets extends ResourceAbstract
      *
      * @return mixed
      */
-    public function updateMany(array $params)
+    public function updateMany( array $params )
     {
-        if (count($this->lastAttachments)) {
+        if (count( $this->lastAttachments )) {
             $params['comment']['uploads'] = $this->lastAttachments;
-            $this->lastAttachments = array();
+            $this->lastAttachments        = array();
         }
 
         $resourceUpdateName = self::OBJ_NAME_PLURAL;
-        $queryParams = [];
-        if (isset($params['ids']) && is_array($params['ids'])) {
-            $queryParams['ids'] = implode(",", $params['ids']);
-            unset($params['ids']);
+        $queryParams        = [ ];
+        if (isset( $params['ids'] ) && is_array( $params['ids'] )) {
+            $queryParams['ids'] = implode( ",", $params['ids'] );
+            unset( $params['ids'] );
 
             $resourceUpdateName = self::OBJ_NAME;
         }
 
         $response = Http::send_with_options(
-            $this->client,
-            $this->getRoute('updateMany'),
-            [
-                'method' => 'PUT',
-                'queryParams' => $queryParams,
-                'postFields' => [$resourceUpdateName => $params]
-            ]
+          $this->client,
+          $this->getRoute( 'updateMany' ),
+          [
+            'method'      => 'PUT',
+            'queryParams' => $queryParams,
+            'postFields'  => [ $resourceUpdateName => $params ]
+          ]
         );
 
         return $response;
@@ -269,33 +270,33 @@ class Tickets extends ResourceAbstract
      *
      * @return mixed
      */
-    public function markAsSpam($id = null)
+    public function markAsSpam( $id = null )
     {
-        $options = ['method' => 'PUT'];
+        $options = [ 'method' => 'PUT' ];
 
-        if (is_array($id)) {
-            $options['queryParams']['ids'] = implode(',', $id);
-            $route = $this->getRoute('markManyAsSpam');
+        if (is_array( $id )) {
+            $options['queryParams']['ids'] = implode( ',', $id );
+            $route                         = $this->getRoute( 'markManyAsSpam' );
         } else {
             $params = $this->addChainedParametersToParams(
-                ['id' => $id],
-                ['id' => get_class($this)]
+              [ 'id' => $id ],
+              [ 'id' => get_class( $this ) ]
             );
-            $route = $this->getRoute('markAsSpam', $params);
+            $route  = $this->getRoute( 'markAsSpam', $params );
         }
 
         $response = Http::send_with_options(
-            $this->client,
-            $route,
-            $options
+          $this->client,
+          $route,
+          $options
         );
 
         // Seems to be a bug in the service, it may respond with 422 even when it succeeds
         if ($this->client->getDebug()->lastResponseCode != 200) {
-            throw new ResponseException(__METHOD__,
-                ($this->client->getDebug()->lastResponseCode == 422 ? ' (note: there\'s currently a bug in the service so this call may have succeeded; call tickets->find to see if it still exists.)' : ''));
+            throw new ResponseException( __METHOD__,
+              ( $this->client->getDebug()->lastResponseCode == 422 ? ' (note: there\'s currently a bug in the service so this call may have succeeded; call tickets->find to see if it still exists.)' : '' ) );
         }
-        $this->client->setSideload(null);
+        $this->client->setSideload( null );
 
         return $response;
     }
@@ -311,33 +312,34 @@ class Tickets extends ResourceAbstract
      *
      * @return mixed
      */
-    public function related(array $params = array())
+    public function related( array $params = array() )
     {
-        $params = $this->addChainedParametersToParams($params, ['id' => get_class($this)]);
+        $params = $this->addChainedParametersToParams( $params, [ 'id' => get_class( $this ) ] );
 
-        if (!$this->hasKeys($params, array('id'))) {
-            throw new MissingParametersException(__METHOD__, array('id'));
+        if ( ! $this->hasKeys( $params, array( 'id' ) )) {
+            throw new MissingParametersException( __METHOD__, array( 'id' ) );
         }
 
-        return $this->_send_get_request(__FUNCTION__, $params);
+        return $this->_send_get_request( __FUNCTION__, $params );
     }
 
     /**
      * Update a ticket or series of tickets
      *
      * @param array $ids
+     *
      * @return mixed
      *
      */
-    public function deleteMany(array $ids)
+    public function deleteMany( array $ids )
     {
         $response = Http::send_with_options(
-            $this->client,
-            $this->getRoute('deleteMany'),
-            [
-                'method' => 'DELETE',
-                'queryParams' => ['ids' => implode(',', $ids)]
-            ]
+          $this->client,
+          $this->getRoute( 'deleteMany' ),
+          [
+            'method'      => 'DELETE',
+            'queryParams' => [ 'ids' => implode( ',', $ids ) ]
+          ]
         );
 
         return $response;
@@ -354,15 +356,15 @@ class Tickets extends ResourceAbstract
      *
      * @return mixed
      */
-    public function collaborators(array $params)
+    public function collaborators( array $params )
     {
-        $params = $this->addChainedParametersToParams($params, ['id' => get_class($this)]);
+        $params = $this->addChainedParametersToParams( $params, [ 'id' => get_class( $this ) ] );
 
-        if (!$this->hasKeys($params, array('id'))) {
-            throw new MissingParametersException(__METHOD__, array('id'));
+        if ( ! $this->hasKeys( $params, array( 'id' ) )) {
+            throw new MissingParametersException( __METHOD__, array( 'id' ) );
         }
 
-        return $this->_send_get_request(__FUNCTION__, $params);
+        return $this->_send_get_request( __FUNCTION__, $params );
     }
 
     /**
@@ -376,15 +378,15 @@ class Tickets extends ResourceAbstract
      *
      * @return mixed
      */
-    public function incidents(array $params)
+    public function incidents( array $params )
     {
-        $params = $this->addChainedParametersToParams($params, ['id' => get_class($this)]);
+        $params = $this->addChainedParametersToParams( $params, [ 'id' => get_class( $this ) ] );
 
-        if (!$this->hasKeys($params, array('id'))) {
-            throw new MissingParametersException(__METHOD__, array('id'));
+        if ( ! $this->hasKeys( $params, array( 'id' ) )) {
+            throw new MissingParametersException( __METHOD__, array( 'id' ) );
         }
 
-        return $this->_send_get_request(__FUNCTION__, $params);
+        return $this->_send_get_request( __FUNCTION__, $params );
     }
 
 
@@ -399,9 +401,9 @@ class Tickets extends ResourceAbstract
      *
      * @return mixed
      */
-    public function problems(array $params = [])
+    public function problems( array $params = [ ] )
     {
-        return $this->_send_get_request(__FUNCTION__, $params);
+        return $this->_send_get_request( __FUNCTION__, $params );
     }
 
     /**
@@ -415,26 +417,26 @@ class Tickets extends ResourceAbstract
      *
      * @return mixed
      */
-    public function problemAutoComplete(array $params)
+    public function problemAutoComplete( array $params )
     {
-        if (!$params['text']) {
-            throw new MissingParametersException(__METHOD__, array('text'));
+        if ( ! $params['text']) {
+            throw new MissingParametersException( __METHOD__, array( 'text' ) );
         }
 
         $response = Http::send_with_options(
-            $this->client,
-            $this->getRoute('problemAutoComplete'),
-            [
-                'method' => 'POST',
-                'postFields' => ['text' => $params['text']]
-            ]
+          $this->client,
+          $this->getRoute( 'problemAutoComplete' ),
+          [
+            'method'     => 'POST',
+            'postFields' => [ 'text' => $params['text'] ]
+          ]
         );
 
-        if ((!is_object($response)) || ($this->client->getDebug()->lastResponseCode != 200)) {
-            throw new ResponseException(__METHOD__);
+        if (( ! is_object( $response ) ) || ( $this->client->getDebug()->lastResponseCode != 200 )) {
+            throw new ResponseException( __METHOD__ );
         }
 
-        $this->client->setSideload(null);
+        $this->client->setSideload( null );
 
         return $response;
     }
@@ -450,17 +452,18 @@ class Tickets extends ResourceAbstract
      *
      * @return mixed
      */
-    public function export(array $params)
+    public function export( array $params )
     {
-        if (!$params['start_time']) {
-            throw new MissingParametersException(__METHOD__, array('start_time'));
+        if ( ! $params['start_time']) {
+            throw new MissingParametersException( __METHOD__, array( 'start_time' ) );
         }
 
-        $queryParams = ["start_time" => $params["start_time"]];
+        $queryParams = [ "start_time" => $params["start_time"] ];
 
-        $response = Http::send_with_options($this->client, $this->getRoute('export'), ["queryParams" => $queryParams]);
+        $response = Http::send_with_options( $this->client, $this->getRoute( 'export' ),
+          [ "queryParams" => $queryParams ] );
 
-        $this->client->setSideload(null);
+        $this->client->setSideload( null );
 
         return $response;
     }
@@ -474,16 +477,16 @@ class Tickets extends ResourceAbstract
      *
      * @return Tickets
      */
-    public function attach(array $params = array())
+    public function attach( array $params = array() )
     {
-        if (!$this->hasKeys($params, array('file'))) {
-            throw new MissingParametersException(__METHOD__, array('file'));
+        if ( ! $this->hasKeys( $params, array( 'file' ) )) {
+            throw new MissingParametersException( __METHOD__, array( 'file' ) );
         }
 
-        $upload = $this->client->attachments()->upload($params);
+        $upload = $this->client->attachments()->upload( $params );
 
-        if ((!is_object($upload->upload)) || (!$upload->upload->token)) {
-            throw new ResponseException(__METHOD__);
+        if (( ! is_object( $upload->upload ) ) || ( ! $upload->upload->token )) {
+            throw new ResponseException( __METHOD__ );
         }
         $this->lastAttachments[] = $upload->upload->token;
 

--- a/src/Zendesk/API/Resources/Users.php
+++ b/src/Zendesk/API/Resources/Users.php
@@ -25,16 +25,16 @@ class Users extends ResourceAbstract
     {
         parent::setUpRoutes();
 
-        $this->setRoutes([
-            'related' => 'users/{id}/related.json',
-            'merge' => 'users/me/merge.json',
-            'search' => 'users/search.json',
-            'autocomplete' => 'users/autocomplete.json',
-            'setPassword' => 'users/{id}/password.json',
-            'changePassword' => 'users/{id}/password.json',
-            'updateMany' => 'users/update_many.json',
-            'createMany' => 'users/create_many.json',
-        ]);
+        $this->setRoutes( [
+          'related'        => 'users/{id}/related.json',
+          'merge'          => 'users/me/merge.json',
+          'search'         => 'users/search.json',
+          'autocomplete'   => 'users/autocomplete.json',
+          'setPassword'    => 'users/{id}/password.json',
+          'changePassword' => 'users/{id}/password.json',
+          'updateMany'     => 'users/update_many.json',
+          'createMany'     => 'users/create_many.json',
+        ] );
     }
 
     /**
@@ -47,12 +47,12 @@ class Users extends ResourceAbstract
      *
      * @return mixed
      */
-    public function findAll(array $params = array())
+    public function findAll( array $params = array() )
     {
-        if (isset($params['organization_id'])) {
+        if (isset( $params['organization_id'] )) {
             $this->endpoint = "organizations/{$params['organization_id']}/users.json";
-        } elseif (isset($params['group_id'])) {
-           $this->endpoint = 'groups/' . $params['group_id'] . '/users.json';
+        } elseif (isset( $params['group_id'] )) {
+            $this->endpoint = 'groups/' . $params['group_id'] . '/users.json';
         } else {
             $this->endpoint = 'users.json';
         }
@@ -71,19 +71,19 @@ class Users extends ResourceAbstract
      *
      * @return mixed
      */
-    public function findMany(array $params = array())
+    public function findMany( array $params = array() )
     {
-        $params = $this->addChainedParametersToParams($params, ['ids' => get_class($this)]);
+        $params         = $this->addChainedParametersToParams( $params, [ 'ids' => get_class( $this ) ] );
         $this->endpoint = 'users/show_many.json';
 
-        $queryParams = ['ids' => implode(",", $params['ids'])];
+        $queryParams = [ 'ids' => implode( ",", $params['ids'] ) ];
 
-        $extraParams = Http::prepareQueryParams($this->client->getSideload($params), $params);
-        $queryParams = array_merge($queryParams, $extraParams);
+        $extraParams = Http::prepareQueryParams( $this->client->getSideload( $params ), $params );
+        $queryParams = array_merge( $queryParams, $extraParams );
 
-        $response = Http::send_with_options($this->client, $this->endpoint, ['queryParams' => $queryParams]);
+        $response = Http::send_with_options( $this->client, $this->endpoint, [ 'queryParams' => $queryParams ] );
 
-        $this->client->setSideload(null);
+        $this->client->setSideload( null );
 
         return $response;
     }
@@ -98,32 +98,32 @@ class Users extends ResourceAbstract
      *
      * @return mixed
      */
-    public function showMany(array $params = array())
+    public function showMany( array $params = array() )
     {
-        if (isset($params['ids']) && isset($params['external_ids'])) {
-            throw new \Exception('Only one parameter of ids or external_ids is allowed');
-        } elseif (!isset($params['ids']) && !isset($params['external_ids'])) {
-            throw new \Exception('Missing parameters ids or external_ids');
-        } elseif (isset($params['ids']) && is_array($params['ids'])) {
+        if (isset( $params['ids'] ) && isset( $params['external_ids'] )) {
+            throw new \Exception( 'Only one parameter of ids or external_ids is allowed' );
+        } elseif ( ! isset( $params['ids'] ) && ! isset( $params['external_ids'] )) {
+            throw new \Exception( 'Missing parameters ids or external_ids' );
+        } elseif (isset( $params['ids'] ) && is_array( $params['ids'] )) {
             $this->endpoint = 'users/show_many.json';
-            $queryParams = ['ids' => implode(',', $params['ids'])];
-        } elseif (isset($params['external_ids']) && is_array($params['external_ids'])) {
+            $queryParams    = [ 'ids' => implode( ',', $params['ids'] ) ];
+        } elseif (isset( $params['external_ids'] ) && is_array( $params['external_ids'] )) {
             $this->endpoint = 'users/show_many.json';
-            $queryParams = ['external_ids' => implode(',', $params['external_ids'])];
+            $queryParams    = [ 'external_ids' => implode( ',', $params['external_ids'] ) ];
         } else {
-            throw new \Exception('Parameters ids or external_ids must be arrays');
+            throw new \Exception( 'Parameters ids or external_ids must be arrays' );
         }
 
-        $extraParams = Http::prepareQueryParams($this->client->getSideload($params), $params);
-        $queryParams = array_merge($queryParams, $extraParams);
+        $extraParams = Http::prepareQueryParams( $this->client->getSideload( $params ), $params );
+        $queryParams = array_merge( $queryParams, $extraParams );
 
         $response = Http::send_with_options(
           $this->client,
           $this->endpoint,
-          ['queryParams' => $queryParams]
+          [ 'queryParams' => $queryParams ]
         );
 
-        $this->client->setSideload(null);
+        $this->client->setSideload( null );
 
         return $response;
     }
@@ -139,22 +139,22 @@ class Users extends ResourceAbstract
      *
      * @return mixed
      */
-    public function related(array $params = array())
+    public function related( array $params = array() )
     {
-        $params = $this->addChainedParametersToParams($params, ['id' => get_class($this)]);
+        $params = $this->addChainedParametersToParams( $params, [ 'id' => get_class( $this ) ] );
 
-        if (!$this->hasKeys($params, array('id'))) {
-            throw new MissingParametersException(__METHOD__, array('id'));
+        if ( ! $this->hasKeys( $params, array( 'id' ) )) {
+            throw new MissingParametersException( __METHOD__, array( 'id' ) );
         }
 
-        $queryParams = Http::prepareQueryParams($this->client->getSideload($params), $params);
-        $response = Http::send_with_options(
+        $queryParams = Http::prepareQueryParams( $this->client->getSideload( $params ), $params );
+        $response    = Http::send_with_options(
           $this->client,
-          $this->getRoute(__FUNCTION__, ['id' => $params['id']]),
-          ['queryParams' => $queryParams]
+          $this->getRoute( __FUNCTION__, [ 'id' => $params['id'] ] ),
+          [ 'queryParams' => $queryParams ]
         );
 
-        $this->client->setSideload(null);
+        $this->client->setSideload( null );
 
         return $response;
     }
@@ -170,21 +170,21 @@ class Users extends ResourceAbstract
      *
      * @return mixed
      */
-    public function merge(array $params = array())
+    public function merge( array $params = array() )
     {
-        $myId = $this->getChainedParameter(get_class($this));
-        $mergeMe = !isset($myId) || is_null($myId);
-        $hasKeys = $mergeMe ? array('email', 'password') : array('id');
-        if (!$this->hasKeys($params, $hasKeys)) {
-            throw new MissingParametersException(__METHOD__, $hasKeys);
+        $myId    = $this->getChainedParameter( get_class( $this ) );
+        $mergeMe = ! isset( $myId ) || is_null( $myId );
+        $hasKeys = $mergeMe ? array( 'email', 'password' ) : array( 'id' );
+        if ( ! $this->hasKeys( $params, $hasKeys )) {
+            throw new MissingParametersException( __METHOD__, $hasKeys );
         }
 
         $response = Http::send_with_options(
           $this->client,
-          $this->getRoute(__FUNCTION__),
-          ['postFields' => [self::OBJ_NAME => $params], 'method' => 'PUT']
+          $this->getRoute( __FUNCTION__ ),
+          [ 'postFields' => [ self::OBJ_NAME => $params ], 'method' => 'PUT' ]
         );
-        $this->client->setSideload(null);
+        $this->client->setSideload( null );
 
         return $response;
     }
@@ -199,15 +199,15 @@ class Users extends ResourceAbstract
      *
      * @return mixed
      */
-    public function createMany(array $params)
+    public function createMany( array $params )
     {
         $response = Http::send_with_options(
           $this->client,
-          $this->getRoute(__FUNCTION__),
-          ['postFields' => [self::OBJ_NAME_PLURAL => $params], 'method' => 'POST']
+          $this->getRoute( __FUNCTION__ ),
+          [ 'postFields' => [ self::OBJ_NAME_PLURAL => $params ], 'method' => 'POST' ]
         );
 
-        $this->client->setSideload(null);
+        $this->client->setSideload( null );
 
         return $response;
     }
@@ -224,20 +224,20 @@ class Users extends ResourceAbstract
      * @return mixed
      */
 
-    public function updateMany(array $params)
+    public function updateMany( array $params )
     {
-        if (!$this->hasKeys($params, array('ids'))) {
-            throw new MissingParametersException(__METHOD__, array('ids'));
+        if ( ! $this->hasKeys( $params, array( 'ids' ) )) {
+            throw new MissingParametersException( __METHOD__, array( 'ids' ) );
         }
         $ids = $params['ids'];
-        unset($params['ids']);
+        unset( $params['ids'] );
         $response = Http::send_with_options(
           $this->client,
-          $this->getRoute(__FUNCTION__),
-          ['postFields' => [self::OBJ_NAME => $params], 'queryParams' => ['ids' => $ids], 'method' => 'PUT']
+          $this->getRoute( __FUNCTION__ ),
+          [ 'postFields' => [ self::OBJ_NAME => $params ], 'queryParams' => [ 'ids' => $ids ], 'method' => 'PUT' ]
         );
 
-        $this->client->setSideload(null);
+        $this->client->setSideload( null );
 
         return $response;
     }
@@ -254,15 +254,15 @@ class Users extends ResourceAbstract
      * @return mixed
      */
 
-    public function updateManyIndividualUsers(array $params)
+    public function updateManyIndividualUsers( array $params )
     {
-        $this->setRoute(__METHOD__, 'users/update_many.json');
+        $this->setRoute( __METHOD__, 'users/update_many.json' );
         $response = Http::send_with_options(
           $this->client,
-          $this->getRoute(__METHOD__),
-          ['postFields' => [self::OBJ_NAME_PLURAL => $params], 'method' => 'PUT']
+          $this->getRoute( __METHOD__ ),
+          [ 'postFields' => [ self::OBJ_NAME_PLURAL => $params ], 'method' => 'PUT' ]
         );
-        $this->client->setSideload(null);
+        $this->client->setSideload( null );
 
         return $response;
     }
@@ -278,15 +278,15 @@ class Users extends ResourceAbstract
      *
      * @return mixed
      */
-    public function suspend(array $params = array())
+    public function suspend( array $params = array() )
     {
-        $params = $this->addChainedParametersToParams($params, ['id' => get_class($this)]);
-        if (!$this->hasKeys($params, array('id'))) {
-            throw new MissingParametersException(__METHOD__, array('id'));
+        $params = $this->addChainedParametersToParams( $params, [ 'id' => get_class( $this ) ] );
+        if ( ! $this->hasKeys( $params, array( 'id' ) )) {
+            throw new MissingParametersException( __METHOD__, array( 'id' ) );
         }
         $params['suspended'] = true;
 
-        return $this->update($params['id'], $params);
+        return $this->update( $params['id'], $params );
     }
 
     /**
@@ -299,18 +299,18 @@ class Users extends ResourceAbstract
      *
      * @return mixed
      */
-    public function search(array $params)
+    public function search( array $params )
     {
-        $queryParams = isset($params['query']) ? ['query' => $params['query']] : [];
-        $extraParams = Http::prepareQueryParams($this->client->getSideload($params), $params);
+        $queryParams = isset( $params['query'] ) ? [ 'query' => $params['query'] ] : [ ];
+        $extraParams = Http::prepareQueryParams( $this->client->getSideload( $params ), $params );
 
         $response = Http::send_with_options(
           $this->client,
-          $this->getRoute(__FUNCTION__),
-          ['queryParams' => array_merge($extraParams, $queryParams)]
+          $this->getRoute( __FUNCTION__ ),
+          [ 'queryParams' => array_merge( $extraParams, $queryParams ) ]
         );
 
-        $this->client->setSideload(null);
+        $this->client->setSideload( null );
 
         return $response;
     }
@@ -325,15 +325,15 @@ class Users extends ResourceAbstract
      *
      * @return mixed
      */
-    public function autocomplete(array $params)
+    public function autocomplete( array $params )
     {
         $response = Http::send_with_options(
           $this->client,
-          $this->getRoute(__FUNCTION__),
-          ['method' => 'POST', 'queryParams' => $params]
+          $this->getRoute( __FUNCTION__ ),
+          [ 'method' => 'POST', 'queryParams' => $params ]
         );
 
-        $this->client->setSideload(null);
+        $this->client->setSideload( null );
 
         return $response;
     }
@@ -350,34 +350,34 @@ class Users extends ResourceAbstract
      *
      * @return mixed
      */
-    public function updateProfileImage(array $params)
+    public function updateProfileImage( array $params )
     {
         // @TODO File upload with guzzle
         if ($this->lastId != null) {
             $params['id'] = $this->lastId;
             $this->lastId = null;
         }
-        if (!$this->hasKeys($params, array('id', 'file'))) {
-            throw new MissingParametersException(__METHOD__, array('id', 'file'));
+        if ( ! $this->hasKeys( $params, array( 'id', 'file' ) )) {
+            throw new MissingParametersException( __METHOD__, array( 'id', 'file' ) );
         }
-        if (!file_exists($params['file'])) {
-            throw new CustomException('File ' . $params['file'] . ' could not be found in ' . __METHOD__);
+        if ( ! file_exists( $params['file'] )) {
+            throw new CustomException( 'File ' . $params['file'] . ' could not be found in ' . __METHOD__ );
         }
         $id = $params['id'];
-        unset($params['id']);
-        $endPoint = Http::prepare('users/' . $id . '.json');
-        if (function_exists('curl_file_create')) {
-            $response = Http::send($this->client, $endPoint, $params['file'], 'PUT',
-                (isset($params['type']) ? $params['type'] : 'application/binary'));
+        unset( $params['id'] );
+        $endPoint = Http::prepare( 'users/' . $id . '.json' );
+        if (function_exists( 'curl_file_create' )) {
+            $response = Http::send( $this->client, $endPoint, $params['file'], 'PUT',
+              ( isset( $params['type'] ) ? $params['type'] : 'application/binary' ) );
         } else {
-            $response = Http::send($this->client, $endPoint,
-                array('user[photo][uploaded_data]' => '@' . $params['file']), 'PUT',
-                (isset($params['type']) ? $params['type'] : 'application/binary'));
+            $response = Http::send( $this->client, $endPoint,
+              array( 'user[photo][uploaded_data]' => '@' . $params['file'] ), 'PUT',
+              ( isset( $params['type'] ) ? $params['type'] : 'application/binary' ) );
         }
-        if ((!is_object($response)) || ($this->client->getDebug()->lastResponseCode != 200)) {
-            throw new ResponseException(__METHOD__);
+        if (( ! is_object( $response ) ) || ( $this->client->getDebug()->lastResponseCode != 200 )) {
+            throw new ResponseException( __METHOD__ );
         }
-        $this->client->setSideload(null);
+        $this->client->setSideload( null );
 
         return $response;
     }
@@ -392,11 +392,11 @@ class Users extends ResourceAbstract
      *
      * @return mixed
      */
-    public function me(array $params = array())
+    public function me( array $params = array() )
     {
         $params['id'] = 'me';
 
-        return $this->find($params['id']);
+        return $this->find( $params['id'] );
     }
 
     /**
@@ -410,21 +410,21 @@ class Users extends ResourceAbstract
      *
      * @return mixed
      */
-    public function setPassword(array $params)
+    public function setPassword( array $params )
     {
-        $params = $this->addChainedParametersToParams($params, ['id' => get_class($this)]);
-        if (!$this->hasKeys($params, array('id', 'password'))) {
-            throw new MissingParametersException(__METHOD__, array('id', 'password'));
+        $params = $this->addChainedParametersToParams( $params, [ 'id' => get_class( $this ) ] );
+        if ( ! $this->hasKeys( $params, array( 'id', 'password' ) )) {
+            throw new MissingParametersException( __METHOD__, array( 'id', 'password' ) );
         }
         $id = $params['id'];
-        unset($params['id']);
+        unset( $params['id'] );
 
         $response = Http::send_with_options(
           $this->client,
-          $this->getRoute(__FUNCTION__, ['id' => $id]),
-          ['postFields' => [self::OBJ_NAME => $params], 'method' => 'POST']);
+          $this->getRoute( __FUNCTION__, [ 'id' => $id ] ),
+          [ 'postFields' => [ self::OBJ_NAME => $params ], 'method' => 'POST' ] );
 
-        $this->client->setSideload(null);
+        $this->client->setSideload( null );
 
         return $response;
     }
@@ -440,22 +440,22 @@ class Users extends ResourceAbstract
      *
      * @return mixed
      */
-    public function changePassword(array $params)
+    public function changePassword( array $params )
     {
-        $params = $this->addChainedParametersToParams($params, ['id' => get_class($this)]);
-        if (!$this->hasKeys($params, array('id', 'previous_password', 'password'))) {
-            throw new MissingParametersException(__METHOD__, array('id', 'previous_password', 'password'));
+        $params = $this->addChainedParametersToParams( $params, [ 'id' => get_class( $this ) ] );
+        if ( ! $this->hasKeys( $params, array( 'id', 'previous_password', 'password' ) )) {
+            throw new MissingParametersException( __METHOD__, array( 'id', 'previous_password', 'password' ) );
         }
         $id = $params['id'];
-        unset($params['id']);
+        unset( $params['id'] );
 
         $response = Http::send_with_options(
           $this->client,
-          $this->getRoute(__FUNCTION__, ['id' => $id]),
-          ['postFields' => $params, 'method' => 'PUT']
+          $this->getRoute( __FUNCTION__, [ 'id' => $id ] ),
+          [ 'postFields' => $params, 'method' => 'PUT' ]
         );
 
-        $this->client->setSideload(null);
+        $this->client->setSideload( null );
 
         return $response;
     }

--- a/src/Zendesk/API/Resources/Views.php
+++ b/src/Zendesk/API/Resources/Views.php
@@ -20,14 +20,14 @@ class Views extends ResourceAbstract
     {
         parent::setUpRoutes();
 
-        $this->setRoutes([
-            'findAll' => 'views{modifier}.json',
-            'export' => 'views/{id}/export.json',
-            'preview' => 'views/preview.json',
-            'previewCount' => 'views/preview/count.json',
-            'execute' => 'views/{id}/execute.json',
-            'tickets' => 'views/{id}/tickets.json',
-        ]);
+        $this->setRoutes( [
+          'findAll'      => 'views{modifier}.json',
+          'export'       => 'views/{id}/export.json',
+          'preview'      => 'views/preview.json',
+          'previewCount' => 'views/preview/count.json',
+          'execute'      => 'views/{id}/execute.json',
+          'tickets'      => 'views/{id}/tickets.json',
+        ] );
     }
 
     /**
@@ -40,17 +40,17 @@ class Views extends ResourceAbstract
      *
      * @return mixed
      */
-    public function findAll(array $params = array())
+    public function findAll( array $params = array() )
     {
-        if (isset($params['active'])) {
+        if (isset( $params['active'] )) {
             $params['modifier'] = '/active';
-        } else if (isset($params['compact'])) {
+        } else if (isset( $params['compact'] )) {
             $params['modifier'] = '/compact';
         } else {
             $params['modifier'] = '';
         }
 
-        return parent::findAll($params);
+        return parent::findAll( $params );
     }
 
     /**
@@ -58,15 +58,16 @@ class Views extends ResourceAbstract
      *
      * @param int $id
      * @param array $queryParams
+     *
      * @return mixed
      */
-    public function find($id = null, array $queryParams = array())
+    public function find( $id = null, array $queryParams = array() )
     {
         $queryParams = Http::prepareQueryParams(
-            $this->client->getSideload($queryParams), $queryParams
+          $this->client->getSideload( $queryParams ), $queryParams
         );
 
-        return parent::find($id, $queryParams);
+        return parent::find( $id, $queryParams );
     }
 
     /**
@@ -78,21 +79,21 @@ class Views extends ResourceAbstract
      * @throws MissingParametersException
      *
      */
-    public function delete($id = null)
+    public function delete( $id = null )
     {
-        if ((empty($id)) && !($this->getChainedParameter('id', false))) {
-            throw new MissingParametersException(__METHOD__, array('id'));
+        if (( empty( $id ) ) && ! ( $this->getChainedParameter( 'id', false ) )) {
+            throw new MissingParametersException( __METHOD__, array( 'id' ) );
         }
 
         $endPoint = 'views/' . $id . '.json';
 
         $response = Http::send_with_options(
-            $this->client,
-            $endPoint,
-            ['method' => 'DELETE']
+          $this->client,
+          $endPoint,
+          [ 'method' => 'DELETE' ]
         );
 
-        $this->client->setSideload(null);
+        $this->client->setSideload( null );
 
         return $response;
     }
@@ -108,25 +109,25 @@ class Views extends ResourceAbstract
      *
      * @return mixed
      */
-    public function execute(array $params = array())
+    public function execute( array $params = array() )
     {
-        $params = $this->addChainedParametersToParams($params, ['id' => get_class($this)]);
+        $params = $this->addChainedParametersToParams( $params, [ 'id' => get_class( $this ) ] );
 
-        if (!$this->hasKeys($params, array('id'))) {
-            throw new MissingParametersException(__METHOD__, array('id'));
+        if ( ! $this->hasKeys( $params, array( 'id' ) )) {
+            throw new MissingParametersException( __METHOD__, array( 'id' ) );
         }
 
         $queryParams = Http::prepareQueryParams(
-          $this->client->getSideload($params), $params
+          $this->client->getSideload( $params ), $params
         );
 
         $response = Http::send_with_options(
           $this->client,
-          $this->getRoute(__FUNCTION__, ['id' => $params['id']]),
-          ['queryParams' => $queryParams]
+          $this->getRoute( __FUNCTION__, [ 'id' => $params['id'] ] ),
+          [ 'queryParams' => $queryParams ]
         );
 
-        $this->client->setSideload(null);
+        $this->client->setSideload( null );
 
         return $response;
     }
@@ -142,24 +143,24 @@ class Views extends ResourceAbstract
      *
      * @return mixed
      */
-    public function tickets(array $params = array())
+    public function tickets( array $params = array() )
     {
-        $params = $this->addChainedParametersToParams($params, ['id' => get_class($this)]);
+        $params = $this->addChainedParametersToParams( $params, [ 'id' => get_class( $this ) ] );
 
-        if (!$this->hasKeys($params, array('id'))) {
-            throw new MissingParametersException(__METHOD__, array('id'));
+        if ( ! $this->hasKeys( $params, array( 'id' ) )) {
+            throw new MissingParametersException( __METHOD__, array( 'id' ) );
         }
 
         $queryParams = Http::prepareQueryParams(
-          $this->client->getSideload($params), $params
+          $this->client->getSideload( $params ), $params
         );
 
         $response = Http::send_with_options(
           $this->client,
-          $this->getRoute(__FUNCTION__, ['id' => $params['id']]),
-          ['queryParams' => $queryParams]
+          $this->getRoute( __FUNCTION__, [ 'id' => $params['id'] ] ),
+          [ 'queryParams' => $queryParams ]
         );
-        $this->client->setSideload(null);
+        $this->client->setSideload( null );
 
         return $response;
     }
@@ -175,34 +176,34 @@ class Views extends ResourceAbstract
      *
      * @return mixed
      */
-    public function count(array $params = array())
+    public function count( array $params = array() )
     {
-        $params = $this->addChainedParametersToParams($params, ['id' => get_class($this)]);
-        if (!$this->hasKeys($params, array('id'))) {
-            throw new MissingParametersException(__METHOD__, array('id'));
+        $params = $this->addChainedParametersToParams( $params, [ 'id' => get_class( $this ) ] );
+        if ( ! $this->hasKeys( $params, array( 'id' ) )) {
+            throw new MissingParametersException( __METHOD__, array( 'id' ) );
         }
 
-        $queryParams = $routeParams =  [];
-        if (is_array($params['id'])) {
-            $this->setRoute(__FUNCTION__, 'views/count_many.json');
-            $queryParams['ids'] = implode(',', $params['id']);
-            unset($params['id']);
+        $queryParams = $routeParams = [ ];
+        if (is_array( $params['id'] )) {
+            $this->setRoute( __FUNCTION__, 'views/count_many.json' );
+            $queryParams['ids'] = implode( ',', $params['id'] );
+            unset( $params['id'] );
         } else {
-            $this->setRoute(__FUNCTION__, 'views/{id}/count.json');
-            $routeParams = ['id' => $params['id']];
+            $this->setRoute( __FUNCTION__, 'views/{id}/count.json' );
+            $routeParams = [ 'id' => $params['id'] ];
         }
 
         $extraParams = Http::prepareQueryParams(
-            $this->client->getSideload($params), $params
+          $this->client->getSideload( $params ), $params
         );
 
         $response = Http::send_with_options(
-            $this->client, $this->getRoute(__FUNCTION__, $routeParams), [
-                'queryParams' => array_merge($queryParams, $extraParams)
-            ]
+          $this->client, $this->getRoute( __FUNCTION__, $routeParams ), [
+            'queryParams' => array_merge( $queryParams, $extraParams )
+          ]
         );
 
-        $this->client->setSideload(null);
+        $this->client->setSideload( null );
 
         return $response;
     }
@@ -218,24 +219,24 @@ class Views extends ResourceAbstract
      *
      * @return mixed
      */
-    public function export(array $params = array())
+    public function export( array $params = array() )
     {
-        $params = $this->addChainedParametersToParams($params, ['id' => get_class($this)]);
-        if (!$this->hasKeys($params, array('id'))) {
-            throw new MissingParametersException(__METHOD__, array('id'));
+        $params = $this->addChainedParametersToParams( $params, [ 'id' => get_class( $this ) ] );
+        if ( ! $this->hasKeys( $params, array( 'id' ) )) {
+            throw new MissingParametersException( __METHOD__, array( 'id' ) );
         }
 
         $queryParams = Http::prepareQueryParams(
-          $this->client->getSideload($params), $params
+          $this->client->getSideload( $params ), $params
         );
 
         $response = Http::send_with_options(
-            $this->client,
-            $this->getRoute(__FUNCTION__, ['id' => $params['id']]),
-            ['queryParams' => $queryParams]
+          $this->client,
+          $this->getRoute( __FUNCTION__, [ 'id' => $params['id'] ] ),
+          [ 'queryParams' => $queryParams ]
         );
 
-        $this->client->setSideload(null);
+        $this->client->setSideload( null );
 
         return $response;
     }
@@ -250,24 +251,24 @@ class Views extends ResourceAbstract
      *
      * @return mixed
      */
-    public function preview(array $params)
+    public function preview( array $params )
     {
         $extraParams = Http::prepareQueryParams(
-            $this->client->getSideload($params),
-            $params
+          $this->client->getSideload( $params ),
+          $params
         );
 
         $response = Http::send_with_options(
-            $this->client,
-            $this->getRoute(__FUNCTION__),
-            [
-                'postFields' => array('view' => $params),
-                'queryParams' => $extraParams,
-                'method' => 'POST'
-            ]
+          $this->client,
+          $this->getRoute( __FUNCTION__ ),
+          [
+            'postFields'  => array( 'view' => $params ),
+            'queryParams' => $extraParams,
+            'method'      => 'POST'
+          ]
         );
 
-        $this->client->setSideload(null);
+        $this->client->setSideload( null );
 
         return $response;
     }
@@ -282,21 +283,21 @@ class Views extends ResourceAbstract
      *
      * @return mixed
      */
-    public function previewCount(array $params)
+    public function previewCount( array $params )
     {
         $extraParams = Http::prepareQueryParams(
-            $this->client->getSideload($params),
-            $params
+          $this->client->getSideload( $params ),
+          $params
         );
 
         $response = Http::send_with_options(
-            $this->client,
-            $this->getRoute(__FUNCTION__),
-            [
-                'postFields' => array('view' => $params),
-                'queryParams' => $extraParams,
-                'method' => 'POST'
-            ]
+          $this->client,
+          $this->getRoute( __FUNCTION__ ),
+          [
+            'postFields'  => array( 'view' => $params ),
+            'queryParams' => $extraParams,
+            'method'      => 'POST'
+          ]
         );
 
         return $response;

--- a/src/Zendesk/API/UtilityTraits/ChainedParametersTrait.php
+++ b/src/Zendesk/API/UtilityTraits/ChainedParametersTrait.php
@@ -16,76 +16,76 @@ namespace Zendesk\API\UtilityTraits;
  *
  */
 
- trait ChainedParametersTrait
- {
-     /**
-      * @var array
-      */
-     protected $chainedParameters = [];
+trait ChainedParametersTrait
+{
+    /**
+     * @var array
+     */
+    protected $chainedParameters = [];
 
-     /**
-      * Sets the chained parameters
-      *
-      * @param $params
-      *
-      * @return $this
-      *
-      */
-     public function setChainedParameters($params)
-     {
-         $this->chainedParameters = $params;
-
-         return $this;
-     }
-
-     /**
-      * Returns chained parameters
-      *
-      * @return $this
-      */
-     public function getChainedParameters()
-     {
-         return $this->chainedParameters;
-     }
-
-     /**
-      * Returns the named chained parameter
-      *
-      * @param $name
-      * @param null $default
-      *
-      * @return $this
-      */
-     public function getChainedParameter($name, $default = null)
-     {
-         $chainedParameters = $this->getChainedParameters();
-         if (array_key_exists($name, $chainedParameters)) {
-             return $chainedParameters[$name];
-         }
-
-         return $default;
-     }
-
-
-     /**
-      * A helper method to add the chained parameters to the existing parameters.
-      *
-      * @param array $params The existing parameters
-      * @param array $map An array describing what parameter key corresponds to which classId
-      *     e.g. ['ticket_id' => 'Zendesk\API\Ticket']
-      *     normal usage would be ['id' => $this::class]
-      *
-      * @return array
-      */
-     public function addChainedParametersToParams($params, $map)
-     {
+    /**
+     * Returns the named chained parameter
+     *
+     * @param $name
+     * @param null $default
+     *
+     * @return $this
+     */
+    public function getChainedParameter($name, $default = null)
+    {
         $chainedParameters = $this->getChainedParameters();
-         foreach ($map as $key => $className) {
-             if (array_key_exists($className, $chainedParameters)) {
-                 $params[$key] = $chainedParameters[$className];
-             }
-         }
-         return $params;
-     }
+        if (array_key_exists($name, $chainedParameters)) {
+            return $chainedParameters[$name];
+        }
 
- }
+        return $default;
+    }
+
+    /**
+     * Returns chained parameters
+     *
+     * @return $this
+     */
+    public function getChainedParameters()
+    {
+        return $this->chainedParameters;
+    }
+
+    /**
+     * Sets the chained parameters
+     *
+     * @param $params
+     *
+     * @return $this
+     *
+     */
+    public function setChainedParameters($params)
+    {
+        $this->chainedParameters = $params;
+
+        return $this;
+    }
+
+    /**
+     * A helper method to add the chained parameters to the existing parameters.
+     *
+     * @param array $params The existing parameters
+     * @param array $map An array describing what parameter key corresponds to which classId
+     *     e.g. ['ticket_id' => 'Zendesk\API\Ticket']
+     *     normal usage would be ['id' => $this::class]
+     *
+     * @return array
+     */
+    public function addChainedParametersToParams($params, $map)
+    {
+        $chainedParameters = $this->getChainedParameters();
+        foreach ($map as $key => $className) {
+            if (array_key_exists($className, $chainedParameters)) {
+                $params[$key] = $chainedParameters[$className];
+            }
+        }
+
+        return $params;
+    }
+
+}

--- a/src/Zendesk/API/UtilityTraits/InstantiatorTrait.php
+++ b/src/Zendesk/API/UtilityTraits/InstantiatorTrait.php
@@ -23,23 +23,23 @@ trait InstantiatorTrait
      * @return
      * @throws \Exception
      */
-    public function __call( $name, $arguments )
+    public function __call($name, $arguments)
     {
-        if (( array_key_exists( $name, $validRelations = $this::getValidRelations() ) )) {
+        if ((array_key_exists($name, $validRelations = $this::getValidRelations()))) {
             $className = $validRelations[$name];
-            $client    = ( $this instanceof HttpClient ) ? $this : $this->client;
-            $class     = new $className( $client );
+            $client = ($this instanceof HttpClient) ? $this : $this->client;
+            $class  = new $className($client);
         } else {
-            throw new \Exception( "No method called $name available in " . __CLASS__ );
+            throw new \Exception("No method called $name available in " . __CLASS__);
         }
 
-        $chainedParams = ( $this instanceof ResourceAbstract ) ? $this->getChainedParameters() : [ ];
+        $chainedParams = ($this instanceof ResourceAbstract) ? $this->getChainedParameters() : [];
 
-        if (( isset( $arguments[0] ) ) && ( $arguments[0] != null )) {
-            $chainedParams = array_merge( $chainedParams, [ get_class( $class ) => $arguments[0] ] );
+        if ((isset($arguments[0])) && ($arguments[0] != null)) {
+            $chainedParams = array_merge($chainedParams, [get_class($class) => $arguments[0]]);
         }
 
-        $class = $class->setChainedParameters( $chainedParams );
+        $class = $class->setChainedParameters($chainedParams);
 
         return $class;
     }

--- a/tests/Zendesk/API/LiveTests/BasicTest.php
+++ b/tests/Zendesk/API/LiveTests/BasicTest.php
@@ -3,7 +3,7 @@
 namespace Zendesk\API\LiveTests;
 
 use Zendesk\API\HttpClient;
-use \Aeris\GuzzleHttpMock\Mock as GuzzleHttpMock;
+use Aeris\GuzzleHttpMock\Mock as GuzzleHttpMock;
 
 
 /**

--- a/tests/Zendesk/API/LiveTests/TicketCommentsTest.php
+++ b/tests/Zendesk/API/LiveTests/TicketCommentsTest.php
@@ -38,7 +38,7 @@ class TicketCommentsTest extends BasicTest
           ]
         );
 
-        $comments = $this->client->ticket($this->ticket_id)->comments()->findAll();
+        $comments = $this->client->tickets($this->ticket_id)->comments()->findAll();
         $this->httpMock->verify();
 
         $this->assertEquals(is_object($comments), true, 'Should return an object');
@@ -63,7 +63,7 @@ class TicketCommentsTest extends BasicTest
             ]
           ]
         );
-        $comment_id = $this->client->ticket($this->ticket_id)->comments()->findAll()->comments[0]->id;
+        $comment_id = $this->client->tickets($this->ticket_id)->comments()->findAll()->comments[0]->id;
         $this->httpMock->verify();
 
         $this->mockApiCall(
@@ -71,7 +71,7 @@ class TicketCommentsTest extends BasicTest
           'tickets/12345/comments/1/make_private.json',
           []
         );
-        $this->client->ticket($this->ticket_id)->comments($comment_id)->makePrivate();
+        $this->client->tickets($this->ticket_id)->comments($comment_id)->makePrivate();
         $this->httpMock->verify();
     }
 }

--- a/tests/Zendesk/API/LiveTests/TicketsTest.php
+++ b/tests/Zendesk/API/LiveTests/TicketsTest.php
@@ -19,7 +19,7 @@ class TicketsTest extends BasicTest
                 'body' => 'Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.'
             ),
             'priority' => 'normal',
-            'id' => "12345"
+            'id' => '12345'
         );
 
         $this->testTicket2 = array(
@@ -37,14 +37,14 @@ class TicketsTest extends BasicTest
     public function testAllSideLoadedMethod()
     {
         $this->mockApiCall(
-            "GET",
-            "tickets.json",
+            'GET',
+            'tickets.json',
             array(
-                "tickets" => [$this->testTicket],
-                "groups" => [],
-                "users" => []
+                'tickets' => [$this->testTicket],
+                'groups' => [],
+                'users' => []
             ),
-            ["queryParams" => ["include" => "users,groups"]]
+            ['queryParams' => ['include' => 'users,groups']]
         );
 
         $this->client->tickets()->sideload(array('users', 'groups'))->findAll();
@@ -54,14 +54,14 @@ class TicketsTest extends BasicTest
     public function testAllSideLoadedParameter()
     {
         $this->mockApiCall(
-            "GET",
-            "tickets.json",
+            'GET',
+            'tickets.json',
             array(
-                "tickets" => [$this->testTicket],
-                "groups" => [],
-                "users" => []
+                'tickets' => [$this->testTicket],
+                'groups' => [],
+                'users' => []
             ),
-            ["queryParams" => array('include' => implode(",", array('users', 'groups')))]
+            ['queryParams' => array('include' => implode(',', array('users', 'groups')))]
         );
 
         $this->client->tickets()->findAll(array('sideload' => array('users', 'groups')));
@@ -71,8 +71,8 @@ class TicketsTest extends BasicTest
     public function testFindSingle()
     {
         $this->mockApiCall(
-            "GET", 'tickets/' . $this->testTicket['id'] . ".json",
-            ["ticket" => $this->testTicket]
+            'GET', 'tickets/' . $this->testTicket['id'] . '.json',
+            ['ticket' => $this->testTicket]
         );
 
         $this->client->tickets()->find($this->testTicket['id']);
@@ -83,9 +83,9 @@ class TicketsTest extends BasicTest
     public function testFindSingleChainPattern()
     {
         $this->mockApiCall(
-            "GET",
-            'tickets/' . $this->testTicket['id'] . ".json",
-            ["ticket" => $this->testTicket]
+            'GET',
+            'tickets/' . $this->testTicket['id'] . '.json',
+            ['ticket' => $this->testTicket]
         );
 
         $this->client->tickets($this->testTicket['id'])->find();
@@ -95,10 +95,10 @@ class TicketsTest extends BasicTest
     public function testFindMultiple()
     {
         $this->mockApiCall(
-            "GET",
-            "tickets/show_many.json",
-            ["tickets" => array($this->testTicket, $this->testTicket2)],
-            ["queryParams" => array('ids' => implode(",", [$this->testTicket['id'], $this->testTicket2['id']]))]
+            'GET',
+            'tickets/show_many.json',
+            ['tickets' => array($this->testTicket, $this->testTicket2)],
+            ['queryParams' => array('ids' => implode(',', [$this->testTicket['id'], $this->testTicket2['id']]))]
         );
 
         $testTicketIds = ['ids' => [$this->testTicket['id'], $this->testTicket2['id']]];
@@ -109,10 +109,10 @@ class TicketsTest extends BasicTest
     public function testDeleteMultiple()
     {
         $this->mockApiCall(
-            "DELETE",
-            "tickets/destroy_many.json?ids=123%2C321",
-            array("tickets" => []),
-            ["queryParams" => array('ids' => implode(",", [123, 321]))]
+            'DELETE',
+            'tickets/destroy_many.json?ids=123%2C321',
+            array('tickets' => []),
+            ['queryParams' => array('ids' => implode(',', [123, 321]))]
         );
 
         $this->client->tickets()->deleteMany(array(123, 321));
@@ -121,12 +121,12 @@ class TicketsTest extends BasicTest
 
     public function testCreateWithAttachment()
     {
-        $this->markTestSkipped("Waiting for side chaining to support this");
+        $this->markTestSkipped('Waiting for side chaining to support this');
         
-        $this->mockApiCall("POST", "/uploads.json?filename=UK%20test%20non-alpha%20chars.png",
-            array("upload" => array("token" => "asdf")), ["code" => 201]);
+        $this->mockApiCall('POST', '/uploads.json?filename=UK%20test%20non-alpha%20chars.png',
+            array('upload' => array('token' => 'asdf')), ['code' => 201]);
 
-        $this->mockApiCall("POST", "tickets.json", array("ticket" => array("id" => "123")),
+        $this->mockApiCall('POST', 'tickets.json', array('ticket' => array('id' => '123')),
             array('code' => 201));
 
         $this->client->tickets()->attach(array(
@@ -138,10 +138,10 @@ class TicketsTest extends BasicTest
 
     public function testExport()
     {
-        $this->mockApiCall("GET",
-            "exports/tickets.json",
-            array("results" => []),
-            ["queryParams" => ["start_time" => "1332034771"]]
+        $this->mockApiCall('GET',
+            'exports/tickets.json',
+            array('results' => []),
+            ['queryParams' => ['start_time' => '1332034771']]
         );
         $this->client->tickets()->export(array('start_time' => '1332034771'));
         $this->httpMock->verify();
@@ -152,19 +152,19 @@ class TicketsTest extends BasicTest
         $ticketIds = [$this->testTicket['id'], $this->testTicket2['id']];
 
         $this->mockApiCall(
-            "PUT",
-            "tickets/update_many.json",
-            array("job_status" => ["job_status" => ["id" => "bugger off"]]),
+            'PUT',
+            'tickets/update_many.json',
+            array('job_status' => ['job_status' => ['id' => 'bugger off']]),
             [
-                "queryParams" => ["ids" => implode(",", $ticketIds)],
-                "bodyParams" => ["ticket" => ["status" => "solved"]]
+                'queryParams' => ['ids' => implode(',', $ticketIds)],
+                'bodyParams' => ['ticket' => ['status' => 'solved']]
             ]
         );
 
         $this->client->tickets()->updateMany(
             [
-                "ids" => $ticketIds,
-                "status" => "solved"
+                'ids' => $ticketIds,
+                'status' => 'solved'
             ]
         );
         $this->httpMock->verify();
@@ -175,11 +175,11 @@ class TicketsTest extends BasicTest
         $tickets = [$this->testTicket, $this->testTicket2];
 
         $this->mockApiCall(
-            "PUT",
-            "tickets/update_many.json",
-            array("job_status" => ["job_status" => ["id" => "bugger off"]]),
+            'PUT',
+            'tickets/update_many.json',
+            array('job_status' => ['job_status' => ['id' => 'bugger off']]),
             [
-                "bodyParams" => ["tickets" => $tickets]
+                'bodyParams' => ['tickets' => $tickets]
             ]
         );
 

--- a/tests/Zendesk/API/LiveTests/TicketsTest.php
+++ b/tests/Zendesk/API/LiveTests/TicketsTest.php
@@ -14,21 +14,21 @@ class TicketsTest extends BasicTest
     public function setUp()
     {
         $this->testTicket = array(
-            'subject' => 'The quick brown fox jumps over the lazy dog',
-            'comment' => array(
-                'body' => 'Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.'
-            ),
-            'priority' => 'normal',
-            'id' => '12345'
+          'subject'  => 'The quick brown fox jumps over the lazy dog',
+          'comment'  => array(
+            'body' => 'Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.'
+          ),
+          'priority' => 'normal',
+          'id'       => '12345'
         );
 
         $this->testTicket2 = array(
-            'subject' => 'The second ticket',
-            'comment' => array(
-                'body' => 'Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.'
-            ),
-            'priority' => 'normal',
-            'id' => '4321'
+          'subject'  => 'The second ticket',
+          'comment'  => array(
+            'body' => 'Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.'
+          ),
+          'priority' => 'normal',
+          'id'       => '4321'
         );
 
         parent::setUp();
@@ -37,45 +37,45 @@ class TicketsTest extends BasicTest
     public function testAllSideLoadedMethod()
     {
         $this->mockApiCall(
-            'GET',
-            'tickets.json',
-            array(
-                'tickets' => [$this->testTicket],
-                'groups' => [],
-                'users' => []
-            ),
-            ['queryParams' => ['include' => 'users,groups']]
+          'GET',
+          'tickets.json',
+          array(
+            'tickets' => [ $this->testTicket ],
+            'groups'  => [ ],
+            'users'   => [ ]
+          ),
+          [ 'queryParams' => [ 'include' => 'users,groups' ] ]
         );
 
-        $this->client->tickets()->sideload(array('users', 'groups'))->findAll();
+        $this->client->tickets()->sideload( array( 'users', 'groups' ) )->findAll();
         $this->httpMock->verify();
     }
 
     public function testAllSideLoadedParameter()
     {
         $this->mockApiCall(
-            'GET',
-            'tickets.json',
-            array(
-                'tickets' => [$this->testTicket],
-                'groups' => [],
-                'users' => []
-            ),
-            ['queryParams' => array('include' => implode(',', array('users', 'groups')))]
+          'GET',
+          'tickets.json',
+          array(
+            'tickets' => [ $this->testTicket ],
+            'groups'  => [ ],
+            'users'   => [ ]
+          ),
+          [ 'queryParams' => array( 'include' => implode( ',', array( 'users', 'groups' ) ) ) ]
         );
 
-        $this->client->tickets()->findAll(array('sideload' => array('users', 'groups')));
+        $this->client->tickets()->findAll( array( 'sideload' => array( 'users', 'groups' ) ) );
         $this->httpMock->verify();
     }
 
     public function testFindSingle()
     {
         $this->mockApiCall(
-            'GET', 'tickets/' . $this->testTicket['id'] . '.json',
-            ['ticket' => $this->testTicket]
+          'GET', 'tickets/' . $this->testTicket['id'] . '.json',
+          [ 'ticket' => $this->testTicket ]
         );
 
-        $this->client->tickets()->find($this->testTicket['id']);
+        $this->client->tickets()->find( $this->testTicket['id'] );
         $this->httpMock->verify();
 
     }
@@ -83,188 +83,188 @@ class TicketsTest extends BasicTest
     public function testFindSingleChainPattern()
     {
         $this->mockApiCall(
-            'GET',
-            'tickets/' . $this->testTicket['id'] . '.json',
-            ['ticket' => $this->testTicket]
+          'GET',
+          'tickets/' . $this->testTicket['id'] . '.json',
+          [ 'ticket' => $this->testTicket ]
         );
 
-        $this->client->tickets($this->testTicket['id'])->find();
+        $this->client->tickets( $this->testTicket['id'] )->find();
         $this->httpMock->verify();
     }
 
     public function testFindMultiple()
     {
         $this->mockApiCall(
-            'GET',
-            'tickets/show_many.json',
-            ['tickets' => array($this->testTicket, $this->testTicket2)],
-            ['queryParams' => array('ids' => implode(',', [$this->testTicket['id'], $this->testTicket2['id']]))]
+          'GET',
+          'tickets/show_many.json',
+          [ 'tickets' => array( $this->testTicket, $this->testTicket2 ) ],
+          [ 'queryParams' => array( 'ids' => implode( ',', [ $this->testTicket['id'], $this->testTicket2['id'] ] ) ) ]
         );
 
-        $testTicketIds = ['ids' => [$this->testTicket['id'], $this->testTicket2['id']]];
-        $this->client->tickets()->findMany($testTicketIds);
+        $testTicketIds = [ 'ids' => [ $this->testTicket['id'], $this->testTicket2['id'] ] ];
+        $this->client->tickets()->findMany( $testTicketIds );
         $this->httpMock->verify();
     }
 
     public function testDeleteMultiple()
     {
         $this->mockApiCall(
-            'DELETE',
-            'tickets/destroy_many.json?ids=123%2C321',
-            array('tickets' => []),
-            ['queryParams' => array('ids' => implode(',', [123, 321]))]
+          'DELETE',
+          'tickets/destroy_many.json?ids=123%2C321',
+          array( 'tickets' => [ ] ),
+          [ 'queryParams' => array( 'ids' => implode( ',', [ 123, 321 ] ) ) ]
         );
 
-        $this->client->tickets()->deleteMany(array(123, 321));
+        $this->client->tickets()->deleteMany( array( 123, 321 ) );
         $this->httpMock->verify();
     }
 
     public function testCreateWithAttachment()
     {
-        $this->markTestSkipped('Waiting for side chaining to support this');
-        
-        $this->mockApiCall('POST', '/uploads.json?filename=UK%20test%20non-alpha%20chars.png',
-            array('upload' => array('token' => 'asdf')), ['code' => 201]);
+        $this->markTestSkipped( 'Waiting for side chaining to support this' );
 
-        $this->mockApiCall('POST', 'tickets.json', array('ticket' => array('id' => '123')),
-            array('code' => 201));
+        $this->mockApiCall( 'POST', '/uploads.json?filename=UK%20test%20non-alpha%20chars.png',
+          array( 'upload' => array( 'token' => 'asdf' ) ), [ 'code' => 201 ] );
 
-        $this->client->tickets()->attach(array(
-            'file' => getcwd() . '/tests/assets/UK.png',
-            'name' => 'UK test non-alpha chars.png'
-        ))->create($this->testTicket);
+        $this->mockApiCall( 'POST', 'tickets.json', array( 'ticket' => array( 'id' => '123' ) ),
+          array( 'code' => 201 ) );
+
+        $this->client->tickets()->attach( array(
+          'file' => getcwd() . '/tests/assets/UK.png',
+          'name' => 'UK test non-alpha chars.png'
+        ) )->create( $this->testTicket );
         $this->httpMock->verify();
     }
 
     public function testExport()
     {
-        $this->mockApiCall('GET',
-            'exports/tickets.json',
-            array('results' => []),
-            ['queryParams' => ['start_time' => '1332034771']]
+        $this->mockApiCall( 'GET',
+          'exports/tickets.json',
+          array( 'results' => [ ] ),
+          [ 'queryParams' => [ 'start_time' => '1332034771' ] ]
         );
-        $this->client->tickets()->export(array('start_time' => '1332034771'));
+        $this->client->tickets()->export( array( 'start_time' => '1332034771' ) );
         $this->httpMock->verify();
     }
 
     public function testUpdateManyWithQueryParams()
     {
-        $ticketIds = [$this->testTicket['id'], $this->testTicket2['id']];
+        $ticketIds = [ $this->testTicket['id'], $this->testTicket2['id'] ];
 
         $this->mockApiCall(
-            'PUT',
-            'tickets/update_many.json',
-            array('job_status' => ['job_status' => ['id' => 'bugger off']]),
-            [
-                'queryParams' => ['ids' => implode(',', $ticketIds)],
-                'bodyParams' => ['ticket' => ['status' => 'solved']]
-            ]
+          'PUT',
+          'tickets/update_many.json',
+          array( 'job_status' => [ 'job_status' => [ 'id' => 'bugger off' ] ] ),
+          [
+            'queryParams' => [ 'ids' => implode( ',', $ticketIds ) ],
+            'bodyParams'  => [ 'ticket' => [ 'status' => 'solved' ] ]
+          ]
         );
 
         $this->client->tickets()->updateMany(
-            [
-                'ids' => $ticketIds,
-                'status' => 'solved'
-            ]
+          [
+            'ids'    => $ticketIds,
+            'status' => 'solved'
+          ]
         );
         $this->httpMock->verify();
     }
 
     public function testUpdateMany()
     {
-        $tickets = [$this->testTicket, $this->testTicket2];
+        $tickets = [ $this->testTicket, $this->testTicket2 ];
 
         $this->mockApiCall(
-            'PUT',
-            'tickets/update_many.json',
-            array('job_status' => ['job_status' => ['id' => 'bugger off']]),
-            [
-                'bodyParams' => ['tickets' => $tickets]
-            ]
+          'PUT',
+          'tickets/update_many.json',
+          array( 'job_status' => [ 'job_status' => [ 'id' => 'bugger off' ] ] ),
+          [
+            'bodyParams' => [ 'tickets' => $tickets ]
+          ]
         );
 
-        $this->client->tickets()->updateMany($tickets);
+        $this->client->tickets()->updateMany( $tickets );
         $this->httpMock->verify();
     }
 
     public function testRelated()
     {
         $this->mockApiCall(
-            'GET',
-            'tickets/12345/related.json',
-            array('topic_id' => 1),
-            array('statusCode' => 200)
+          'GET',
+          'tickets/12345/related.json',
+          array( 'topic_id' => 1 ),
+          array( 'statusCode' => 200 )
         );
 
-        $related = $this->client->tickets(12345)->related();
+        $related = $this->client->tickets( 12345 )->related();
 
         $this->httpMock->verify();
 
         // Test if the method returns readable data
-        $this->assertEquals(is_object($related), true, 'Should return an object');
+        $this->assertEquals( is_object( $related ), true, 'Should return an object' );
     }
 
     public function testCollaborators()
     {
         $this->mockApiCall(
-            'GET',
-            'tickets/12345/collaborators.json',
-            array('topic_id' => 1),
-            array('statusCode' => 200)
+          'GET',
+          'tickets/12345/collaborators.json',
+          array( 'topic_id' => 1 ),
+          array( 'statusCode' => 200 )
         );
 
-        $collaborators = $this->client->tickets()->collaborators(array('id' => 12345));
+        $collaborators = $this->client->tickets()->collaborators( array( 'id' => 12345 ) );
 
         $this->httpMock->verify();
 
-        $this->assertEquals(is_object($collaborators), true, 'Should return an object');
+        $this->assertEquals( is_object( $collaborators ), true, 'Should return an object' );
     }
 
     public function testIncidents()
     {
         $this->mockApiCall(
-            'GET',
-            'tickets/12345/incidents.json',
-            array('topic_id' => 1),
-            array('statusCode' => 200)
+          'GET',
+          'tickets/12345/incidents.json',
+          array( 'topic_id' => 1 ),
+          array( 'statusCode' => 200 )
         );
 
-        $incidents = $this->client->tickets()->incidents(array('id' => 12345));
+        $incidents = $this->client->tickets()->incidents( array( 'id' => 12345 ) );
 
         $this->httpMock->verify();
 
-        $this->assertEquals(is_object($incidents), true, 'Should return an object');
+        $this->assertEquals( is_object( $incidents ), true, 'Should return an object' );
     }
 
     public function testProblems()
     {
         $this->mockApiCall(
-            'GET',
-            'problems.json',
-            array('tickets' => []),
-            array('statusCode' => 200)
+          'GET',
+          'problems.json',
+          array( 'tickets' => [ ] ),
+          array( 'statusCode' => 200 )
         );
 
         $problems = $this->client->tickets()->problems();
 
         $this->httpMock->verify();
 
-        $this->assertEquals(is_object($problems), true, 'Should return an object');
+        $this->assertEquals( is_object( $problems ), true, 'Should return an object' );
     }
 
     public function testProblemAutoComplete()
     {
         $this->mockApiCall(
-            'POST',
-            'problems/autocomplete.json',
-            array('tickets' => []),
-            array(
-                'statusCode' => 200,
-                'bodyParams' => ['text' => 'foo']
-            )
+          'POST',
+          'problems/autocomplete.json',
+          array( 'tickets' => [ ] ),
+          array(
+            'statusCode' => 200,
+            'bodyParams' => [ 'text' => 'foo' ]
+          )
         );
 
-        $this->client->tickets()->problemAutoComplete(array('text' => 'foo'));
+        $this->client->tickets()->problemAutoComplete( array( 'text' => 'foo' ) );
 
         $this->httpMock->verify();
     }
@@ -272,29 +272,29 @@ class TicketsTest extends BasicTest
     public function testMarkAsSpam()
     {
         $this->mockApiCall(
-            'PUT',
-            'tickets/12345/mark_as_spam.json',
-            [],
-            ['statusCode' => 200]
+          'PUT',
+          'tickets/12345/mark_as_spam.json',
+          [ ],
+          [ 'statusCode' => 200 ]
         );
 
-        $this->client->tickets(12345)->markAsSpam();
+        $this->client->tickets( 12345 )->markAsSpam();
         $this->httpMock->verify();
     }
 
     public function testMarkManyAsSpam()
     {
         $this->mockApiCall(
-            'PUT',
-            'tickets/mark_many_as_spam.json',
-            [],
-            [
-                'statusCode' => 200,
-                'queryParams' => ['ids' => '12345,54321']
-            ]
+          'PUT',
+          'tickets/mark_many_as_spam.json',
+          [ ],
+          [
+            'statusCode'  => 200,
+            'queryParams' => [ 'ids' => '12345,54321' ]
+          ]
         );
 
-        $this->client->tickets()->markAsSpam([12345, 54321]);
+        $this->client->tickets()->markAsSpam( [ 12345, 54321 ] );
         $this->httpMock->verify();
     }
 }

--- a/tests/Zendesk/API/LiveTests/UsersTest.php
+++ b/tests/Zendesk/API/LiveTests/UsersTest.php
@@ -68,7 +68,7 @@ class UsersTest extends BasicTest
           [ 'user' => [ 'id' => 12345 ] ]
         );
 
-        $user = $this->client->user( 12345 )->find();
+        $user = $this->client->users( 12345 )->find();
         $this->httpMock->verify();
         $this->assertEquals( is_object( $user ), true, 'Should return an object' );
         $this->assertEquals( is_object( $user->user ), true, 'Should return an object called "user"' );
@@ -159,7 +159,7 @@ class UsersTest extends BasicTest
           [ 'user_related' => [ 'requested_tickets' => 1 ] ]
           );
 
-        $related = $this->client->user( 12345 )->related();
+        $related = $this->client->users( 12345 )->related();
         $this->httpMock->verify();
         $this->assertEquals( is_object( $related ), true, 'Should return an object' );
         $this->assertEquals( is_object( $related->user_related ), true,
@@ -177,7 +177,7 @@ class UsersTest extends BasicTest
           ['user' => [ 'id' => 12345 ]],
           ['bodyParams' => [Users::OBJ_NAME => $bodyParams]]
         );
-        $this->client->user('me')->merge($bodyParams);
+        $this->client->users('me')->merge($bodyParams);
         $this->httpMock->verify();
     }
 
@@ -220,7 +220,7 @@ class UsersTest extends BasicTest
           ['bodyParams' => [Users::OBJ_NAME => $bodyParams]]
         );
 
-        $user = $this->client->user(12345)->update(null, $bodyParams);
+        $user = $this->client->users(12345)->update(null, $bodyParams);
         $this->httpMock->verify();
     }
 
@@ -283,7 +283,7 @@ class UsersTest extends BasicTest
           ['user' => ['id' => $userId]],
           ['bodyParams' => [Users::OBJ_NAME => ['id' => $userId, 'suspended' => true]]]
         );
-        $user = $this->client->user($userId)->suspend();
+        $user = $this->client->users($userId)->suspend();
         $this->httpMock->verify();
         $this->assertEquals( is_object( $user ), true, 'Should return an object' );
         $this->assertEquals( is_object( $user->user ), true, 'Should return an object called "user"' );
@@ -335,7 +335,7 @@ class UsersTest extends BasicTest
         $this->mockApiCall( 'GET', '/users/12345.json?', array( 'id' => 12345 ) );
         $this->mockApiCall( 'PUT', '/users/12345.json', array( 'user' => array( 'id' => 12345 ) ) );
 
-        $user = $this->client->user( 12345 )->updateProfileImage( array(
+        $user = $this->client->users( 12345 )->updateProfileImage( array(
           'file' => getcwd() . '/tests/assets/UK.png'
         ) );
 
@@ -372,7 +372,7 @@ class UsersTest extends BasicTest
           ['bodyParams' => [Users::OBJ_NAME => $bodyParams]]
         );
 
-        $user = $this->client->user(12345)->setPassword($bodyParams);
+        $user = $this->client->users(12345)->setPassword($bodyParams);
         $this->httpMock->verify();
     }
 
@@ -389,7 +389,7 @@ class UsersTest extends BasicTest
           ['bodyParams' => $bodyParams]
         );
 
-        $user = $this->client->user(421450109)->changePassword($bodyParams);
+        $user = $this->client->users(421450109)->changePassword($bodyParams);
         $this->httpMock->verify();
     }
 

--- a/tests/Zendesk/API/LiveTests/ViewsTest.php
+++ b/tests/Zendesk/API/LiveTests/ViewsTest.php
@@ -51,7 +51,7 @@ class ViewsTest extends BasicTest
           ['queryParams' => $queryParams]
         );
 
-        $view = $this->client->view($this->id)->execute($queryParams);
+        $view = $this->client->views($this->id)->execute($queryParams);
         $this->httpMock->verify();
         $this->assertEquals(is_object($view), true, 'Should return an object');
         $this->assertEquals(is_object($view->view), true, 'Should return an object called "view"');
@@ -66,7 +66,7 @@ class ViewsTest extends BasicTest
           ['view_count' => ['view_id' => $this->id]]
         );
 
-        $counts = $this->client->view($this->id)->count();
+        $counts = $this->client->views($this->id)->count();
         $this->httpMock->verify();
         $this->assertEquals(is_object($counts), true, 'Should return an object');
         $this->assertEquals(is_object($counts->view_count), true, 'Should return an object called "view_count"');
@@ -83,7 +83,7 @@ class ViewsTest extends BasicTest
           ['queryParams' => ['ids' => implode(',' , $queryIds)]]
         );
 
-        $counts = $this->client->view($queryIds)->count();
+        $counts = $this->client->views($queryIds)->count();
         $this->httpMock->verify();
         $this->assertEquals(is_array($counts->view_counts), true,
             'Should return an array of objects called "view_counts"');
@@ -99,7 +99,7 @@ class ViewsTest extends BasicTest
           ['export' => ['view_id' => $this->id]]
         );
 
-        $export = $this->client->view($this->id)->export();
+        $export = $this->client->views($this->id)->export();
         $this->httpMock->verify();
         $this->assertEquals(is_object($export), true, 'Should return an object');
         $this->assertGreaterThan(0, $export->export->view_id, 'Returns a non-numeric view_id for export');


### PR DESCRIPTION
Create new instances of each resource when calling them. 
`$client->tickets()->comments()` would instantiate new classes for `Tickets` and `Comments`. 
This means we do not have to worry about leftover state variables and is better design overall.

Additionally we want to add consistency and always use plural both for the resources class names and when instantiating them.

/cc @joseconsador @jwswj @mmolina @atroche 

### References
 - Jira link: 

### Risks
 - We might not be able to chain properly (medium)