### PR TITLE
Remove var_dump(), pass Guzzle exception to our own exception class

### DIFF
--- a/src/Zendesk/API/Http.php
+++ b/src/Zendesk/API/Http.php
@@ -2,27 +2,30 @@
 
 namespace Zendesk\API;
 
+use Zendesk\API\Exceptions\ResponseException;
+
 /**
  * HTTP functions via curl
+ *
  * @package Zendesk\API
  */
 class Http
 {
     public static $curl;
 
-  /**
-   * Prepares an endpoint URL with optional side-loading
-   *
-   * @param string $endPoint
-   * @param array $sideload
-   * @param array $iterators
-   *
-   * @return string
-   */
+    /**
+     * Prepares an endpoint URL with optional side-loading
+     *
+     * @param string $endPoint
+     * @param array  $sideload
+     * @param array  $iterators
+     *
+     * @return string
+     */
     public static function prepareQueryParams(array $sideload = null, array $iterators = null)
     {
-        $addParams = array();
-      // First look for side-loaded variables
+        $addParams = [];
+        // First look for side-loaded variables
         if (is_array($sideload)) {
             $addParams['include'] = implode(',', $sideload);
         }
@@ -30,7 +33,7 @@ class Http
       // Next look for special collection iterators
         if (is_array($iterators)) {
             foreach ($iterators as $k => $v) {
-                if (in_array($k, array('per_page', 'page', 'sort_order', 'sort_by'))) {
+                if (in_array($k, ['per_page', 'page', 'sort_order', 'sort_by'])) {
                     $addParams[$k] = $v;
                 }
             }
@@ -39,31 +42,31 @@ class Http
         return $addParams;
     }
 
-  /**
-   * Use the send method to call every endpoint except for oauth/tokens
-   *
-   * @param HttpClient $client
-   * @param string $endPoint E.g. "/tickets.json"
-   * @param array $options
-   *          Available options are listed below:
-   *          array $queryParams Array of unencoded key-value pairs, e.g. ["ids" => "1,2,3,4"]
-   *          array $postFields Array of unencoded key-value pairs, e.g. ["filename" => "blah.png"]
-   *          string $method "GET", "POST", etc. Default is GET.
-   *          string $contentType Default is "application/json"
-   *
-   * @return array The response body, parsed from JSON into an associative array
-   */
-    public static function sendWithOptions(
+    /**
+     * Use the send method to call every endpoint except for oauth/tokens
+     *
+     * @param HttpClient $client
+     * @param string     $endPoint E.g. "/tickets.json"
+     * @param array      $options
+     *                             Available options are listed below:
+     *                             array $queryParams Array of unencoded key-value pairs, e.g. ["ids" => "1,2,3,4"]
+     *                             array $postFields Array of unencoded key-value pairs, e.g. ["filename" => "blah.png"]
+     *                             string $method "GET", "POST", etc. Default is GET.
+     *                             string $contentType Default is "application/json"
+     *
+     * @return array The response body, parsed from JSON into an associative array
+     */
+    public static function send_with_options(
         HttpClient $client,
         $endPoint,
         $options = []
     ) {
         $options = array_merge(
             [
-            'method'      => 'GET',
-            'contentType' => 'application/json',
-            'postFields'  => [],
-            'queryParams' => []
+                'method'      => 'GET',
+                'contentType' => 'application/json',
+                'postFields'  => [],
+                'queryParams' => []
             ],
             $options
         );
@@ -79,64 +82,61 @@ class Http
             $method,
             $url,
             [
-            'query'   => $queryParams,
-            'body'    => json_encode($postFields),
-            'headers' => [
-            'Accept'       => 'application/json',
-            'Content-Type' => $contentType
-            ]
+                'query'   => $queryParams,
+                'body'    => json_encode($postFields),
+                'headers' => [
+                    'Accept'       => 'application/json',
+                    'Content-Type' => $contentType
+                ]
             ]
         );
 
         try {
             $response = $client->guzzle->send($request);
+
+            $responseCode = $response->getStatusCode();
+
+            $client->setDebug(
+                $response->getHeaders(),
+                $responseCode,
+                10,
+                null
+            );
         } catch (\GuzzleHttp\Exception\ClientException $e) {
-            var_dump($e->getRequest()->getUri());
-            var_dump($e->getResponse()->getStatusCode());
+            throw new ResponseException($endPoint, null, null, $e);
         }
 
-        $responseCode       = $response->getStatusCode();
-        $parsedResponseBody = json_decode($response->getBody());
-
-        $client->setDebug(
-            $response->getHeaders(),
-            $responseCode,
-            10,
-            null
-        );
-
-        return $parsedResponseBody;
+        return json_decode($response->getBody());
     }
 
-  /**
-   * Specific case for OAuth. Run /oauth.php via your browser to get an access token
-   *
-   * @param HttpClient $client
-   * @param string $code
-   * @param string $oAuthId
-   * @param string $oAuthSecret
-   *
-   * @throws \Exception
-   *
-   * @return mixed
-   */
+    /**
+     * Specific case for OAuth. Run /oauth.php via your browser to get an access token
+     *
+     * @param HttpClient $client
+     * @param string     $code
+     * @param string     $oAuthId
+     * @param string     $oAuthSecret
+     *
+     * @throws \Exception
+     *
+     * @return mixed
+     */
     public static function oauth(HttpClient $client, $code, $oAuthId, $oAuthSecret)
     {
-        $url    = 'https://' . $client->getSubdomain() . '.zendesk.com/oauth/tokens';
-        $method = 'POST';
+        $url = 'https://' . $client->getSubdomain() . '.zendesk.com/oauth/tokens';
 
         $curl = (isset(self::$curl)) ? self::$curl : new CurlRequest;
         $curl->setopt(CURLOPT_URL, $url);
         $curl->setopt(CURLOPT_POST, true);
-        $curl->setopt(CURLOPT_POSTFIELDS, json_encode(array(
-        'grant_type'    => 'authorization_code',
-        'code'          => $code,
-        'client_id'     => $oAuthId,
-        'client_secret' => $oAuthSecret,
-        'redirect_uri'  => ($_SERVER['HTTPS'] ? 'https://' : 'http://') . $_SERVER['HTTP_HOST'] . $_SERVER['PHP_SELF'],
-        'scope'         => 'read'
-        )));
-        $curl->setopt(CURLOPT_HTTPHEADER, array('Content-Type: application/json'));
+        $curl->setopt(CURLOPT_POSTFIELDS, json_encode([
+            'grant_type'    => 'authorization_code',
+            'code'          => $code,
+            'client_id'     => $oAuthId,
+            'client_secret' => $oAuthSecret,
+            'redirect_uri'  => ($_SERVER['HTTPS'] ? 'https://' : 'http://') . $_SERVER['HTTP_HOST'] . $_SERVER['PHP_SELF'],
+            'scope'         => 'read'
+        ]));
+        $curl->setopt(CURLOPT_HTTPHEADER, ['Content-Type: application/json']);
         $curl->setopt(CURLINFO_HEADER_OUT, true);
         $curl->setopt(CURLOPT_RETURNTRANSFER, true);
         $curl->setopt(CURLOPT_CONNECTTIMEOUT, 30);

--- a/src/Zendesk/API/Http.php
+++ b/src/Zendesk/API/Http.php
@@ -30,7 +30,7 @@ class Http
             $addParams['include'] = implode(',', $sideload);
         }
 
-      // Next look for special collection iterators
+        // Next look for special collection iterators
         if (is_array($iterators)) {
             foreach ($iterators as $k => $v) {
                 if (in_array($k, ['per_page', 'page', 'sort_order', 'sort_by'])) {
@@ -56,7 +56,7 @@ class Http
      *
      * @return array The response body, parsed from JSON into an associative array
      */
-    public static function send_with_options(
+    public static function sendWithOptions(
         HttpClient $client,
         $endPoint,
         $options = []
@@ -71,9 +71,9 @@ class Http
             $options
         );
 
-        $method      = $options["method"];
+        $method = $options["method"];
         $contentType = $options["contentType"];
-        $postFields  = $options["postFields"];
+        $postFields = $options["postFields"];
         $queryParams = $options["queryParams"];
 
         $url = $client->getApiUrl() . $endPoint;
@@ -150,8 +150,8 @@ class Http
         if ($response === false) {
             throw new \Exception(sprintf('Curl error message: "%s" in %s', $curl->error(), __METHOD__));
         }
-        $headerSize     = $curl->getinfo(CURLINFO_HEADER_SIZE);
-        $responseBody   = substr($response, $headerSize);
+        $headerSize = $curl->getinfo(CURLINFO_HEADER_SIZE);
+        $responseBody = substr($response, $headerSize);
         $responseObject = json_decode($responseBody);
         $client->setDebug(
             $curl->getinfo(CURLINFO_HEADER_OUT),


### PR DESCRIPTION
Remove var_dump() when an exception is thrown.
Wrap Guzzle exception to our own exception class.

/cc @miogalang @jwswj @mmolina @atroche 

### Risks
 - Medium - Existing classes for v2 that rely on exception handling may work differently