### PR TITLE
Added support for creating many tickets

### DIFF
--- a/src/Zendesk/API/Tickets.php
+++ b/src/Zendesk/API/Tickets.php
@@ -186,6 +186,28 @@ class Tickets extends ClientAbstract
     }
 
     /**
+     * Create many tickets
+     *
+     * @param array $params
+     *
+     * @throws ResponseException
+     * @throws \Exception
+     *
+     * @return mixed
+     */
+    public function createMany(array $params)
+    {
+        $endPoint = Http::prepare('tickets/create_many.json');
+        $response = Http::send($this->client, $endPoint, array(self::OBJ_NAME_PLURAL => $params), 'POST');
+        if ((!is_object($response)) || ($this->client->getDebug()->lastResponseCode != 200)) {
+            throw new ResponseException(__METHOD__);
+        }
+        $this->client->setSideload(null);
+
+        return $response;
+    }
+
+    /**
      * Create a ticket from a tweet
      *
      * @param array $params


### PR DESCRIPTION
Just a simple addition to support the [tickets/create_many.json](https://developer.zendesk.com/rest_api/docs/core/tickets#creating-many-tickets) endpoint.

The new `Tickets::createMany()` method is based on the existing `Tickets::create()` method. The main difference being that it doesn't support attachments.