### PR TITLE
Move tests to UnitTests folder

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,4 +4,4 @@ php:
   # - 5.4
   # - hhvm
 before_script: composer self-update && composer install
-script: phpunit --testsuite "Zendesk API Live Test Suites"
+script: phpunit --testsuite "Zendesk API Unit Test Suites"

--- a/tests/Zendesk/API/UnitTests/BasicTest.php
+++ b/tests/Zendesk/API/UnitTests/BasicTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Zendesk\API\LiveTests;
+namespace Zendesk\API\UnitTests;
 
 use Zendesk\API\HttpClient;
 use \Aeris\GuzzleHttpMock\Mock as GuzzleHttpMock;

--- a/tests/Zendesk/API/UnitTests/DummyResource.php
+++ b/tests/Zendesk/API/UnitTests/DummyResource.php
@@ -1,5 +1,5 @@
 <?php
-namespace Zendesk\API\LiveTests;
+namespace Zendesk\API\UnitTests;
 
 use Zendesk\API\Resources\ResourceAbstract;
 

--- a/tests/Zendesk/API/UnitTests/ResourceTest.php
+++ b/tests/Zendesk/API/UnitTests/ResourceTest.php
@@ -1,5 +1,5 @@
 <?php
-namespace Zendesk\API\LiveTests;
+namespace Zendesk\API\UnitTests;
 
 class ResourceTest extends BasicTest
 {

--- a/tests/Zendesk/API/UnitTests/TicketCommentsTest.php
+++ b/tests/Zendesk/API/UnitTests/TicketCommentsTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Zendesk\API\LiveTests;
+namespace Zendesk\API\UnitTests;
 
 /**
  * Ticket Comments test class

--- a/tests/Zendesk/API/UnitTests/TicketsTest.php
+++ b/tests/Zendesk/API/UnitTests/TicketsTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Zendesk\API\LiveTests;
+namespace Zendesk\API\UnitTests;
 
 
 /**

--- a/tests/Zendesk/API/UnitTests/UsersTest.php
+++ b/tests/Zendesk/API/UnitTests/UsersTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Zendesk\API\LiveTests;
+namespace Zendesk\API\UnitTests;
 
 use Zendesk\API\Resources\Users;
 

--- a/tests/Zendesk/API/UnitTests/ViewsTest.php
+++ b/tests/Zendesk/API/UnitTests/ViewsTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Zendesk\API\LiveTests;
+namespace Zendesk\API\UnitTests;
 
 use Zendesk\API\Resources\Views;
 


### PR DESCRIPTION
Moved the tests in LiveTests to the UnitTests folder, for consistency. 
Updated .travis.yml to run the unit tests only.

/cc @miogalang @jwswj @mmolina

### Risks
 - The tests may fail (medium)