### PR TITLE
[MI-111] Allow user to upload an attachment

### DIFF
--- a/src/Zendesk/API/Http.php
+++ b/src/Zendesk/API/Http.php
@@ -10,7 +10,6 @@ use Zendesk\API\Exceptions\ApiResponseException;
 use Zendesk\API\Exceptions\AuthException;
 use GuzzleHttp\Psr7\Stream;
 
-
 /**
  * HTTP functions via curl
  * @package Zendesk\API
@@ -22,8 +21,8 @@ class Http
     /**
      * Prepares an endpoint URL with optional side-loading
      *
-     * @param array  $sideload
-     * @param array  $iterators
+     * @param array $sideload
+     * @param array $iterators
      *
      * @return string
      */
@@ -127,9 +126,9 @@ class Http
                 10,
                 null
             );
-        } catch (\GuzzleHttp\Exception\ClientException $e) {
+        } catch (ClientException $e) {
             throw new ResponseException($endPoint, null, null, $e);
-		}
+        }
 
         if (isset($file)) {
             fclose($file);

--- a/src/Zendesk/API/Http.php
+++ b/src/Zendesk/API/Http.php
@@ -66,10 +66,10 @@ class Http
     ) {
         $options = array_merge(
             [
-                'method'      => 'GET',
-                'contentType' => 'application/json',
-                'postFields'  => null,
-                'queryParams' => null
+            'method'      => 'GET',
+            'contentType' => 'application/json',
+            'postFields'  => null,
+            'queryParams' => null
             ],
             $options
         );
@@ -145,12 +145,12 @@ class Http
         $curl->setopt(CURLOPT_URL, $url);
         $curl->setopt(CURLOPT_POST, true);
         $curl->setopt(CURLOPT_POSTFIELDS, json_encode([
-            'grant_type'    => 'authorization_code',
-            'code'          => $code,
-            'client_id'     => $oAuthId,
-            'client_secret' => $oAuthSecret,
-            'redirect_uri'  => $protocol . $_SERVER['HTTP_HOST'] . $_SERVER['PHP_SELF'],
-            'scope'         => 'read'
+          'grant_type'    => 'authorization_code',
+          'code'          => $code,
+          'client_id'     => $oAuthId,
+          'client_secret' => $oAuthSecret,
+          'redirect_uri'  => $protocol . $_SERVER['HTTP_HOST'] . $_SERVER['PHP_SELF'],
+          'scope'         => 'read'
         ]));
         $curl->setopt(CURLOPT_HTTPHEADER, ['Content-Type: application/json']);
         $curl->setopt(CURLINFO_HEADER_OUT, true);

--- a/src/Zendesk/API/Http.php
+++ b/src/Zendesk/API/Http.php
@@ -6,6 +6,8 @@ use GuzzleHttp\Exception\RequestException;
 use GuzzleHttp\Psr7\Request;
 use Zendesk\API\Exceptions\ApiResponseException;
 use Zendesk\API\Exceptions\AuthException;
+use GuzzleHttp\Psr7\Stream;
+
 
 /**
  * HTTP functions via curl

--- a/src/Zendesk/API/Http.php
+++ b/src/Zendesk/API/Http.php
@@ -3,12 +3,10 @@
 namespace Zendesk\API;
 
 use GuzzleHttp\Exception\RequestException;
-use GuzzleHttp\Exception\ClientException;
 use GuzzleHttp\Psr7\LazyOpenStream;
 use GuzzleHttp\Psr7\Request;
 use Zendesk\API\Exceptions\ApiResponseException;
 use Zendesk\API\Exceptions\AuthException;
-use GuzzleHttp\Psr7\Stream;
 
 /**
  * HTTP functions via curl
@@ -69,10 +67,10 @@ class Http
     ) {
         $options = array_merge(
             [
-            'method'      => 'GET',
-            'contentType' => 'application/json',
-            'postFields'  => null,
-            'queryParams' => null
+                'method'      => 'GET',
+                'contentType' => 'application/json',
+                'postFields'  => null,
+                'queryParams' => null
             ],
             $options
         );
@@ -126,8 +124,8 @@ class Http
                 10,
                 null
             );
-        } catch (ClientException $e) {
-            throw new ResponseException($endPoint, null, null, $e);
+        } catch (RequestException $e) {
+            throw new ApiResponseException($e);
         }
 
         if (isset($file)) {
@@ -159,12 +157,12 @@ class Http
         $curl->setopt(CURLOPT_URL, $url);
         $curl->setopt(CURLOPT_POST, true);
         $curl->setopt(CURLOPT_POSTFIELDS, json_encode([
-          'grant_type'    => 'authorization_code',
-          'code'          => $code,
-          'client_id'     => $oAuthId,
-          'client_secret' => $oAuthSecret,
-          'redirect_uri'  => $protocol . $_SERVER['HTTP_HOST'] . $_SERVER['PHP_SELF'],
-          'scope'         => 'read'
+            'grant_type'    => 'authorization_code',
+            'code'          => $code,
+            'client_id'     => $oAuthId,
+            'client_secret' => $oAuthSecret,
+            'redirect_uri'  => $protocol . $_SERVER['HTTP_HOST'] . $_SERVER['PHP_SELF'],
+            'scope'         => 'read'
         ]));
         $curl->setopt(CURLOPT_HTTPHEADER, ['Content-Type: application/json']);
         $curl->setopt(CURLINFO_HEADER_OUT, true);

--- a/src/Zendesk/API/Http.php
+++ b/src/Zendesk/API/Http.php
@@ -121,6 +121,7 @@ class Http
             throw new ApiResponseException($e);
         }
 
+
         return json_decode($response->getBody()->getContents());
     }
 

--- a/src/Zendesk/API/Http.php
+++ b/src/Zendesk/API/Http.php
@@ -18,8 +18,8 @@ class Http
     /**
      * Prepares an endpoint URL with optional side-loading
      *
-     * @param array $sideload
-     * @param array $iterators
+     * @param array  $sideload
+     * @param array  $iterators
      *
      * @return string
      */
@@ -79,6 +79,7 @@ class Http
             'Content-Type' => $options['contentType'],
         ];
 
+
         $request = new Request(
             $options['method'],
             $client->getApiUrl() . $endPoint,
@@ -120,7 +121,6 @@ class Http
         } catch (RequestException $e) {
             throw new ApiResponseException($e);
         }
-
 
         return json_decode($response->getBody()->getContents());
     }

--- a/src/Zendesk/API/HttpClient.php
+++ b/src/Zendesk/API/HttpClient.php
@@ -160,11 +160,12 @@ class HttpClient
     public static function getValidRelations()
     {
         return [
-            'tickets'     => Tickets::class,
-            'users'       => Users::class,
-            'views'       => Views::class,
-            'tags'        => Tags::class,
-            'macros'      => Macros::class,
+            'tickets' => Tickets::class,
+            'users'   => Users::class,
+            'views'   => Views::class,
+            'tags'    => Tags::class,
+            'macros'  => Macros::class,
+            'attachments' => Attachments::class,
             'groups'      => Groups::class,
             'automations' => Automations::class,
             'triggers'    => Triggers::class,

--- a/src/Zendesk/API/HttpClient.php
+++ b/src/Zendesk/API/HttpClient.php
@@ -8,6 +8,7 @@ namespace Zendesk\API;
  */
 
 use Zendesk\API\Exceptions\AuthException;
+use Zendesk\API\Resources\Attachments;
 use Zendesk\API\Resources\Automations;
 use Zendesk\API\Resources\Groups;
 use Zendesk\API\Resources\Macros;
@@ -160,11 +161,11 @@ class HttpClient
     public static function getValidRelations()
     {
         return [
-            'tickets' => Tickets::class,
-            'users'   => Users::class,
-            'views'   => Views::class,
-            'tags'    => Tags::class,
-            'macros'  => Macros::class,
+            'tickets'     => Tickets::class,
+            'users'       => Users::class,
+            'views'       => Views::class,
+            'tags'        => Tags::class,
+            'macros'      => Macros::class,
             'attachments' => Attachments::class,
             'groups'      => Groups::class,
             'automations' => Automations::class,

--- a/src/Zendesk/API/Resources/Attachments.php
+++ b/src/Zendesk/API/Resources/Attachments.php
@@ -34,7 +34,6 @@ class Attachments extends ResourceAbstract
      *
      * @throws CustomException
      * @throws MissingParametersException
-     * @throws ResponseException
      * @throws \Exception
      *
      * @return mixed
@@ -67,12 +66,6 @@ class Attachments extends ResourceAbstract
           ]
         );
 
-//        $endPoint = Http::prepare('uploads.json?filename=' . urlencode($params['name']) . (isset($params['optional_token']) ? '&token=' . $params['optional_token'] : ''));
-//        $response = Http::send($this->client, $endPoint, array('filename' => $params['file']), 'POST',
-//            (isset($params['type']) ? $params['type'] : 'application/binary'));
-//        if ((!is_object($response)) || ($this->client->getDebug()->lastResponseCode != 201)) {
-//            throw new ResponseException(__METHOD__);
-//        }
         $this->client->setSideload(null);
 
         return $response;
@@ -115,62 +108,4 @@ class Attachments extends ResourceAbstract
 //        return $response;
 //    }
 //
-//    /**
-//     * Delete one or more attachments by token or id
-//     * $params must include one of these:
-//     *        'token' - the token given to you after the original upload
-//     *        'id' - the id of the attachment
-//     *
-//     * @param array $params
-//     *
-//     * @throws MissingParametersException
-//     * @throws ResponseException
-//     * @throws \Exception
-//     *
-//     * @return bool
-//     */
-//    public function delete(array $params)
-//    {
-//        if ( ! $this->hasAnyKey($params, array('id', 'token'))) {
-//            throw new MissingParametersException(__METHOD__, array('id', 'token'));
-//        }
-//        $endPoint = Http::prepare(($params['token'] ? 'uploads/' . $params['token'] : 'attachments/' . $params['id']) . '.json');
-//        $response = Http::send($this->client, $endPoint, null, 'DELETE');
-//        if ($this->client->getDebug()->lastResponseCode != 200) {
-//            throw new ResponseException(__METHOD__);
-//        }
-//        $this->client->setSideload(null);
-//
-//        return true;
-//    }
-//
-//    /**
-//     * Get a list of uploaded attachments (by id)
-//     * $params must include:
-//     *        'id' - the id of the attachment
-//     *
-//     * @param array $params
-//     *
-//     * @throws MissingParametersException
-//     * @throws ResponseException
-//     * @throws \Exception
-//     *
-//     * @return mixed
-//     */
-//    public function find(array $params)
-//    {
-//        if ( ! $this->hasKeys($params, array('id'))) {
-//            throw new MissingParametersException(__METHOD__, array('id'));
-//        }
-//        $id       = $params['id'];
-//        $endPoint = Http::prepare('attachments/' . $id . '.json');
-//        $response = Http::send($this->client, $endPoint);
-//        if (( ! is_object($response)) || ($this->client->getDebug()->lastResponseCode != 200)) {
-//            throw new ResponseException(__METHOD__);
-//        }
-//        $this->client->setSideload(null);
-//
-//        return $response;
-//    }
-
 }

--- a/src/Zendesk/API/Resources/Attachments.php
+++ b/src/Zendesk/API/Resources/Attachments.php
@@ -1,0 +1,176 @@
+<?php
+
+namespace Zendesk\API\Resources;
+
+use Zendesk\API\Exceptions\CustomException;
+use Zendesk\API\Exceptions\MissingParametersException;
+use Zendesk\API\Http;
+
+/**
+ * The Attachments class exposes methods for uploading and retrieving attachments
+ * @package Zendesk\API
+ */
+class Attachments extends ResourceAbstract
+{
+
+
+    protected function setUpRoutes()
+    {
+        $this->setRoutes([
+          'upload' => "uploads.json",
+        ]);
+    }
+
+    /**
+     * Upload an attachment
+     * $params must include:
+     *    'file' - an attribute with the absolute local file path on the server
+     *    'type' - the MIME type of the file
+     * Optional:
+     *    'optional_token' - an existing token
+     *        'name' - preferred filename
+     *
+     * @param array $params
+     *
+     * @throws CustomException
+     * @throws MissingParametersException
+     * @throws ResponseException
+     * @throws \Exception
+     *
+     * @return mixed
+     */
+    public function upload(array $params)
+    {
+        if ( ! $this->hasKeys($params, array('file'))) {
+            throw new MissingParametersException(__METHOD__, array('file'));
+        }
+        if ( ! file_exists($params['file'])) {
+            throw new CustomException('File ' . $params['file'] . ' could not be found in ' . __METHOD__);
+        }
+        if ( ! $params['name'] && strrpos($params['file'], '/') > - 1) {
+            $path_array     = explode('/', $params['file']);
+            $file_index     = count($path_array) - 1;
+            $params['name'] = $path_array[$file_index];
+        }
+        if ( ! $params['name'] && strrpos($params['file'], '/') == false) {
+            $params['name'] = $params['file'];
+        }
+
+        $response = Http::send_with_options(
+          $this->client,
+          $this->getRoute(__FUNCTION__),
+          [
+            'method'      => 'POST',
+            'contentType' => 'application/binary',
+            'file'        => $params['file'],
+            'queryParams' => ['filename' => $params ['name']],
+          ]
+        );
+
+//        $endPoint = Http::prepare('uploads.json?filename=' . urlencode($params['name']) . (isset($params['optional_token']) ? '&token=' . $params['optional_token'] : ''));
+//        $response = Http::send($this->client, $endPoint, array('filename' => $params['file']), 'POST',
+//            (isset($params['type']) ? $params['type'] : 'application/binary'));
+//        if ((!is_object($response)) || ($this->client->getDebug()->lastResponseCode != 201)) {
+//            throw new ResponseException(__METHOD__);
+//        }
+        $this->client->setSideload(null);
+
+        return $response;
+    }
+//
+//    /**
+//     * Upload an attachment from a buffer in memory
+//     * $params must include:
+//     *    'body' - the raw file data to upload
+//     *    'name' - the filename
+//     *    'type' - the MIME type of the file
+//     * Optional:
+//     *    'optional_token' - an existing token
+//     *
+//     * @param array $params
+//     *
+//     * @throws CustomException
+//     * @throws MissingParametersException
+//     * @throws ResponseException
+//     * @throws \Exception
+//     *
+//     * @return mixed
+//     */
+//    public function uploadWithBody(array $params)
+//    {
+//        if ( ! $this->hasKeys($params, array('body'))) {
+//            throw new MissingParametersException(__METHOD__, array('body'));
+//        }
+//        if ( ! $params['name']) {
+//            throw new MissingParametersException(__METHOD__, array('name'));
+//        }
+//        $endPoint = Http::prepare('uploads.json?filename=' . $params['name'] . (isset($params['optional_token']) ? '&token=' . $params['optional_token'] : ''));
+//        $response = Http::send($this->client, $endPoint, array('body' => $params['body']), 'POST',
+//          (isset($params['type']) ? $params['type'] : 'application/binary'));
+//        if (( ! is_object($response)) || ($this->client->getDebug()->lastResponseCode != 201)) {
+//            throw new ResponseException(__METHOD__);
+//        }
+//        $this->client->setSideload(null);
+//
+//        return $response;
+//    }
+//
+//    /**
+//     * Delete one or more attachments by token or id
+//     * $params must include one of these:
+//     *        'token' - the token given to you after the original upload
+//     *        'id' - the id of the attachment
+//     *
+//     * @param array $params
+//     *
+//     * @throws MissingParametersException
+//     * @throws ResponseException
+//     * @throws \Exception
+//     *
+//     * @return bool
+//     */
+//    public function delete(array $params)
+//    {
+//        if ( ! $this->hasAnyKey($params, array('id', 'token'))) {
+//            throw new MissingParametersException(__METHOD__, array('id', 'token'));
+//        }
+//        $endPoint = Http::prepare(($params['token'] ? 'uploads/' . $params['token'] : 'attachments/' . $params['id']) . '.json');
+//        $response = Http::send($this->client, $endPoint, null, 'DELETE');
+//        if ($this->client->getDebug()->lastResponseCode != 200) {
+//            throw new ResponseException(__METHOD__);
+//        }
+//        $this->client->setSideload(null);
+//
+//        return true;
+//    }
+//
+//    /**
+//     * Get a list of uploaded attachments (by id)
+//     * $params must include:
+//     *        'id' - the id of the attachment
+//     *
+//     * @param array $params
+//     *
+//     * @throws MissingParametersException
+//     * @throws ResponseException
+//     * @throws \Exception
+//     *
+//     * @return mixed
+//     */
+//    public function find(array $params)
+//    {
+//        if ( ! $this->hasKeys($params, array('id'))) {
+//            throw new MissingParametersException(__METHOD__, array('id'));
+//        }
+//        $id       = $params['id'];
+//        $endPoint = Http::prepare('attachments/' . $id . '.json');
+//        $response = Http::send($this->client, $endPoint);
+//        if (( ! is_object($response)) || ($this->client->getDebug()->lastResponseCode != 200)) {
+//            throw new ResponseException(__METHOD__);
+//        }
+//        $this->client->setSideload(null);
+//
+//        return $response;
+//    }
+
+}

--- a/src/Zendesk/API/Resources/Attachments.php
+++ b/src/Zendesk/API/Resources/Attachments.php
@@ -35,35 +35,39 @@ class Attachments extends ResourceAbstract
      * @throws CustomException
      * @throws MissingParametersException
      * @throws \Exception
-     *
      * @return mixed
      */
     public function upload(array $params)
     {
-        if ( ! $this->hasKeys($params, array('file'))) {
+        if (! $this->hasKeys($params, array('file'))) {
             throw new MissingParametersException(__METHOD__, array('file'));
         }
-        if ( ! file_exists($params['file'])) {
+        if (! file_exists($params['file'])) {
             throw new CustomException('File ' . $params['file'] . ' could not be found in ' . __METHOD__);
         }
-        if ( ! $params['name'] && strrpos($params['file'], '/') > - 1) {
+        if (! $params['name'] && strrpos($params['file'], '/') > - 1) {
             $path_array     = explode('/', $params['file']);
             $file_index     = count($path_array) - 1;
             $params['name'] = $path_array[$file_index];
         }
-        if ( ! $params['name'] && strrpos($params['file'], '/') == false) {
+        if (! $params['name'] && strrpos($params['file'], '/') == false) {
             $params['name'] = $params['file'];
         }
 
-        $response = Http::send_with_options(
-          $this->client,
-          $this->getRoute(__FUNCTION__),
-          [
+        $queryParams = ['filename' => $params ['name']];
+        if (isset($params['token'])) {
+            $queryParams['token'] = $params['token'];
+        }
+
+        $response = Http::sendWithOptions(
+            $this->client,
+            $this->getRoute(__FUNCTION__),
+            [
             'method'      => 'POST',
             'contentType' => 'application/binary',
             'file'        => $params['file'],
-            'queryParams' => ['filename' => $params ['name']],
-          ]
+            'queryParams' => $queryParams,
+            ]
         );
 
         $this->client->setSideload(null);
@@ -97,7 +101,8 @@ class Attachments extends ResourceAbstract
 //        if ( ! $params['name']) {
 //            throw new MissingParametersException(__METHOD__, array('name'));
 //        }
-//        $endPoint = Http::prepare('uploads.json?filename=' . $params['name'] . (isset($params['optional_token']) ? '&token=' . $params['optional_token'] : ''));
+//        $endPoint = Http::prepare('uploads.json?filename='
+//             . $params['name'] . (isset($params['optional_token']) ? '&token=' . $params['optional_token'] : ''));
 //        $response = Http::send($this->client, $endPoint, array('body' => $params['body']), 'POST',
 //          (isset($params['type']) ? $params['type'] : 'application/binary'));
 //        if (( ! is_object($response)) || ($this->client->getDebug()->lastResponseCode != 201)) {

--- a/src/Zendesk/API/Resources/Attachments.php
+++ b/src/Zendesk/API/Resources/Attachments.php
@@ -15,10 +15,10 @@ class Attachments extends ResourceAbstract
     protected function setUpRoutes()
     {
         $this->setRoutes([
-          'upload'       => "uploads.json",
-          'deleteUpload' => "uploads/{token}.json",
-          'delete'       => "{$this->resourceName}/{id}.json",
-          'find'         => "{$this->resourceName}/{id}.json",
+            'upload'       => "uploads.json",
+            'deleteUpload' => "uploads/{token}.json",
+            'delete'       => "{$this->resourceName}/{id}.json",
+            'find'         => "{$this->resourceName}/{id}.json",
         ]);
     }
 
@@ -40,22 +40,17 @@ class Attachments extends ResourceAbstract
      */
     public function upload(array $params)
     {
-        if (! $this->hasKeys($params, array('file'))) {
-            throw new MissingParametersException(__METHOD__, array('file'));
-        }
-        if (! file_exists($params['file'])) {
+        if (! $this->hasKeys($params, ['file'])) {
+            throw new MissingParametersException(__METHOD__, ['file']);
+        } elseif (! file_exists($params['file'])) {
             throw new CustomException('File ' . $params['file'] . ' could not be found in ' . __METHOD__);
         }
-        if (! $params['name'] && strrpos($params['file'], '/') > - 1) {
-            $path_array     = explode('/', $params['file']);
-            $file_index     = count($path_array) - 1;
-            $params['name'] = $path_array[$file_index];
-        }
-        if (! $params['name'] && strrpos($params['file'], '/') == false) {
-            $params['name'] = $params['file'];
+
+        if (! isset($params['name'])) {
+            $params['name'] = basename($params['file']);
         }
 
-        $queryParams = ['filename' => $params ['name']];
+        $queryParams = ['filename' => $params['name']];
         if (isset($params['token'])) {
             $queryParams['token'] = $params['token'];
         }
@@ -64,10 +59,10 @@ class Attachments extends ResourceAbstract
             $this->client,
             $this->getRoute(__FUNCTION__),
             [
-            'method'      => 'POST',
-            'contentType' => 'application/binary',
-            'file'        => $params['file'],
-            'queryParams' => $queryParams,
+                'method'      => 'POST',
+                'contentType' => 'application/binary',
+                'file'        => $params['file'],
+                'queryParams' => $queryParams,
             ]
         );
 
@@ -90,7 +85,7 @@ class Attachments extends ResourceAbstract
     {
         $response = Http::sendWithOptions(
             $this->client,
-            $this->getRoute(__FUNCTION__, array('token' => $token)),
+            $this->getRoute(__FUNCTION__, ['token' => $token]),
             ['method' => 'DELETE']
         );
 

--- a/src/Zendesk/API/Resources/Attachments.php
+++ b/src/Zendesk/API/Resources/Attachments.php
@@ -12,12 +12,13 @@ use Zendesk\API\Http;
  */
 class Attachments extends ResourceAbstract
 {
-
-
     protected function setUpRoutes()
     {
         $this->setRoutes([
-          'upload' => "uploads.json",
+          'upload'       => "uploads.json",
+          'deleteUpload' => "uploads/{token}.json",
+          'delete'       => "{$this->resourceName}/{id}.json",
+          'find'         => "{$this->resourceName}/{id}.json",
         ]);
     }
 
@@ -74,43 +75,27 @@ class Attachments extends ResourceAbstract
 
         return $response;
     }
-//
-//    /**
-//     * Upload an attachment from a buffer in memory
-//     * $params must include:
-//     *    'body' - the raw file data to upload
-//     *    'name' - the filename
-//     *    'type' - the MIME type of the file
-//     * Optional:
-//     *    'optional_token' - an existing token
-//     *
-//     * @param array $params
-//     *
-//     * @throws CustomException
-//     * @throws MissingParametersException
-//     * @throws ResponseException
-//     * @throws \Exception
-//     *
-//     * @return mixed
-//     */
-//    public function uploadWithBody(array $params)
-//    {
-//        if ( ! $this->hasKeys($params, array('body'))) {
-//            throw new MissingParametersException(__METHOD__, array('body'));
-//        }
-//        if ( ! $params['name']) {
-//            throw new MissingParametersException(__METHOD__, array('name'));
-//        }
-//        $endPoint = Http::prepare('uploads.json?filename='
-//             . $params['name'] . (isset($params['optional_token']) ? '&token=' . $params['optional_token'] : ''));
-//        $response = Http::send($this->client, $endPoint, array('body' => $params['body']), 'POST',
-//          (isset($params['type']) ? $params['type'] : 'application/binary'));
-//        if (( ! is_object($response)) || ($this->client->getDebug()->lastResponseCode != 201)) {
-//            throw new ResponseException(__METHOD__);
-//        }
-//        $this->client->setSideload(null);
-//
-//        return $response;
-//    }
-//
+
+    /**
+     * Delete a resource
+     *
+     * @param $token
+     *
+     * @return bool
+     * @throws MissingParametersException
+     * @throws \Exception
+     * @throws \Zendesk\API\Exceptions\ResponseException
+     */
+    public function deleteUpload($token)
+    {
+        $response = Http::sendWithOptions(
+            $this->client,
+            $this->getRoute(__FUNCTION__, array('token' => $token)),
+            ['method' => 'DELETE']
+        );
+
+        $this->client->setSideload(null);
+
+        return $response;
+    }
 }

--- a/src/Zendesk/API/Resources/ResourceAbstract.php
+++ b/src/Zendesk/API/Resources/ResourceAbstract.php
@@ -325,8 +325,8 @@ abstract class ResourceAbstract
             $this->client,
             $this->getRoute('create'),
             [
-            'postFields' => [$class::OBJ_NAME => $params],
-            'method'     => 'POST'
+                'postFields' => [$class::OBJ_NAME => $params],
+                'method'     => 'POST'
             ]
         );
 

--- a/src/Zendesk/API/Resources/ResourceAbstract.php
+++ b/src/Zendesk/API/Resources/ResourceAbstract.php
@@ -95,10 +95,6 @@ abstract class ResourceAbstract
 
     protected function setUpRoutes()
     {
-        if (! isset($this->resourceName)) {
-            $this->resourceName = $this->getResourceNameFromClass();
-        }
-
         $this->setRoutes([
             'findAll' => "{$this->resourceName}.json",
             'find'    => "{$this->resourceName}/{id}.json",
@@ -329,8 +325,8 @@ abstract class ResourceAbstract
             $this->client,
             $this->getRoute('create'),
             [
-                'postFields' => [$class::OBJ_NAME => $params],
-                'method'     => 'POST'
+            'postFields' => [$class::OBJ_NAME => $params],
+            'method'     => 'POST'
             ]
         );
 

--- a/src/Zendesk/API/Resources/Tickets.php
+++ b/src/Zendesk/API/Resources/Tickets.php
@@ -9,9 +9,7 @@ use Zendesk\API\UtilityTraits\InstantiatorTrait;
 
 /**
  * The Tickets class exposes key methods for reading and updating ticket data
- *
  * @package Zendesk\API
- *
  * @method TicketComments comments()
  */
 class Tickets extends ResourceAbstract
@@ -57,11 +55,12 @@ class Tickets extends ResourceAbstract
     public static function getValidRelations()
     {
         return [
-            'comments' => TicketComments::class,
-            'forms'    => TicketForms::class,
-            'tags'     => Tags::class,
-            'audits'   => TicketAudits::class,
-            'metrics'  => TicketMetrics::class,
+          'comments'    => TicketComments::class,
+          'forms'       => TicketForms::class,
+          'tags'        => Tags::class,
+          'audits'      => TicketAudits::class,
+          'attachments' => Attachments::class,
+          'metrics'  => TicketMetrics::class,
         ];
     }
 
@@ -81,7 +80,7 @@ class Tickets extends ResourceAbstract
             $this->client->getSideload($params),
             $params
         );
-        $response = Http::sendWithOptions(
+        $response    = Http::sendWithOptions(
             $this->client,
             $this->getRoute($route, $params),
             ['queryParams' => $queryParams]
@@ -100,17 +99,17 @@ class Tickets extends ResourceAbstract
         parent::setUpRoutes();
 
         $this->setRoutes([
-            'findMany'            => 'tickets/show_many.json',
-            'updateMany'          => 'tickets/update_many.json',
-            'markAsSpam'          => 'tickets/{id}/mark_as_spam.json',
-            'markManyAsSpam'      => 'tickets/mark_many_as_spam.json',
-            'related'             => 'tickets/{id}/related.json',
-            'deleteMany'          => 'tickets/destroy_many.json',
-            'collaborators'       => 'tickets/{id}/collaborators.json',
-            'incidents'           => 'tickets/{id}/incidents.json',
-            'problems'            => 'problems.json',
-            'export'              => 'exports/tickets.json',
-            'problemAutoComplete' => 'problems/autocomplete.json'
+          'findMany'            => 'tickets/show_many.json',
+          'updateMany'          => 'tickets/update_many.json',
+          'markAsSpam'          => 'tickets/{id}/mark_as_spam.json',
+          'markManyAsSpam'      => 'tickets/mark_many_as_spam.json',
+          'related'             => 'tickets/{id}/related.json',
+          'deleteMany'          => 'tickets/destroy_many.json',
+          'collaborators'       => 'tickets/{id}/collaborators.json',
+          'incidents'           => 'tickets/{id}/incidents.json',
+          'problems'            => 'problems.json',
+          'export'              => 'exports/tickets.json',
+          'problemAutoComplete' => 'problems/autocomplete.json'
         ]);
     }
 
@@ -122,13 +121,12 @@ class Tickets extends ResourceAbstract
      * @throws MissingParametersException
      * @throws ResponseException
      * @throws \Exception
-     *
      * @return mixed
      */
     public function findMany(array $params = [])
     {
 
-        $queryParams = Http::prepareQueryParams($this->client->getSideload($params), $params);
+        $queryParams        = Http::prepareQueryParams($this->client->getSideload($params), $params);
         $queryParams['ids'] = implode(",", $params['ids']);
 
         $response = Http::sendWithOptions(
@@ -150,18 +148,17 @@ class Tickets extends ResourceAbstract
      * @throws MissingParametersException
      * @throws ResponseException
      * @throws \Exception
-     *
      * @return mixed
      */
     public function findTwicket(array $params = [])
     {
         $params = $this->addChainedParametersToParams($params, ['id' => get_class($this)]);
 
-        if (!$this->hasKeys($params, ['id'])) {
+        if (! $this->hasKeys($params, ['id'])) {
             throw new MissingParametersException(__METHOD__, ['id']);
         }
         $endPointBase = 'channels/twitter/tickets/' . $params['id'] . '/statuses.json';
-        $endPoint = Http::prepare(
+        $endPoint     = Http::prepare(
             $endPointBase . (is_array($params['comment_ids']) ? '?' . implode(',', $params['comment_ids']) : ''),
             $this->client->getSideload($params)
         );
@@ -179,14 +176,13 @@ class Tickets extends ResourceAbstract
      *
      * @throws ResponseException
      * @throws \Exception
-     *
      * @return mixed
      */
     public function create(array $params)
     {
         if (count($this->lastAttachments)) {
             $params['comment']['uploads'] = $this->lastAttachments;
-            $this->lastAttachments = [];
+            $this->lastAttachments        = [];
         }
 
         return parent::create($params);
@@ -200,21 +196,20 @@ class Tickets extends ResourceAbstract
      * @throws MissingParametersException
      * @throws ResponseException
      * @throws \Exception
-     *
      * @return mixed
      */
     public function createFromTweet(array $params)
     {
-        if ((!$params['twitter_status_message_id']) || (!$params['monitored_twitter_handle_id'])) {
+        if (( ! $params['twitter_status_message_id']) || ( ! $params['monitored_twitter_handle_id'])) {
             throw new MissingParametersException(
                 __METHOD__,
                 ['twitter_status_message_id', 'monitored_twitter_handle_id']
             );
         }
-        $endPoint = Http::prepare('channels/twitter/tickets.json');
-        $response = Http::sendWithOptions($this->client, $endPoint, [self::OBJ_NAME => $params], 'POST');
+        $endPoint         = Http::prepare('channels/twitter/tickets.json');
+        $response         = Http::sendWithOptions($this->client, $endPoint, [self::OBJ_NAME => $params], 'POST');
         $lastResponseCode = $this->client->getDebug()->lastResponseCode;
-        if ((!is_object($response)) || ($lastResponseCode != 201)) {
+        if (( ! is_object($response)) || ($lastResponseCode != 201)) {
             throw new ResponseException(
                 __METHOD__,
                 ($lastResponseCode == 422 ? ' (hint: you can\'t create two tickets from the same tweet)' : '')
@@ -233,14 +228,13 @@ class Tickets extends ResourceAbstract
      * @throws MissingParametersException
      * @throws ResponseException
      * @throws \Exception
-     *
      * @return mixed
      */
     public function update($id = null, array $updateResourceFields = [])
     {
         if (count($this->lastAttachments)) {
             $updateResourceFields['comment']['uploads'] = $this->lastAttachments;
-            $this->lastAttachments = [];
+            $this->lastAttachments                      = [];
         }
 
         return parent::update($id, $updateResourceFields);
@@ -254,18 +248,17 @@ class Tickets extends ResourceAbstract
      * @throws MissingParametersException
      * @throws ResponseException
      * @throws \Exception
-     *
      * @return mixed
      */
     public function updateMany(array $params)
     {
         if (count($this->lastAttachments)) {
             $params['comment']['uploads'] = $this->lastAttachments;
-            $this->lastAttachments = [];
+            $this->lastAttachments        = [];
         }
 
         $resourceUpdateName = self::OBJ_NAME_PLURAL;
-        $queryParams = [];
+        $queryParams        = [];
         if (isset($params['ids']) && is_array($params['ids'])) {
             $queryParams['ids'] = implode(",", $params['ids']);
             unset($params['ids']);
@@ -277,9 +270,9 @@ class Tickets extends ResourceAbstract
             $this->client,
             $this->getRoute('updateMany'),
             [
-                'method'      => 'PUT',
-                'queryParams' => $queryParams,
-                'postFields'  => [$resourceUpdateName => $params]
+            'method'      => 'PUT',
+            'queryParams' => $queryParams,
+            'postFields'  => [$resourceUpdateName => $params]
             ]
         );
 
@@ -293,7 +286,6 @@ class Tickets extends ResourceAbstract
      *
      * @throws ResponseException
      * @throws \Exception
-     *
      * @return mixed
      */
     public function markAsSpam($id = null)
@@ -302,13 +294,13 @@ class Tickets extends ResourceAbstract
 
         if (is_array($id)) {
             $options['queryParams']['ids'] = implode(',', $id);
-            $route = $this->getRoute('markManyAsSpam');
+            $route                         = $this->getRoute('markManyAsSpam');
         } else {
             $params = $this->addChainedParametersToParams(
                 ['id' => $id],
                 ['id' => get_class($this)]
             );
-            $route = $this->getRoute('markAsSpam', $params);
+            $route  = $this->getRoute('markAsSpam', $params);
         }
 
         $response = Http::sendWithOptions(
@@ -330,14 +322,13 @@ class Tickets extends ResourceAbstract
      * @throws MissingParametersException
      * @throws ResponseException
      * @throws \Exception
-     *
      * @return mixed
      */
     public function related(array $params = [])
     {
         $params = $this->addChainedParametersToParams($params, ['id' => get_class($this)]);
 
-        if (!$this->hasKeys($params, ['id'])) {
+        if (! $this->hasKeys($params, ['id'])) {
             throw new MissingParametersException(__METHOD__, ['id']);
         }
 
@@ -350,7 +341,6 @@ class Tickets extends ResourceAbstract
      * @param array $ids
      *
      * @return mixed
-     *
      */
     public function deleteMany(array $ids)
     {
@@ -358,8 +348,8 @@ class Tickets extends ResourceAbstract
             $this->client,
             $this->getRoute('deleteMany'),
             [
-                'method'      => 'DELETE',
-                'queryParams' => ['ids' => implode(',', $ids)]
+            'method'      => 'DELETE',
+            'queryParams' => ['ids' => implode(',', $ids)]
             ]
         );
 
@@ -374,14 +364,13 @@ class Tickets extends ResourceAbstract
      * @throws MissingParametersException
      * @throws ResponseException
      * @throws \Exception
-     *
      * @return mixed
      */
     public function collaborators(array $params)
     {
         $params = $this->addChainedParametersToParams($params, ['id' => get_class($this)]);
 
-        if (!$this->hasKeys($params, ['id'])) {
+        if (! $this->hasKeys($params, ['id'])) {
             throw new MissingParametersException(__METHOD__, ['id']);
         }
 
@@ -396,14 +385,13 @@ class Tickets extends ResourceAbstract
      * @throws MissingParametersException
      * @throws ResponseException
      * @throws \Exception
-     *
      * @return mixed
      */
     public function incidents(array $params)
     {
         $params = $this->addChainedParametersToParams($params, ['id' => get_class($this)]);
 
-        if (!$this->hasKeys($params, ['id'])) {
+        if (! $this->hasKeys($params, ['id'])) {
             throw new MissingParametersException(__METHOD__, ['id']);
         }
 
@@ -419,7 +407,6 @@ class Tickets extends ResourceAbstract
      * @throws MissingParametersException
      * @throws ResponseException
      * @throws \Exception
-     *
      * @return mixed
      */
     public function problems(array $params = [])
@@ -435,12 +422,11 @@ class Tickets extends ResourceAbstract
      * @throws MissingParametersException
      * @throws ResponseException
      * @throws \Exception
-     *
      * @return mixed
      */
     public function problemAutoComplete(array $params)
     {
-        if (!$params['text']) {
+        if (! $params['text']) {
             throw new MissingParametersException(__METHOD__, ['text']);
         }
 
@@ -448,8 +434,8 @@ class Tickets extends ResourceAbstract
             $this->client,
             $this->getRoute('problemAutoComplete'),
             [
-                'method'     => 'POST',
-                'postFields' => ['text' => $params['text']]
+            'method'     => 'POST',
+            'postFields' => ['text' => $params['text']]
             ]
         );
 
@@ -466,12 +452,11 @@ class Tickets extends ResourceAbstract
      * @throws MissingParametersException
      * @throws ResponseException
      * @throws \Exception
-     *
      * @return mixed
      */
     public function export(array $params)
     {
-        if (!$params['start_time']) {
+        if (! $params['start_time']) {
             throw new MissingParametersException(__METHOD__, ['start_time']);
         }
 
@@ -491,21 +476,19 @@ class Tickets extends ResourceAbstract
     /**
      * @param array $params
      *
-     * @throws CustomException
      * @throws MissingParametersException
      * @throws ResponseException
-     *
      * @return Tickets
      */
     public function attach(array $params = [])
     {
-        if (!$this->hasKeys($params, ['file'])) {
+        if (! $this->hasKeys($params, ['file'])) {
             throw new MissingParametersException(__METHOD__, ['file']);
         }
 
         $upload = $this->client->attachments()->upload($params);
 
-        if ((!is_object($upload->upload)) || (!$upload->upload->token)) {
+        if (( ! is_object($upload->upload)) || ( ! $upload->upload->token)) {
             throw new ResponseException(__METHOD__);
         }
         $this->lastAttachments[] = $upload->upload->token;

--- a/src/Zendesk/API/Resources/Users.php
+++ b/src/Zendesk/API/Resources/Users.php
@@ -2,8 +2,6 @@
 
 namespace Zendesk\API\Resources;
 
-use GuzzleHttp\Psr7\LazyOpenStream;
-use GuzzleHttp\Psr7\MultipartStream;
 use Zendesk\API\Exceptions\CustomException;
 use Zendesk\API\Exceptions\MissingParametersException;
 use Zendesk\API\Exceptions\ResponseException;

--- a/src/Zendesk/API/Resources/Users.php
+++ b/src/Zendesk/API/Resources/Users.php
@@ -2,6 +2,8 @@
 
 namespace Zendesk\API\Resources;
 
+use GuzzleHttp\Psr7\LazyOpenStream;
+use GuzzleHttp\Psr7\MultipartStream;
 use Zendesk\API\Exceptions\CustomException;
 use Zendesk\API\Exceptions\MissingParametersException;
 use Zendesk\API\Exceptions\ResponseException;
@@ -33,14 +35,15 @@ class Users extends ResourceAbstract
         parent::setUpRoutes();
 
         $this->setRoutes([
-            'related'        => 'users/{id}/related.json',
-            'merge'          => 'users/me/merge.json',
-            'search'         => 'users/search.json',
-            'autocomplete'   => 'users/autocomplete.json',
-            'setPassword'    => 'users/{id}/password.json',
-            'changePassword' => 'users/{id}/password.json',
-            'updateMany'     => 'users/update_many.json',
-            'createMany'     => 'users/create_many.json',
+          'related'            => 'users/{id}/related.json',
+          'merge'              => 'users/me/merge.json',
+          'search'             => 'users/search.json',
+          'autocomplete'       => 'users/autocomplete.json',
+          'setPassword'        => 'users/{id}/password.json',
+          'changePassword'     => 'users/{id}/password.json',
+          'updateMany'         => 'users/update_many.json',
+          'createMany'         => 'users/create_many.json',
+          'updateProfileImage' => 'users/{id}.json',
         ]);
     }
 
@@ -133,9 +136,9 @@ class Users extends ResourceAbstract
         $queryParams = array_merge($queryParams, $extraParams);
 
         $response = Http::sendWithOptions(
-            $this->client,
-            $this->endpoint,
-            ['queryParams' => $queryParams]
+          $this->client,
+          $this->endpoint,
+          ['queryParams' => $queryParams]
         );
 
         $this->client->setSideload(null);
@@ -163,9 +166,9 @@ class Users extends ResourceAbstract
 
         $queryParams = Http::prepareQueryParams($this->client->getSideload($params), $params);
         $response    = Http::sendWithOptions(
-            $this->client,
-            $this->getRoute(__FUNCTION__, ['id' => $params['id']]),
-            ['queryParams' => $queryParams]
+          $this->client,
+          $this->getRoute(__FUNCTION__, ['id' => $params['id']]),
+          ['queryParams' => $queryParams]
         );
 
         $this->client->setSideload(null);
@@ -187,15 +190,15 @@ class Users extends ResourceAbstract
     {
         $myId    = $this->getChainedParameter(get_class($this));
         $mergeMe = ! isset($myId) || is_null($myId);
-        $hasKeys = $mergeMe ? ['email', 'password'] : ['id'];
-        if (! $this->hasKeys($params, $hasKeys)) {
+        $hasKeys = $mergeMe ? array('email', 'password') : array('id');
+        if ( ! $this->hasKeys($params, $hasKeys)) {
             throw new MissingParametersException(__METHOD__, $hasKeys);
         }
 
         $response = Http::sendWithOptions(
-            $this->client,
-            $this->getRoute(__FUNCTION__),
-            ['postFields' => [self::OBJ_NAME => $params], 'method' => 'PUT']
+          $this->client,
+          $this->getRoute(__FUNCTION__),
+          ['postFields' => [self::OBJ_NAME => $params], 'method' => 'PUT']
         );
         $this->client->setSideload(null);
 
@@ -214,9 +217,9 @@ class Users extends ResourceAbstract
     public function createMany(array $params)
     {
         $response = Http::sendWithOptions(
-            $this->client,
-            $this->getRoute(__FUNCTION__),
-            ['postFields' => [self::OBJ_NAME_PLURAL => $params], 'method' => 'POST']
+          $this->client,
+          $this->getRoute(__FUNCTION__),
+          ['postFields' => [self::OBJ_NAME_PLURAL => $params], 'method' => 'POST']
         );
 
         $this->client->setSideload(null);
@@ -243,9 +246,9 @@ class Users extends ResourceAbstract
         $ids = $params['ids'];
         unset($params['ids']);
         $response = Http::sendWithOptions(
-            $this->client,
-            $this->getRoute(__FUNCTION__),
-            ['postFields' => [self::OBJ_NAME => $params], 'queryParams' => ['ids' => $ids], 'method' => 'PUT']
+          $this->client,
+          $this->getRoute(__FUNCTION__),
+          ['postFields' => [self::OBJ_NAME => $params], 'queryParams' => ['ids' => $ids], 'method' => 'PUT']
         );
 
         $this->client->setSideload(null);
@@ -268,9 +271,9 @@ class Users extends ResourceAbstract
     {
         $this->setRoute(__METHOD__, 'users/update_many.json');
         $response = Http::sendWithOptions(
-            $this->client,
-            $this->getRoute(__METHOD__),
-            ['postFields' => [self::OBJ_NAME_PLURAL => $params], 'method' => 'PUT']
+          $this->client,
+          $this->getRoute(__METHOD__),
+          ['postFields' => [self::OBJ_NAME_PLURAL => $params], 'method' => 'PUT']
         );
         $this->client->setSideload(null);
 

--- a/src/Zendesk/API/Resources/Users.php
+++ b/src/Zendesk/API/Resources/Users.php
@@ -27,6 +27,16 @@ class Users extends ResourceAbstract
      */
     protected $identities;
 
+   /**
+     * {@inheritdoc}
+     */
+    public static function getValidRelations()
+    {
+        return [
+            'groups' => Groups::class,
+        ];
+    }
+
     /**
      * {@inheritdoc}
      */
@@ -136,9 +146,9 @@ class Users extends ResourceAbstract
         $queryParams = array_merge($queryParams, $extraParams);
 
         $response = Http::sendWithOptions(
-          $this->client,
-          $this->endpoint,
-          ['queryParams' => $queryParams]
+            $this->client,
+            $this->endpoint,
+            ['queryParams' => $queryParams]
         );
 
         $this->client->setSideload(null);
@@ -166,9 +176,9 @@ class Users extends ResourceAbstract
 
         $queryParams = Http::prepareQueryParams($this->client->getSideload($params), $params);
         $response    = Http::sendWithOptions(
-          $this->client,
-          $this->getRoute(__FUNCTION__, ['id' => $params['id']]),
-          ['queryParams' => $queryParams]
+            $this->client,
+            $this->getRoute(__FUNCTION__, ['id' => $params['id']]),
+            ['queryParams' => $queryParams]
         );
 
         $this->client->setSideload(null);
@@ -191,14 +201,14 @@ class Users extends ResourceAbstract
         $myId    = $this->getChainedParameter(get_class($this));
         $mergeMe = ! isset($myId) || is_null($myId);
         $hasKeys = $mergeMe ? array('email', 'password') : array('id');
-        if ( ! $this->hasKeys($params, $hasKeys)) {
+        if (! $this->hasKeys($params, $hasKeys)) {
             throw new MissingParametersException(__METHOD__, $hasKeys);
         }
 
         $response = Http::sendWithOptions(
-          $this->client,
-          $this->getRoute(__FUNCTION__),
-          ['postFields' => [self::OBJ_NAME => $params], 'method' => 'PUT']
+            $this->client,
+            $this->getRoute(__FUNCTION__),
+            ['postFields' => [self::OBJ_NAME => $params], 'method' => 'PUT']
         );
         $this->client->setSideload(null);
 
@@ -217,9 +227,9 @@ class Users extends ResourceAbstract
     public function createMany(array $params)
     {
         $response = Http::sendWithOptions(
-          $this->client,
-          $this->getRoute(__FUNCTION__),
-          ['postFields' => [self::OBJ_NAME_PLURAL => $params], 'method' => 'POST']
+            $this->client,
+            $this->getRoute(__FUNCTION__),
+            ['postFields' => [self::OBJ_NAME_PLURAL => $params], 'method' => 'POST']
         );
 
         $this->client->setSideload(null);
@@ -241,14 +251,14 @@ class Users extends ResourceAbstract
     public function updateMany(array $params)
     {
         if (! $this->hasKeys($params, ['ids'])) {
-            throw new MissingParametersException(__METHOD__, ['ids']);
+            throw new MissingParametersException(__METHOD__, array('ids'));
         }
         $ids = $params['ids'];
         unset($params['ids']);
         $response = Http::sendWithOptions(
-          $this->client,
-          $this->getRoute(__FUNCTION__),
-          ['postFields' => [self::OBJ_NAME => $params], 'queryParams' => ['ids' => $ids], 'method' => 'PUT']
+            $this->client,
+            $this->getRoute(__FUNCTION__),
+            ['postFields' => [self::OBJ_NAME => $params], 'queryParams' => ['ids' => $ids], 'method' => 'PUT']
         );
 
         $this->client->setSideload(null);
@@ -271,9 +281,9 @@ class Users extends ResourceAbstract
     {
         $this->setRoute(__METHOD__, 'users/update_many.json');
         $response = Http::sendWithOptions(
-          $this->client,
-          $this->getRoute(__METHOD__),
-          ['postFields' => [self::OBJ_NAME_PLURAL => $params], 'method' => 'PUT']
+            $this->client,
+            $this->getRoute(__METHOD__),
+            ['postFields' => [self::OBJ_NAME_PLURAL => $params], 'method' => 'PUT']
         );
         $this->client->setSideload(null);
 

--- a/src/Zendesk/API/Resources/Users.php
+++ b/src/Zendesk/API/Resources/Users.php
@@ -25,16 +25,6 @@ class Users extends ResourceAbstract
      */
     protected $identities;
 
-   /**
-     * {@inheritdoc}
-     */
-    public static function getValidRelations()
-    {
-        return [
-            'groups' => Groups::class,
-        ];
-    }
-
     /**
      * {@inheritdoc}
      */
@@ -43,15 +33,15 @@ class Users extends ResourceAbstract
         parent::setUpRoutes();
 
         $this->setRoutes([
-          'related'            => 'users/{id}/related.json',
-          'merge'              => 'users/me/merge.json',
-          'search'             => 'users/search.json',
-          'autocomplete'       => 'users/autocomplete.json',
-          'setPassword'        => 'users/{id}/password.json',
-          'changePassword'     => 'users/{id}/password.json',
-          'updateMany'         => 'users/update_many.json',
-          'createMany'         => 'users/create_many.json',
-          'updateProfileImage' => 'users/{id}.json',
+            'related'            => 'users/{id}/related.json',
+            'merge'              => 'users/me/merge.json',
+            'search'             => 'users/search.json',
+            'autocomplete'       => 'users/autocomplete.json',
+            'setPassword'        => 'users/{id}/password.json',
+            'changePassword'     => 'users/{id}/password.json',
+            'updateMany'         => 'users/update_many.json',
+            'createMany'         => 'users/create_many.json',
+            'updateProfileImage' => 'users/{id}.json',
         ]);
     }
 
@@ -198,7 +188,7 @@ class Users extends ResourceAbstract
     {
         $myId    = $this->getChainedParameter(get_class($this));
         $mergeMe = ! isset($myId) || is_null($myId);
-        $hasKeys = $mergeMe ? array('email', 'password') : array('id');
+        $hasKeys = $mergeMe ? ['email', 'password'] : ['id'];
         if (! $this->hasKeys($params, $hasKeys)) {
             throw new MissingParametersException(__METHOD__, $hasKeys);
         }
@@ -249,7 +239,7 @@ class Users extends ResourceAbstract
     public function updateMany(array $params)
     {
         if (! $this->hasKeys($params, ['ids'])) {
-            throw new MissingParametersException(__METHOD__, array('ids'));
+            throw new MissingParametersException(__METHOD__, ['ids']);
         }
         $ids = $params['ids'];
         unset($params['ids']);

--- a/tests/Zendesk/API/UnitTests/AttachmentsTest.php
+++ b/tests/Zendesk/API/UnitTests/AttachmentsTest.php
@@ -16,24 +16,51 @@ class AttachmentsTest extends BasicTest
     public function testUploadAttachment()
     {
         $this->mockAPIResponses([
-          new Response(201, [], '')
+            new Response(201, [], '')
         ]);
 
         $attachmentData = [
-          'file' => getcwd() . '/tests/assets/UK.png',
-          'type' => 'image/png',
-          'name' => 'UK test non-alpha chars.png'
+            'file' => getcwd() . '/tests/assets/UK.png',
+            'type' => 'image/png',
+            'name' => 'UK test non-alpha chars.png'
         ];
 
         $this->client->attachments()->upload($attachmentData);
 
         $this->assertLastRequestIs(
             [
-            'method'      => 'POST',
-            'endpoint'    => 'uploads.json',
-            'statusCode'  => 201,
-            'queryParams' => ['filename' => rawurlencode($attachmentData['name'])],
-            'file'        => $attachmentData['file'],
+                'method'      => 'POST',
+                'endpoint'    => 'uploads.json',
+                'statusCode'  => 201,
+                'queryParams' => ['filename' => rawurlencode($attachmentData['name'])],
+                'file'        => $attachmentData['file'],
+            ]
+        );
+    }
+
+    /**
+     * Test upload of file
+     */
+    public function testUploadAttachmentWithNoName()
+    {
+        $this->mockAPIResponses([
+            new Response(201, [], '')
+        ]);
+
+        $attachmentData = [
+            'file' => getcwd() . '/tests/assets/UK.png',
+            'type' => 'image/png',
+        ];
+
+        $this->client->attachments()->upload($attachmentData);
+
+        $this->assertLastRequestIs(
+            [
+                'method'      => 'POST',
+                'endpoint'    => 'uploads.json',
+                'statusCode'  => 201,
+                'queryParams' => ['filename' => 'UK.png'], // Taken from file path
+                'file'        => $attachmentData['file'],
             ]
         );
     }
@@ -44,7 +71,7 @@ class AttachmentsTest extends BasicTest
     public function testDeleteAttachment()
     {
         $this->mockAPIResponses([
-          new Response(200, [], '')
+            new Response(200, [], '')
         ]);
 
         $token = 'validToken';
@@ -53,8 +80,8 @@ class AttachmentsTest extends BasicTest
 
         $this->assertLastRequestIs(
             [
-            'method'   => 'DELETE',
-            'endpoint' => "uploads/{$token}.json",
+                'method'   => 'DELETE',
+                'endpoint' => "uploads/{$token}.json",
             ]
         );
     }

--- a/tests/Zendesk/API/UnitTests/AttachmentsTest.php
+++ b/tests/Zendesk/API/UnitTests/AttachmentsTest.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace Zendesk\API\UnitTests;
+
+use GuzzleHttp\Psr7\Response;
+
+/**
+ * Attachments test class
+ */
+class AttachmentsTest extends BasicTest
+{
+
+    /**
+     * Test upload of file
+     */
+    public function testUploadAttachment()
+    {
+        $this->mockAPIResponses([
+          new Response(201, [], '')
+        ]);
+
+        $attachmentData = [
+          'file' => getcwd() . '/tests/assets/UK.png',
+          'type' => 'image/png',
+          'name' => 'UK test non-alpha chars.png'
+        ];
+
+        $this->client->attachments()->upload($attachmentData);
+
+        $this->assertLastRequestIs(
+            [
+            'method'      => 'POST',
+            'endpoint'    => 'uploads.json',
+            'statusCode'  => 201,
+            'queryParams' => ['filename' => rawurlencode($attachmentData['name'])],
+            'file'        => $attachmentData['file'],
+            ]
+        );
+    }
+
+    /**
+     * Test delete uploaded file
+     */
+    public function testDeleteAttachment()
+    {
+        $this->mockAPIResponses([
+          new Response(200, [], '')
+        ]);
+
+        $token = 'validToken';
+
+        $this->client->attachments()->deleteUpload($token);
+
+        $this->assertLastRequestIs(
+            [
+            'method'   => 'DELETE',
+            'endpoint' => "uploads/{$token}.json",
+            ]
+        );
+    }
+
+    /**
+     * Test routes for find and delete are present
+     */
+    public function testRoutes()
+    {
+        $attachment = $this->client->attachments();
+
+        // Test route for find
+        $id = 1;
+        $this->assertEquals("attachments/{$id}.json", $attachment->getRoute('find', ['id' => $id]));
+
+        // Test route for delete
+        $this->assertEquals("attachments/{$id}.json", $attachment->getRoute('delete', ['id' => $id]));
+    }
+}

--- a/tests/Zendesk/API/UnitTests/BasicTest.php
+++ b/tests/Zendesk/API/UnitTests/BasicTest.php
@@ -6,6 +6,7 @@ use GuzzleHttp\Client;
 use GuzzleHttp\Handler\MockHandler;
 use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Middleware;
+use GuzzleHttp\Psr7\LazyOpenStream;
 use Zendesk\API\HttpClient;
 
 /**
@@ -154,6 +155,13 @@ abstract class BasicTest extends \PHPUnit_Framework_TestCase
 
         if (isset($options['postFields'])) {
             $this->assertEquals(json_encode($options['postFields']), $request->getBody()->getContents());
+        }
+
+        if (isset($options['file'])) {
+            $body = $request->getBody();
+            $this->assertInstanceOf(LazyOpenStream::class, $body);
+            $this->assertGreaterThan(0, $body->getSize());
+            $this->assertEquals($options['file'], $body->getMetadata('uri'));
         }
     }
 }

--- a/tests/Zendesk/API/UnitTests/TicketsTest.php
+++ b/tests/Zendesk/API/UnitTests/TicketsTest.php
@@ -15,23 +15,23 @@ class TicketsTest extends BasicTest
     public function setUp()
     {
         $this->testTicket = array(
-          'subject'  => 'The quick brown fox jumps over the lazy dog',
-          'comment'  => array(
-            'body' => 'Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod'
-                      . ' tempor incididunt ut labore et dolore magna aliqua.'
-          ),
-          'priority' => 'normal',
-          'id'       => '12345'
+            'subject'  => 'The quick brown fox jumps over the lazy dog',
+            'comment'  => array(
+                'body' => 'Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod'
+                          . ' tempor incididunt ut labore et dolore magna aliqua.'
+            ),
+            'priority' => 'normal',
+            'id'       => '12345'
         );
 
         $this->testTicket2 = array(
-          'subject'  => 'The second ticket',
-          'comment'  => array(
-            'body' => 'Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod'
-                      . ' tempor incididunt ut labore et dolore magna aliqua.'
-          ),
-          'priority' => 'normal',
-          'id'       => '4321'
+            'subject'  => 'The second ticket',
+            'comment'  => array(
+                'body' => 'Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod'
+                          . ' tempor incididunt ut labore et dolore magna aliqua.'
+            ),
+            'priority' => 'normal',
+            'id'       => '4321'
         );
 
         parent::setUp();
@@ -40,16 +40,16 @@ class TicketsTest extends BasicTest
     public function testAllSideLoadedMethod()
     {
         $this->mockAPIResponses([
-          new Response(200, [], '')
+            new Response(200, [], '')
         ]);
 
         $this->client->tickets()->sideload(array('users', 'groups'))->findAll();
 
         $this->assertLastRequestIs(
             [
-            'method'      => 'GET',
-            'endpoint'    => 'tickets.json',
-            'queryParams' => ['include' => 'users,groups'],
+                'method'      => 'GET',
+                'endpoint'    => 'tickets.json',
+                'queryParams' => ['include' => 'users,groups'],
             ]
         );
     }
@@ -57,16 +57,16 @@ class TicketsTest extends BasicTest
     public function testAllSideLoadedParameter()
     {
         $this->mockAPIResponses([
-          new Response(200, [], '')
+            new Response(200, [], '')
         ]);
 
         $this->client->tickets()->findAll(array('sideload' => array('users', 'groups')));
 
         $this->assertLastRequestIs(
             [
-            'method'      => 'GET',
-            'endpoint'    => 'tickets.json',
-            'queryParams' => ['include' => 'users,groups'],
+                'method'      => 'GET',
+                'endpoint'    => 'tickets.json',
+                'queryParams' => ['include' => 'users,groups'],
             ]
         );
     }
@@ -74,15 +74,15 @@ class TicketsTest extends BasicTest
     public function testFindSingle()
     {
         $this->mockAPIResponses([
-          new Response(200, [], '')
+            new Response(200, [], '')
         ]);
 
         $this->client->tickets()->find($this->testTicket['id']);
 
         $this->assertLastRequestIs(
             [
-            'method'   => 'GET',
-            'endpoint' => 'tickets/' . $this->testTicket['id'] . '.json',
+                'method'   => 'GET',
+                'endpoint' => 'tickets/' . $this->testTicket['id'] . '.json',
             ]
         );
 
@@ -91,15 +91,15 @@ class TicketsTest extends BasicTest
     public function testFindSingleChainPattern()
     {
         $this->mockAPIResponses([
-          new Response(200, [], '')
+            new Response(200, [], '')
         ]);
 
         $this->client->tickets($this->testTicket['id'])->find();
 
         $this->assertLastRequestIs(
             [
-            'method' => 'GET',
-            'tickets/' . $this->testTicket['id'] . '.json',
+                'method' => 'GET',
+                'tickets/' . $this->testTicket['id'] . '.json',
             ]
         );
     }
@@ -107,7 +107,7 @@ class TicketsTest extends BasicTest
     public function testFindMultiple()
     {
         $this->mockAPIResponses([
-          new Response(200, [], '')
+            new Response(200, [], '')
         ]);
 
         $testTicketIds = ['ids' => [$this->testTicket['id'], $this->testTicket2['id']]];
@@ -115,9 +115,9 @@ class TicketsTest extends BasicTest
 
         $this->assertLastRequestIs(
             [
-            'method'      => 'GET',
-            'endpoint'    => 'tickets/show_many.json',
-            'queryParams' => ['ids' => implode(',', [$this->testTicket['id'], $this->testTicket2['id']])],
+                'method'      => 'GET',
+                'endpoint'    => 'tickets/show_many.json',
+                'queryParams' => ['ids' => implode(',', [$this->testTicket['id'], $this->testTicket2['id']])],
             ]
         );
     }
@@ -125,15 +125,15 @@ class TicketsTest extends BasicTest
     public function testDeleteMultiple()
     {
         $this->mockAPIResponses([
-          new Response(200, [], '')
+            new Response(200, [], '')
         ]);
 
         $this->client->tickets()->deleteMany(array(123, 321));
         $this->assertLastRequestIs(
             [
-            'method'      => 'DELETE',
-            'endpoint'    => 'tickets/destroy_many.json',
-            'queryParams' => ['ids' => implode(',', [123, 321])],
+                'method'      => 'DELETE',
+                'endpoint'    => 'tickets/destroy_many.json',
+                'queryParams' => ['ids' => implode(',', [123, 321])],
             ]
         );
     }
@@ -141,42 +141,57 @@ class TicketsTest extends BasicTest
     public function testCreateWithAttachment()
     {
         $this->mockAPIResponses([
-          new Response(201, [], json_encode(['upload' => ['token' => 'asdf']])),
-          new Response(201, [], json_encode(['ticket' => ['id' => '123']])),
+            new Response(200, [], json_encode(['upload' => ['token' => 'asdf']])),
+            new Response(200, [], json_encode(['ticket' => ['id' => '123']])),
         ]);
 
         $attachmentData = [
-          'file' => getcwd() . '/tests/assets/UK.png',
-          'name' => 'UK test non-alpha chars.png'
+            'file' => getcwd() . '/tests/assets/UK.png',
+            'name' => 'UK test non-alpha chars.png'
         ];
 
-        $response = $this->client->tickets()->attach($attachmentData)->create($this->testTicket);
+        $this->client->tickets()->attach($attachmentData)->create($this->testTicket);
 
         $this->assertRequestIs(
             [
-            'method'      => 'POST',
-            'endpoint'    => 'uploads.json',
-            'statusCode'  => 201,
-            'queryParams' => ['filename' => rawurlencode($attachmentData['name'])],
-            'file'        => $attachmentData['file'],
+                'method'      => 'POST',
+                'endpoint'    => 'uploads.json',
+                'queryParams' => ['filename' => rawurlencode($attachmentData['name'])],
+                'file'        => $attachmentData['file'],
             ],
             0
         );
+
+        $postFields = [
+            'ticket' => [
+                'subject'  => $this->testTicket['subject'],
+                'comment'  => array_merge($this->testTicket['comment'], ['uploads' => ['asdf']]),
+                'priority' => $this->testTicket['priority'],
+                'id'       => $this->testTicket['id'],
+
+            ]
+        ];
+        array_merge([$this->testTicket, ['uploads' => ['asdf']]]);
+        $this->assertLastRequestIs([
+            'method'     => 'POST',
+            'endpoint'   => 'tickets.json',
+            'postFields' => $postFields,
+        ]);
     }
 
     public function testExport()
     {
         $this->mockAPIResponses([
-          new Response(200, [], '')
+            new Response(200, [], '')
         ]);
 
         $this->client->tickets()->export(array('start_time' => '1332034771'));
 
         $this->assertLastRequestIs(
             [
-            'method'      => 'GET',
-            'endpoint'    => 'exports/tickets.json',
-            'queryParams' => ['start_time' => '1332034771'],
+                'method'      => 'GET',
+                'endpoint'    => 'exports/tickets.json',
+                'queryParams' => ['start_time' => '1332034771'],
             ]
         );
     }
@@ -186,22 +201,22 @@ class TicketsTest extends BasicTest
         $ticketIds = [$this->testTicket['id'], $this->testTicket2['id']];
 
         $this->mockAPIResponses([
-          new Response(200, [], '')
+            new Response(200, [], '')
         ]);
 
         $this->client->tickets()->updateMany(
             [
-            'ids'    => $ticketIds,
-            'status' => 'solved'
+                'ids'    => $ticketIds,
+                'status' => 'solved'
             ]
         );
 
         $this->assertLastRequestIs(
             [
-            'method'      => 'PUT',
-            'endpoint'    => 'tickets/update_many.json',
-            'queryParams' => ['ids' => implode(',', $ticketIds)],
-            'postFields'  => ['ticket' => ['status' => 'solved']]
+                'method'      => 'PUT',
+                'endpoint'    => 'tickets/update_many.json',
+                'queryParams' => ['ids' => implode(',', $ticketIds)],
+                'postFields'  => ['ticket' => ['status' => 'solved']]
             ]
         );
     }
@@ -211,16 +226,16 @@ class TicketsTest extends BasicTest
         $tickets = [$this->testTicket, $this->testTicket2];
 
         $this->mockAPIResponses([
-          new Response(200, [], '')
+            new Response(200, [], '')
         ]);
 
         $this->client->tickets()->updateMany($tickets);
 
         $this->assertLastRequestIs(
             [
-            'method'     => 'PUT',
-            'endpoint'   => 'tickets/update_many.json',
-            'postFields' => ['tickets' => $tickets]
+                'method'     => 'PUT',
+                'endpoint'   => 'tickets/update_many.json',
+                'postFields' => ['tickets' => $tickets]
             ]
         );
     }
@@ -228,15 +243,15 @@ class TicketsTest extends BasicTest
     public function testRelated()
     {
         $this->mockAPIResponses([
-          new Response(200, [], json_encode(['topic_id' => 1]))
+            new Response(200, [], json_encode(['topic_id' => 1]))
         ]);
 
         $related = $this->client->tickets(12345)->related();
 
         $this->assertLastRequestIs(
             [
-            'method'   => 'GET',
-            'endpoint' => 'tickets/12345/related.json',
+                'method'   => 'GET',
+                'endpoint' => 'tickets/12345/related.json',
             ]
         );
 
@@ -247,15 +262,15 @@ class TicketsTest extends BasicTest
     public function testCollaborators()
     {
         $this->mockAPIResponses([
-          new Response(200, [], json_encode(['topic_id' => 1]))
+            new Response(200, [], json_encode(['topic_id' => 1]))
         ]);
 
         $collaborators = $this->client->tickets()->collaborators(array('id' => 12345));
 
         $this->assertLastRequestIs(
             [
-            'method'   => 'GET',
-            'endpoint' => 'tickets/12345/collaborators.json',
+                'method'   => 'GET',
+                'endpoint' => 'tickets/12345/collaborators.json',
             ]
         );
 
@@ -265,15 +280,15 @@ class TicketsTest extends BasicTest
     public function testIncidents()
     {
         $this->mockAPIResponses([
-          new Response(200, [], json_encode(['topic_id' => 1]))
+            new Response(200, [], json_encode(['topic_id' => 1]))
         ]);
 
         $incidents = $this->client->tickets()->incidents(array('id' => 12345));
 
         $this->assertLastRequestIs(
             [
-            'method'   => 'GET',
-            'endpoint' => 'tickets/12345/incidents.json',
+                'method'   => 'GET',
+                'endpoint' => 'tickets/12345/incidents.json',
             ]
         );
 
@@ -283,15 +298,15 @@ class TicketsTest extends BasicTest
     public function testProblems()
     {
         $this->mockAPIResponses([
-          new Response(200, [], json_encode(['tickets' => []]))
+            new Response(200, [], json_encode(['tickets' => []]))
         ]);
 
         $problems = $this->client->tickets()->problems();
 
         $this->assertLastRequestIs(
             [
-            'method'   => 'GET',
-            'endpoint' => 'problems.json',
+                'method'   => 'GET',
+                'endpoint' => 'problems.json',
             ]
         );
 
@@ -301,16 +316,16 @@ class TicketsTest extends BasicTest
     public function testProblemAutoComplete()
     {
         $this->mockAPIResponses([
-          new Response(200, [], json_encode(['tickets' => []]))
+            new Response(200, [], json_encode(['tickets' => []]))
         ]);
 
         $this->client->tickets()->problemAutoComplete(array('text' => 'foo'));
 
         $this->assertLastRequestIs(
             [
-            'method'     => 'POST',
-            'endpoint'   => 'problems/autocomplete.json',
-            'postFields' => ['text' => 'foo'],
+                'method'     => 'POST',
+                'endpoint'   => 'problems/autocomplete.json',
+                'postFields' => ['text' => 'foo'],
             ]
         );
 
@@ -319,15 +334,15 @@ class TicketsTest extends BasicTest
     public function testMarkAsSpam()
     {
         $this->mockAPIResponses([
-          new Response(200, [], '')
+            new Response(200, [], '')
         ]);
 
         $this->client->tickets(12345)->markAsSpam();
 
         $this->assertLastRequestIs(
             [
-            'method'   => 'PUT',
-            'endpoint' => 'tickets/12345/mark_as_spam.json',
+                'method'   => 'PUT',
+                'endpoint' => 'tickets/12345/mark_as_spam.json',
             ]
         );
     }
@@ -335,16 +350,16 @@ class TicketsTest extends BasicTest
     public function testMarkManyAsSpam()
     {
         $this->mockAPIResponses([
-          new Response(200, [], '')
+            new Response(200, [], '')
         ]);
 
         $this->client->tickets()->markAsSpam([12345, 54321]);
 
         $this->assertLastRequestIs(
             [
-            'method'      => 'PUT',
-            'endpoint'    => 'tickets/mark_many_as_spam.json',
-            'queryParams' => ['ids' => '12345,54321']
+                'method'      => 'PUT',
+                'endpoint'    => 'tickets/mark_many_as_spam.json',
+                'queryParams' => ['ids' => '12345,54321']
             ]
         );
     }

--- a/tests/Zendesk/API/UnitTests/TicketsTest.php
+++ b/tests/Zendesk/API/UnitTests/TicketsTest.php
@@ -150,7 +150,7 @@ class TicketsTest extends BasicTest
           'name' => 'UK test non-alpha chars.png'
         ];
 
-        $this->client->tickets()->attach($attachmentData)->create($this->testTicket);
+        $response = $this->client->tickets()->attach($attachmentData)->create($this->testTicket);
 
         $this->assertRequestIs(
             [


### PR DESCRIPTION
Add uploading of attachments to version 2. Allow uploading of attachments and creating tickets with them.

- [x] Update sending to only include options that are available
- [x] Implement with `send_with_options`
- [x] Unit Test
- [x] Test in live

/cc @joseconsador @jwswj @mmolina @atroche 

### References
 - Jira link: https://zendesk.atlassian.net/browse/MI-111

### Risks
 - Ticket attachments might fail (medium)