### PR TITLE
Update guzzle and mocking to use new guzzle

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,14 +5,12 @@
     "homepage": "https://github.com/zendesk/zendesk_api_client_php",
     "require": {
 		"php": ">=5.3.1",
-        "guzzlehttp/guzzle": "^5.0"
+        "guzzlehttp/guzzle": "~6.0"
     },
 	"require-dev": {
         "phpunit/phpunit": "4.5.*",
         "squizlabs/php_codesniffer": "2.*",
-        "phpmd/phpmd": "@stable",
-        "aeris/guzzle-http-mock": "1.0.*",
-        "squizlabs/php_codesniffer": "2.*"
+        "phpmd/phpmd": "@stable"
     },
 	"autoload": {
         "psr-0": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,38 +4,42 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "e3689543c0f14dc57785cdc92c236a20",
+    "hash": "21c200df8465bdef070c9c9030fdb337",
     "packages": [
         {
             "name": "guzzlehttp/guzzle",
-            "version": "5.0.3",
+            "version": "6.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/guzzle.git",
-                "reference": "6c72627de1d66832e4270e36e56acdb0d1d8f282"
+                "reference": "f992b7b487a816c957d317442bed4966409873e0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/6c72627de1d66832e4270e36e56acdb0d1d8f282",
-                "reference": "6c72627de1d66832e4270e36e56acdb0d1d8f282",
+                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/f992b7b487a816c957d317442bed4966409873e0",
+                "reference": "f992b7b487a816c957d317442bed4966409873e0",
                 "shasum": ""
             },
             "require": {
-                "guzzlehttp/ringphp": "~1.0",
-                "php": ">=5.4.0"
+                "guzzlehttp/promises": "^1.0.0",
+                "guzzlehttp/psr7": "^1.0.0",
+                "php": ">=5.5.0"
             },
             "require-dev": {
                 "ext-curl": "*",
-                "phpunit/phpunit": "~4.0",
-                "psr/log": "~1.0"
+                "phpunit/phpunit": "^4.0",
+                "psr/log": "^1.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "5.0-dev"
+                    "dev-master": "6.0-dev"
                 }
             },
             "autoload": {
+                "files": [
+                    "src/functions.php"
+                ],
                 "psr-4": {
                     "GuzzleHttp\\": "src/"
                 }
@@ -51,7 +55,7 @@
                     "homepage": "https://github.com/mtdowling"
                 }
             ],
-            "description": "Guzzle is a PHP HTTP client library and framework for building RESTful web service clients",
+            "description": "Guzzle is a PHP HTTP client library",
             "homepage": "http://guzzlephp.org/",
             "keywords": [
                 "client",
@@ -62,138 +66,40 @@
                 "rest",
                 "web service"
             ],
-            "time": "2014-11-04 07:09:15"
+            "time": "2015-05-27 16:57:51"
         },
         {
-            "name": "guzzlehttp/ringphp",
-            "version": "1.1.0",
+            "name": "guzzlehttp/promises",
+            "version": "1.0.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/guzzle/RingPHP.git",
-                "reference": "dbbb91d7f6c191e5e405e900e3102ac7f261bc0b"
+                "url": "https://github.com/guzzle/promises.git",
+                "reference": "01abc3232138f330d8a1eaa808fcbdf9b4292f47"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/RingPHP/zipball/dbbb91d7f6c191e5e405e900e3102ac7f261bc0b",
-                "reference": "dbbb91d7f6c191e5e405e900e3102ac7f261bc0b",
+                "url": "https://api.github.com/repos/guzzle/promises/zipball/01abc3232138f330d8a1eaa808fcbdf9b4292f47",
+                "reference": "01abc3232138f330d8a1eaa808fcbdf9b4292f47",
                 "shasum": ""
             },
             "require": {
-                "guzzlehttp/streams": "~3.0",
-                "php": ">=5.4.0",
-                "react/promise": "~2.0"
+                "php": ">=5.5.0"
             },
             "require-dev": {
-                "ext-curl": "*",
-                "phpunit/phpunit": "~4.0"
-            },
-            "suggest": {
-                "ext-curl": "Guzzle will use specific adapters if cURL is present"
+                "phpunit/phpunit": "^4.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.1-dev"
+                    "dev-master": "1.0-dev"
                 }
             },
             "autoload": {
                 "psr-4": {
-                    "GuzzleHttp\\Ring\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Michael Dowling",
-                    "email": "mtdowling@gmail.com",
-                    "homepage": "https://github.com/mtdowling"
-                }
-            ],
-            "description": "Provides a simple API and specification that abstracts away the details of HTTP into a single PHP function.",
-            "time": "2015-05-20 03:37:09"
-        },
-        {
-            "name": "guzzlehttp/streams",
-            "version": "3.0.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/guzzle/streams.git",
-                "reference": "47aaa48e27dae43d39fc1cea0ccf0d84ac1a2ba5"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/streams/zipball/47aaa48e27dae43d39fc1cea0ccf0d84ac1a2ba5",
-                "reference": "47aaa48e27dae43d39fc1cea0ccf0d84ac1a2ba5",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.4.0"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "~4.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "3.0-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "GuzzleHttp\\Stream\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Michael Dowling",
-                    "email": "mtdowling@gmail.com",
-                    "homepage": "https://github.com/mtdowling"
-                }
-            ],
-            "description": "Provides a simple abstraction over streams of data",
-            "homepage": "http://guzzlephp.org/",
-            "keywords": [
-                "Guzzle",
-                "stream"
-            ],
-            "time": "2014-10-12 19:18:40"
-        },
-        {
-            "name": "react/promise",
-            "version": "v2.2.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/reactphp/promise.git",
-                "reference": "365fcee430dfa4ace1fbc75737ca60ceea7eeeef"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/reactphp/promise/zipball/365fcee430dfa4ace1fbc75737ca60ceea7eeeef",
-                "reference": "365fcee430dfa4ace1fbc75737ca60ceea7eeeef",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.4.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "2.0-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "React\\Promise\\": "src/"
+                    "GuzzleHttp\\Promise\\": "src/"
                 },
                 "files": [
-                    "src/functions_include.php"
+                    "src/functions.php"
                 ]
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -202,65 +108,126 @@
             ],
             "authors": [
                 {
-                    "name": "Jan Sorgalla",
-                    "email": "jsorgalla@googlemail.com"
+                    "name": "Michael Dowling",
+                    "email": "mtdowling@gmail.com",
+                    "homepage": "https://github.com/mtdowling"
                 }
             ],
-            "description": "A lightweight implementation of CommonJS Promises/A for PHP",
-            "time": "2014-12-30 13:32:42"
-        }
-    ],
-    "packages-dev": [
+            "description": "Guzzle promises library",
+            "keywords": [
+                "promise"
+            ],
+            "time": "2015-05-13 05:05:10"
+        },
         {
-            "name": "aeris/guzzle-http-mock",
-            "version": "1.0.2",
+            "name": "guzzlehttp/psr7",
+            "version": "1.0.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/aerisweather/GuzzleHttpMock.git",
-                "reference": "be941e92da44811f192a3aab930ce19d4df754f2"
+                "url": "https://github.com/guzzle/psr7.git",
+                "reference": "19e510056d8d671d9d9e25dc16937b3dd3802ae6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/aerisweather/GuzzleHttpMock/zipball/be941e92da44811f192a3aab930ce19d4df754f2",
-                "reference": "be941e92da44811f192a3aab930ce19d4df754f2",
+                "url": "https://api.github.com/repos/guzzle/psr7/zipball/19e510056d8d671d9d9e25dc16937b3dd3802ae6",
+                "reference": "19e510056d8d671d9d9e25dc16937b3dd3802ae6",
                 "shasum": ""
             },
             "require": {
-                "guzzlehttp/guzzle": "~5.0.0",
-                "php": ">=5.3.3"
+                "php": ">=5.4.0",
+                "psr/http-message": "^1.0"
+            },
+            "provide": {
+                "psr/http-message-implementation": "1.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.0"
             },
             "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
             "autoload": {
                 "psr-4": {
-                    "Aeris\\GuzzleHttpMock\\": "src/",
-                    "Aeris\\GuzzleHttpMockTest\\": "test/GuzzleHttpMockTest'"
+                    "GuzzleHttp\\Psr7\\": "src/"
+                },
+                "files": [
+                    "src/functions.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Michael Dowling",
+                    "email": "mtdowling@gmail.com",
+                    "homepage": "https://github.com/mtdowling"
+                }
+            ],
+            "description": "PSR-7 message implementation",
+            "keywords": [
+                "http",
+                "message",
+                "stream",
+                "uri"
+            ],
+            "time": "2015-05-19 17:58:45"
+        },
+        {
+            "name": "psr/http-message",
+            "version": "1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/http-message.git",
+                "reference": "85d63699f0dbedb190bbd4b0d2b9dc707ea4c298"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/http-message/zipball/85d63699f0dbedb190bbd4b0d2b9dc707ea4c298",
+                "reference": "85d63699f0dbedb190bbd4b0d2b9dc707ea4c298",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Http\\Message\\": "src/"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
-                "GPL"
+                "MIT"
             ],
             "authors": [
                 {
-                    "name": "Edan Schwartz",
-                    "email": "edanschwartz@gmail.com"
-                },
-                {
-                    "name": "Seth Miller",
-                    "email": "seth@four43.com"
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
                 }
             ],
-            "description": "A mock library for verifying requests made with the Guzzle Http Client, and mocking responses.",
+            "description": "Common interface for HTTP messages",
             "keywords": [
-                "Guzzle",
-                "client",
                 "http",
-                "mock",
-                "mocking",
-                "testing"
+                "http-message",
+                "psr",
+                "psr-7",
+                "request",
+                "response"
             ],
-            "time": "2015-03-31 18:36:12"
-        },
+            "time": "2015-05-04 20:22:00"
+        }
+    ],
+    "packages-dev": [
         {
             "name": "doctrine/instantiator",
             "version": "1.0.5",
@@ -527,16 +494,16 @@
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "2.1.5",
+            "version": "2.1.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "be2286cb8c7e1773eded49d9719219e6f74f9e3e"
+                "reference": "631e365cf26bb2c078683e8d9bcf8bc631ac4d44"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/be2286cb8c7e1773eded49d9719219e6f74f9e3e",
-                "reference": "be2286cb8c7e1773eded49d9719219e6f74f9e3e",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/631e365cf26bb2c078683e8d9bcf8bc631ac4d44",
+                "reference": "631e365cf26bb2c078683e8d9bcf8bc631ac4d44",
                 "shasum": ""
             },
             "require": {
@@ -585,7 +552,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2015-06-09 13:05:42"
+            "time": "2015-06-19 07:11:55"
         },
         {
             "name": "phpunit/php-file-iterator",
@@ -634,16 +601,16 @@
         },
         {
             "name": "phpunit/php-text-template",
-            "version": "1.2.0",
+            "version": "1.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-text-template.git",
-                "reference": "206dfefc0ffe9cebf65c413e3d0e809c82fbf00a"
+                "reference": "31f8b717e51d9a2afca6c9f046f5d69fc27c8686"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/206dfefc0ffe9cebf65c413e3d0e809c82fbf00a",
-                "reference": "206dfefc0ffe9cebf65c413e3d0e809c82fbf00a",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/31f8b717e51d9a2afca6c9f046f5d69fc27c8686",
+                "reference": "31f8b717e51d9a2afca6c9f046f5d69fc27c8686",
                 "shasum": ""
             },
             "require": {
@@ -652,20 +619,17 @@
             "type": "library",
             "autoload": {
                 "classmap": [
-                    "Text/"
+                    "src/"
                 ]
             },
             "notification-url": "https://packagist.org/downloads/",
-            "include-path": [
-                ""
-            ],
             "license": [
                 "BSD-3-Clause"
             ],
             "authors": [
                 {
                     "name": "Sebastian Bergmann",
-                    "email": "sb@sebastian-bergmann.de",
+                    "email": "sebastian@phpunit.de",
                     "role": "lead"
                 }
             ],
@@ -674,7 +638,7 @@
             "keywords": [
                 "template"
             ],
-            "time": "2014-01-30 17:20:04"
+            "time": "2015-06-21 13:50:34"
         },
         {
             "name": "phpunit/php-timer",
@@ -719,16 +683,16 @@
         },
         {
             "name": "phpunit/php-token-stream",
-            "version": "1.4.2",
+            "version": "1.4.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-token-stream.git",
-                "reference": "db63be1159c81df649cd0260e30249a586d4129e"
+                "reference": "7a9b0969488c3c54fd62b4d504b3ec758fd005d9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/db63be1159c81df649cd0260e30249a586d4129e",
-                "reference": "db63be1159c81df649cd0260e30249a586d4129e",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/7a9b0969488c3c54fd62b4d504b3ec758fd005d9",
+                "reference": "7a9b0969488c3c54fd62b4d504b3ec758fd005d9",
                 "shasum": ""
             },
             "require": {
@@ -764,7 +728,7 @@
             "keywords": [
                 "tokenizer"
             ],
-            "time": "2015-06-12 07:34:24"
+            "time": "2015-06-19 03:43:16"
         },
         {
             "name": "phpunit/phpunit",
@@ -1231,16 +1195,16 @@
         },
         {
             "name": "sebastian/version",
-            "version": "1.0.5",
+            "version": "1.0.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/version.git",
-                "reference": "ab931d46cd0d3204a91e1b9a40c4bc13032b58e4"
+                "reference": "58b3a85e7999757d6ad81c787a1fbf5ff6c628c6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/ab931d46cd0d3204a91e1b9a40c4bc13032b58e4",
-                "reference": "ab931d46cd0d3204a91e1b9a40c4bc13032b58e4",
+                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/58b3a85e7999757d6ad81c787a1fbf5ff6c628c6",
+                "reference": "58b3a85e7999757d6ad81c787a1fbf5ff6c628c6",
                 "shasum": ""
             },
             "type": "library",
@@ -1262,7 +1226,7 @@
             ],
             "description": "Library that helps with managing the version number of Git-hosted PHP projects",
             "homepage": "https://github.com/sebastianbergmann/version",
-            "time": "2015-02-24 06:35:25"
+            "time": "2015-06-21 13:59:46"
         },
         {
             "name": "squizlabs/php_codesniffer",

--- a/src/Zendesk/API/Http.php
+++ b/src/Zendesk/API/Http.php
@@ -82,9 +82,9 @@ class Http
 
         // TODO Add query parameters if they are present
         $request = new Request(
-          $options['method'],
-          $client->getApiUrl() . $endPoint,
-          $headers
+            $options['method'],
+            $client->getApiUrl() . $endPoint,
+            $headers
         );
 
         if (isset($options['postFields'])) {

--- a/src/Zendesk/API/Http.php
+++ b/src/Zendesk/API/Http.php
@@ -59,18 +59,18 @@ class Http
      * @return array The response body, parsed from JSON into an associative array
      */
     public static function sendWithOptions(
-      HttpClient $client,
-      $endPoint,
-      $options = []
+        HttpClient $client,
+        $endPoint,
+        $options = []
     ) {
         $options = array_merge(
-          [
+            [
             'method'      => 'GET',
             'contentType' => 'application/json',
             'postFields'  => null,
             'queryParams' => null
-          ],
-          $options
+            ],
+            $options
         );
 
         $headers = [
@@ -79,9 +79,9 @@ class Http
         ];
 
         $request = new Request(
-          $options['method'],
-          $client->getApiUrl() . $endPoint,
-          $headers
+            $options['method'],
+            $client->getApiUrl() . $endPoint,
+            $headers
         );
 
         if (!empty($options['postFields'])) {
@@ -107,10 +107,10 @@ class Http
         $parsedResponseBody = json_decode($response->getBody()->getContents());
 
         $client->setDebug(
-          $response->getHeaders(),
-          $responseCode,
-          10,
-          null
+            $response->getHeaders(),
+            $responseCode,
+            10,
+            null
         );
 
         return $parsedResponseBody;

--- a/src/Zendesk/API/HttpClient.php
+++ b/src/Zendesk/API/HttpClient.php
@@ -256,7 +256,11 @@ class HttpClient
      */
     public function getSideload(array $params = null)
     {
-        return ((isset($params['sideload'])) && (is_array($params['sideload'])) ? $params['sideload'] : $this->sideload);
+        if ((isset($params['sideload'])) && (is_array($params['sideload']))) {
+            return $params['sideload'];
+        } else {
+            return $this->sideload;
+        }
     }
 
     /*

--- a/src/Zendesk/API/Resources/ResourceAbstract.php
+++ b/src/Zendesk/API/Resources/ResourceAbstract.php
@@ -5,6 +5,7 @@ namespace Zendesk\API\Resources;
 use Zendesk\API\Http;
 use Zendesk\API\HttpClient;
 use Zendesk\API\UtilityTraits\ChainedParametersTrait;
+use Zendesk\API\Exceptions\MissingParametersException;
 
 /**
  * Abstract class for all endpoints

--- a/tests/Zendesk/API/UnitTests/BasicTest.php
+++ b/tests/Zendesk/API/UnitTests/BasicTest.php
@@ -92,6 +92,7 @@ abstract class BasicTest extends \PHPUnit_Framework_TestCase
     }
 
     public function assertRequestIs ($options, $index = 0) {
+        // TODO Add assertions on headers
         $transaction = $this->mockedTransactionsContainer[$index];
         $request = $transaction['request'];
 
@@ -99,15 +100,19 @@ abstract class BasicTest extends \PHPUnit_Framework_TestCase
             $this->assertEquals($options['method'], $request->getMethod());
         }
 
-        if (isset($options['url'])) {
+        if (isset($options['endpoint'])) {
             // Truncate the `/api/v2` part of the target
-            $url = str_replace('/api/v2/', '', $request->getRequestTarget());
-            $this->assertEquals($options['url'], $url);
+            $endpoint = str_replace('/api/v2/', '', $request->getUri()->getPath());
+            $this->assertEquals($options['endpoint'], $endpoint);
+        }
+
+        if (isset($options['queryParams'])) {
+            $expectedQueryParams = urldecode(http_build_query($options['queryParams']));
+            $this->assertEquals($expectedQueryParams, $request->getUri()->getQuery());
         }
 
         if (isset($options['postFields'])) {
             $this->assertEquals(json_encode($options['postFields']), $request->getBody()->getContents());
         }
-        // TODO: Add other asserts
     }
 }

--- a/tests/Zendesk/API/UnitTests/BasicTest.php
+++ b/tests/Zendesk/API/UnitTests/BasicTest.php
@@ -92,9 +92,26 @@ abstract class BasicTest extends \PHPUnit_Framework_TestCase
     }
 
     public function assertRequestIs ($options, $index = 0) {
-        // TODO Add assertions on headers
         $transaction = $this->mockedTransactionsContainer[$index];
         $request = $transaction['request'];
+        $response = $transaction['response'];
+
+        $options = array_merge([
+          'statusCode' => 200,
+          'headers' => [
+            'Accept'       => 'application/json',
+            'Content-Type' => 'application/json'
+          ]
+        ], $options);
+
+        $this->assertEquals($options['statusCode'], $response->getStatusCode());
+
+        if (isset($options['headers']) && is_array($options['headers'])) {
+            foreach ($options['headers'] as $headerKey => $value) {
+                $this->assertNotEmpty($header = $request->getHeader($headerKey));
+                $this->assertEquals($options['headers'][$headerKey], $value);
+            }
+        }
 
         if (isset($options['method'])) {
             $this->assertEquals($options['method'], $request->getMethod());

--- a/tests/Zendesk/API/UnitTests/BasicTest.php
+++ b/tests/Zendesk/API/UnitTests/BasicTest.php
@@ -100,7 +100,9 @@ abstract class BasicTest extends \PHPUnit_Framework_TestCase
         }
 
         if (isset($options['url'])) {
-            $this->assertEquals($options['url'], $request->getRequestTarget());
+            // Truncate the `/api/v2` part of the target
+            $url = str_replace('/api/v2/', '', $request->getRequestTarget());
+            $this->assertEquals($options['url'], $url);
         }
 
         if (isset($options['postFields'])) {

--- a/tests/Zendesk/API/UnitTests/BasicTest.php
+++ b/tests/Zendesk/API/UnitTests/BasicTest.php
@@ -87,11 +87,13 @@ abstract class BasicTest extends \PHPUnit_Framework_TestCase
         );
     }
 
-    public function assertLastRequestIs ($options) {
+    public function assertLastRequestIs($options)
+    {
         $this->assertRequestIs($options, count($this->mockedTransactionsContainer) - 1);
     }
 
-    public function assertRequestIs ($options, $index = 0) {
+    public function assertRequestIs($options, $index = 0)
+    {
         $transaction = $this->mockedTransactionsContainer[$index];
         $request = $transaction['request'];
         $response = $transaction['response'];

--- a/tests/Zendesk/API/UnitTests/ResourceTest.php
+++ b/tests/Zendesk/API/UnitTests/ResourceTest.php
@@ -23,7 +23,7 @@ class ResourceTest extends BasicTest
 
         $this->assertLastRequestIs([
             'method' => 'GET',
-            'url' => '/api/v2/dummyresource.json',
+            'url' => 'dummyresource.json',
           ]
         );
     }
@@ -38,7 +38,7 @@ class ResourceTest extends BasicTest
 
         $this->assertLastRequestIs([
             'method' => 'GET',
-            'url' => '/api/v2/dummyresource/1.json',
+            'url' => 'dummyresource/1.json',
         ]);
     }
 
@@ -55,7 +55,7 @@ class ResourceTest extends BasicTest
         $this->assertLastRequestIs(
           [
             'method' => 'POST',
-            'url' => '/api/v2/dummyresource.json',
+            'url' => 'dummyresource.json',
             'postFields' => ['dummy' => $postFields]
           ]
         );
@@ -73,7 +73,7 @@ class ResourceTest extends BasicTest
         $this->assertLastRequestIs(
           [
               'method' => 'PUT',
-              'url' => '/api/v2/dummyresource/1.json',
+              'url' => 'dummyresource/1.json',
               'postFields' => ['dummy' => $postFields],
           ]
         );
@@ -90,7 +90,7 @@ class ResourceTest extends BasicTest
         $this->assertLastRequestIs(
           [
               'method' => 'DELETE',
-              'url' => '/api/v2/dummyresource/1.json'
+              'url' => 'dummyresource/1.json'
           ]
         );
     }

--- a/tests/Zendesk/API/UnitTests/ResourceTest.php
+++ b/tests/Zendesk/API/UnitTests/ResourceTest.php
@@ -23,7 +23,7 @@ class ResourceTest extends BasicTest
 
         $this->assertLastRequestIs([
             'method' => 'GET',
-            'url' => 'dummyresource.json',
+            'endpoint' => 'dummyresource.json',
           ]
         );
     }
@@ -38,7 +38,7 @@ class ResourceTest extends BasicTest
 
         $this->assertLastRequestIs([
             'method' => 'GET',
-            'url' => 'dummyresource/1.json',
+            'endpoint' => 'dummyresource/1.json',
         ]);
     }
 
@@ -55,7 +55,7 @@ class ResourceTest extends BasicTest
         $this->assertLastRequestIs(
           [
             'method' => 'POST',
-            'url' => 'dummyresource.json',
+            'endpoint' => 'dummyresource.json',
             'postFields' => ['dummy' => $postFields]
           ]
         );
@@ -73,7 +73,7 @@ class ResourceTest extends BasicTest
         $this->assertLastRequestIs(
           [
               'method' => 'PUT',
-              'url' => 'dummyresource/1.json',
+              'endpoint' => 'dummyresource/1.json',
               'postFields' => ['dummy' => $postFields],
           ]
         );
@@ -90,7 +90,7 @@ class ResourceTest extends BasicTest
         $this->assertLastRequestIs(
           [
               'method' => 'DELETE',
-              'url' => 'dummyresource/1.json'
+              'endpoint' => 'dummyresource/1.json'
           ]
         );
     }

--- a/tests/Zendesk/API/UnitTests/ResourceTest.php
+++ b/tests/Zendesk/API/UnitTests/ResourceTest.php
@@ -24,8 +24,7 @@ class ResourceTest extends BasicTest
         $this->assertLastRequestIs([
             'method' => 'GET',
             'endpoint' => 'dummyresource.json',
-          ]
-        );
+          ]);
     }
 
     public function testFind()
@@ -53,11 +52,11 @@ class ResourceTest extends BasicTest
         $this->_dummyResource->create($postFields);
 
         $this->assertLastRequestIs(
-          [
+            [
             'method' => 'POST',
             'endpoint' => 'dummyresource.json',
             'postFields' => ['dummy' => $postFields]
-          ]
+            ]
         );
     }
 
@@ -71,11 +70,11 @@ class ResourceTest extends BasicTest
         $this->_dummyResource->update(1, $postFields);
 
         $this->assertLastRequestIs(
-          [
+            [
               'method' => 'PUT',
               'endpoint' => 'dummyresource/1.json',
               'postFields' => ['dummy' => $postFields],
-          ]
+            ]
         );
     }
 
@@ -88,10 +87,10 @@ class ResourceTest extends BasicTest
         $this->_dummyResource->delete(1);
 
         $this->assertLastRequestIs(
-          [
+            [
               'method' => 'DELETE',
               'endpoint' => 'dummyresource/1.json'
-          ]
+            ]
         );
     }
 }

--- a/tests/Zendesk/API/UnitTests/ResourceTest.php
+++ b/tests/Zendesk/API/UnitTests/ResourceTest.php
@@ -1,6 +1,8 @@
 <?php
 namespace Zendesk\API\UnitTests;
 
+use GuzzleHttp\Psr7\Response;
+
 class ResourceTest extends BasicTest
 {
     private $_dummyResource;
@@ -13,74 +15,83 @@ class ResourceTest extends BasicTest
 
     public function testFindAll()
     {
-        $this->mockApiCall(
-            'GET',
-            'dummyresource.json',
-            array('dummies' => true)
-        );
+        $this->mockAPIResponses([
+          new Response(200, [], '')
+        ]);
 
         $this->_dummyResource->findAll();
+
+        $this->assertLastRequestIs([
+            'method' => 'GET',
+            'url' => '/api/v2/dummyresource.json',
+          ]
+        );
     }
 
     public function testFind()
     {
-        $this->mockApiCall(
-            'GET',
-            'dummyresource/1.json',
-            array('dummy' => true)
-        );
+        $this->mockAPIResponses([
+          new Response(200, [], json_encode(['dummy' => true]))
+        ]);
 
-        $response = $this->_dummyResource->find(1);
+        $this->_dummyResource->find(1);
 
-        $this->assertEquals(
-            isset($response->dummy),
-            true,
-            'Should return a response called "dummy"'
-        );
+        $this->assertLastRequestIs([
+            'method' => 'GET',
+            'url' => '/api/v2/dummyresource/1.json',
+        ]);
     }
 
     public function testCreate()
     {
-        $this->mockApiCall(
-            'POST',
-            'dummyresource.json',
-            array('foo' => 'test response'),
-            array(
-                'bodyParams' => array(
-                    'dummy' => array('foo' => 'test body')
-                )
-            )
-        );
+        $this->mockAPIResponses([
+          new Response(200, [], '')
+        ]);
 
-        $this->_dummyResource->create(
-            array('foo' => 'test body')
-        );
+        $postFields = ['foo' => 'test body'];
 
-        $this->httpMock->verify();
+        $this->_dummyResource->create($postFields);
+
+        $this->assertLastRequestIs(
+          [
+            'method' => 'POST',
+            'url' => '/api/v2/dummyresource.json',
+            'postFields' => ['dummy' => $postFields]
+          ]
+        );
     }
 
     public function testUpdate()
     {
-        $this->mockApiCall(
-            'PUT',
-            'dummyresource/1.json',
-            array('foo' => 'test response'),
-            array(
-                'bodyParams' => array(
-                    'dummy' => array('foo' => 'test body')
-                )
-            )
-        );
+        $this->mockAPIResponses([
+          new Response(200, [], '')
+        ]);
 
-        $this->_dummyResource->update(1, array('foo' => 'test body'));
-        $this->httpMock->verify();
+        $postFields = ['foo' => 'test body'];
+        $this->_dummyResource->update(1, $postFields);
+
+        $this->assertLastRequestIs(
+          [
+              'method' => 'PUT',
+              'url' => '/api/v2/dummyresource/1.json',
+              'postFields' => ['dummy' => $postFields],
+          ]
+        );
     }
 
     public function testDelete()
     {
-        $this->mockApiCall('DELETE', 'dummyresource/1.json', []);
+        $this->mockAPIResponses([
+          new Response(200, [], '')
+        ]);
 
         $this->_dummyResource->delete(1);
-        $this->httpMock->verify();
+
+        $this->assertLastRequestIs(
+          [
+              'method' => 'DELETE',
+              'url' => '/api/v2/dummyresource/1.json'
+          ]
+        );
     }
 }

--- a/tests/Zendesk/API/UnitTests/TicketCommentsTest.php
+++ b/tests/Zendesk/API/UnitTests/TicketCommentsTest.php
@@ -35,10 +35,10 @@ class TicketCommentsTest extends BasicTest
         $comments = $this->client->tickets($this->ticket_id)->comments()->findAll();
 
         $this->assertLastRequestIs(
-          [
+            [
             'method' => 'GET',
             'endpoint' => 'tickets/12345/comments.json',
-          ]
+            ]
         );
 
         $this->assertEquals(is_object($comments), true, 'Should return an object');
@@ -62,10 +62,10 @@ class TicketCommentsTest extends BasicTest
         $this->client->tickets(12345)->comments(1)->makePrivate();
 
         $this->assertLastRequestIs(
-          [
+            [
             'method' => 'PUT',
             'endpoint' => 'tickets/12345/comments/1/make_private.json',
-          ]
+            ]
         );
     }
 }

--- a/tests/Zendesk/API/UnitTests/TicketCommentsTest.php
+++ b/tests/Zendesk/API/UnitTests/TicketCommentsTest.php
@@ -37,7 +37,7 @@ class TicketCommentsTest extends BasicTest
         $this->assertLastRequestIs(
           [
             'method' => 'GET',
-            'url' => 'tickets/12345/comments.json',
+            'endpoint' => 'tickets/12345/comments.json',
           ]
         );
 
@@ -64,7 +64,7 @@ class TicketCommentsTest extends BasicTest
         $this->assertLastRequestIs(
           [
             'method' => 'PUT',
-            'url' => 'tickets/12345/comments/1/make_private.json',
+            'endpoint' => 'tickets/12345/comments/1/make_private.json',
           ]
         );
     }

--- a/tests/Zendesk/API/UnitTests/TicketCommentsTest.php
+++ b/tests/Zendesk/API/UnitTests/TicketCommentsTest.php
@@ -2,6 +2,8 @@
 
 namespace Zendesk\API\UnitTests;
 
+use GuzzleHttp\Psr7\Response;
+
 /**
  * Ticket Comments test class
  */
@@ -11,7 +13,6 @@ class TicketCommentsTest extends BasicTest
 
     public function setUp()
     {
-
         $this->testTicket = array(
             'id' => "12345",
             'subject' => 'Ticket comment test',
@@ -27,20 +28,18 @@ class TicketCommentsTest extends BasicTest
 
     public function testAll()
     {
-        $this->mockApiCall(
-            'GET',
-            'tickets/12345/comments.json',
-            [
-            'comments' => [
-              [
-                'id' => 1
-              ]
-            ]
-            ]
-        );
+        $this->mockAPIResponses([
+          new Response(200, [], json_encode(['comments' => [['id' => 1]]]))
+        ]);
 
         $comments = $this->client->tickets($this->ticket_id)->comments()->findAll();
-        $this->httpMock->verify();
+
+        $this->assertLastRequestIs(
+          [
+            'method' => 'GET',
+            'url' => 'tickets/12345/comments.json',
+          ]
+        );
 
         $this->assertEquals(is_object($comments), true, 'Should return an object');
         $this->assertEquals(
@@ -48,7 +47,7 @@ class TicketCommentsTest extends BasicTest
             true,
             'Should return an object containing an array called "comments"'
         );
-        $this->assertGreaterThan(0, $comments->comments[0]->id, 'Returns a non-numeric id in first audit');
+        $this->assertGreaterThan(0, $comments->comments[0]->id, 'Should return a numeric ID.');
     }
 
     /*
@@ -56,26 +55,17 @@ class TicketCommentsTest extends BasicTest
      */
     public function testMakePrivate()
     {
-        $this->mockApiCall(
-            'GET',
-            'tickets/12345/comments.json',
-            [
-            'comments' => [
-              [
-                'id' => 1
-              ]
-            ]
-            ]
-        );
-        $comment_id = $this->client->tickets($this->ticket_id)->comments()->findAll()->comments[0]->id;
-        $this->httpMock->verify();
+        $this->mockAPIResponses([
+          new Response(200, [], '')
+        ]);
 
-        $this->mockApiCall(
-            'PUT',
-            'tickets/12345/comments/1/make_private.json',
-            []
+        $this->client->tickets(12345)->comments(1)->makePrivate();
+
+        $this->assertLastRequestIs(
+          [
+            'method' => 'PUT',
+            'url' => 'tickets/12345/comments/1/make_private.json',
+          ]
         );
-        $this->client->tickets($this->ticket_id)->comments($comment_id)->makePrivate();
-        $this->httpMock->verify();
     }
 }

--- a/tests/Zendesk/API/UnitTests/TicketsTest.php
+++ b/tests/Zendesk/API/UnitTests/TicketsTest.php
@@ -44,11 +44,11 @@ class TicketsTest extends BasicTest
         $this->client->tickets()->sideload(array( 'users', 'groups' ))->findAll();
 
         $this->assertLastRequestIs(
-          [
+            [
             'method' => 'GET',
             'endpoint' => 'tickets.json',
             'queryParams' => ['include' => 'users,groups'],
-          ]
+            ]
         );
     }
 
@@ -61,11 +61,11 @@ class TicketsTest extends BasicTest
         $this->client->tickets()->findAll(array( 'sideload' => array( 'users', 'groups' ) ));
 
         $this->assertLastRequestIs(
-          [
+            [
             'method' => 'GET',
             'endpoint' => 'tickets.json',
             'queryParams' => ['include' => 'users,groups'],
-          ]
+            ]
         );
     }
 
@@ -78,10 +78,10 @@ class TicketsTest extends BasicTest
         $this->client->tickets()->find($this->testTicket['id']);
 
         $this->assertLastRequestIs(
-          [
+            [
             'method' => 'GET',
             'endpoint' => 'tickets/' . $this->testTicket['id'] . '.json',
-          ]
+            ]
         );
 
     }
@@ -95,10 +95,10 @@ class TicketsTest extends BasicTest
         $this->client->tickets($this->testTicket['id'])->find();
 
         $this->assertLastRequestIs(
-          [
+            [
             'method' => 'GET',
             'tickets/' . $this->testTicket['id'] . '.json',
-          ]
+            ]
         );
     }
 
@@ -112,11 +112,11 @@ class TicketsTest extends BasicTest
         $this->client->tickets()->findMany($testTicketIds);
 
         $this->assertLastRequestIs(
-          [
+            [
             'method' => 'GET',
             'endpoint' => 'tickets/show_many.json',
             'queryParams' => ['ids' => implode(',', [ $this->testTicket['id'], $this->testTicket2['id'] ])],
-          ]
+            ]
         );
     }
 
@@ -128,11 +128,11 @@ class TicketsTest extends BasicTest
 
         $this->client->tickets()->deleteMany(array( 123, 321 ));
         $this->assertLastRequestIs(
-          [
+            [
             'method' => 'DELETE',
             'endpoint' => 'tickets/destroy_many.json',
             'queryParams' => ['ids' => implode(',', [ 123, 321 ])],
-          ]
+            ]
         );
     }
 
@@ -170,11 +170,11 @@ class TicketsTest extends BasicTest
         $this->client->tickets()->export(array( 'start_time' => '1332034771' ));
 
         $this->assertLastRequestIs(
-          [
+            [
             'method' => 'GET',
             'endpoint' => 'exports/tickets.json',
             'queryParams' => [ 'start_time' => '1332034771' ],
-          ]
+            ]
         );
     }
 
@@ -194,12 +194,12 @@ class TicketsTest extends BasicTest
         );
 
         $this->assertLastRequestIs(
-          [
+            [
             'method' => 'PUT',
             'endpoint' => 'tickets/update_many.json',
             'queryParams' => [ 'ids' => implode(',', $ticketIds) ],
             'postFields'  => [ 'ticket' => [ 'status' => 'solved' ] ]
-          ]
+            ]
         );
     }
 
@@ -214,11 +214,11 @@ class TicketsTest extends BasicTest
         $this->client->tickets()->updateMany($tickets);
 
         $this->assertLastRequestIs(
-          [
+            [
             'method' => 'PUT',
             'endpoint' => 'tickets/update_many.json',
             'postFields' => [ 'tickets' => $tickets ]
-          ]
+            ]
         );
     }
 
@@ -231,10 +231,10 @@ class TicketsTest extends BasicTest
         $related = $this->client->tickets(12345)->related();
 
         $this->assertLastRequestIs(
-          [
+            [
             'method' => 'GET',
             'endpoint' => 'tickets/12345/related.json',
-          ]
+            ]
         );
 
         // Test if the method returns readable data
@@ -250,10 +250,10 @@ class TicketsTest extends BasicTest
         $collaborators = $this->client->tickets()->collaborators(array( 'id' => 12345 ));
 
         $this->assertLastRequestIs(
-          [
+            [
             'method' => 'GET',
             'endpoint' => 'tickets/12345/collaborators.json',
-          ]
+            ]
         );
 
         $this->assertEquals(is_object($collaborators), true, 'Should return an object');
@@ -268,10 +268,10 @@ class TicketsTest extends BasicTest
         $incidents = $this->client->tickets()->incidents(array( 'id' => 12345 ));
 
         $this->assertLastRequestIs(
-          [
+            [
             'method' => 'GET',
             'endpoint' => 'tickets/12345/incidents.json',
-          ]
+            ]
         );
 
         $this->assertEquals(is_object($incidents), true, 'Should return an object');
@@ -286,10 +286,10 @@ class TicketsTest extends BasicTest
         $problems = $this->client->tickets()->problems();
 
         $this->assertLastRequestIs(
-          [
+            [
             'method' => 'GET',
             'endpoint' => 'problems.json',
-          ]
+            ]
         );
 
         $this->assertEquals(is_object($problems), true, 'Should return an object');
@@ -304,11 +304,11 @@ class TicketsTest extends BasicTest
         $this->client->tickets()->problemAutoComplete(array( 'text' => 'foo' ));
 
         $this->assertLastRequestIs(
-          [
+            [
             'method' => 'POST',
             'endpoint' => 'problems/autocomplete.json',
             'postFields' => ['text' => 'foo'],
-          ]
+            ]
         );
 
     }
@@ -322,10 +322,10 @@ class TicketsTest extends BasicTest
         $this->client->tickets(12345)->markAsSpam();
 
         $this->assertLastRequestIs(
-          [
+            [
             'method' => 'PUT',
             'endpoint' => 'tickets/12345/mark_as_spam.json',
-          ]
+            ]
         );
     }
 
@@ -338,11 +338,11 @@ class TicketsTest extends BasicTest
         $this->client->tickets()->markAsSpam([ 12345, 54321 ]);
 
         $this->assertLastRequestIs(
-          [
+            [
             'method' => 'PUT',
             'endpoint' => 'tickets/mark_many_as_spam.json',
             'queryParams' => [ 'ids' => '12345,54321' ]
-          ]
+            ]
         );
     }
 }

--- a/tests/Zendesk/API/UnitTests/TicketsTest.php
+++ b/tests/Zendesk/API/UnitTests/TicketsTest.php
@@ -2,6 +2,8 @@
 
 namespace Zendesk\API\UnitTests;
 
+use GuzzleHttp\Psr7\Response;
+
 /**
  * Tickets test class
  */
@@ -35,88 +37,103 @@ class TicketsTest extends BasicTest
 
     public function testAllSideLoadedMethod()
     {
-        $this->mockApiCall(
-            'GET',
-            'tickets.json',
-            array(
-            'tickets' => [ $this->testTicket ],
-            'groups'  => [ ],
-            'users'   => [ ]
-            ),
-            [ 'queryParams' => [ 'include' => 'users,groups' ] ]
-        );
+        $this->mockAPIResponses([
+          new Response(200, [], '')
+        ]);
 
         $this->client->tickets()->sideload(array( 'users', 'groups' ))->findAll();
-        $this->httpMock->verify();
+
+        $this->assertLastRequestIs(
+          [
+            'method' => 'GET',
+            'endpoint' => 'tickets.json',
+            'queryParams' => ['include' => 'users,groups'],
+          ]
+        );
     }
 
     public function testAllSideLoadedParameter()
     {
-        $this->mockApiCall(
-            'GET',
-            'tickets.json',
-            array(
-            'tickets' => [ $this->testTicket ],
-            'groups'  => [ ],
-            'users'   => [ ]
-            ),
-            [ 'queryParams' => array( 'include' => implode(',', array( 'users', 'groups' )) ) ]
-        );
+        $this->mockAPIResponses([
+          new Response(200, [], '')
+        ]);
 
         $this->client->tickets()->findAll(array( 'sideload' => array( 'users', 'groups' ) ));
-        $this->httpMock->verify();
+
+        $this->assertLastRequestIs(
+          [
+            'method' => 'GET',
+            'endpoint' => 'tickets.json',
+            'queryParams' => ['include' => 'users,groups'],
+          ]
+        );
     }
 
     public function testFindSingle()
     {
-        $this->mockApiCall(
-            'GET',
-            'tickets/' . $this->testTicket['id'] . '.json',
-            [ 'ticket' => $this->testTicket ]
-        );
+        $this->mockAPIResponses([
+          new Response(200, [], '')
+        ]);
 
         $this->client->tickets()->find($this->testTicket['id']);
-        $this->httpMock->verify();
+
+        $this->assertLastRequestIs(
+          [
+            'method' => 'GET',
+            'endpoint' => 'tickets/' . $this->testTicket['id'] . '.json',
+          ]
+        );
 
     }
 
     public function testFindSingleChainPattern()
     {
-        $this->mockApiCall(
-            'GET',
-            'tickets/' . $this->testTicket['id'] . '.json',
-            [ 'ticket' => $this->testTicket ]
-        );
+        $this->mockAPIResponses([
+          new Response(200, [], '')
+        ]);
 
         $this->client->tickets($this->testTicket['id'])->find();
-        $this->httpMock->verify();
+
+        $this->assertLastRequestIs(
+          [
+            'method' => 'GET',
+            'tickets/' . $this->testTicket['id'] . '.json',
+          ]
+        );
     }
 
     public function testFindMultiple()
     {
-        $this->mockApiCall(
-            'GET',
-            'tickets/show_many.json',
-            [ 'tickets' => array( $this->testTicket, $this->testTicket2 ) ],
-            [ 'queryParams' => array( 'ids' => implode(',', [ $this->testTicket['id'], $this->testTicket2['id'] ]) ) ]
-        );
+        $this->mockAPIResponses([
+          new Response(200, [], '')
+        ]);
 
         $testTicketIds = [ 'ids' => [ $this->testTicket['id'], $this->testTicket2['id'] ] ];
         $this->client->tickets()->findMany($testTicketIds);
-        $this->httpMock->verify();
+
+        $this->assertLastRequestIs(
+          [
+            'method' => 'GET',
+            'endpoint' => 'tickets/show_many.json',
+            'queryParams' => ['ids' => implode(',', [ $this->testTicket['id'], $this->testTicket2['id'] ])],
+          ]
+        );
     }
 
     public function testDeleteMultiple()
     {
-        $this->mockApiCall(
-            'DELETE',
-            'tickets/destroy_many.json?ids=123%2C321',
-            array( 'tickets' => [ ] ),
-            [ 'queryParams' => array( 'ids' => implode(',', [ 123, 321 ]) ) ]
-        );
+        $this->mockAPIResponses([
+          new Response(200, [], '')
+        ]);
 
         $this->client->tickets()->deleteMany(array( 123, 321 ));
-        $this->httpMock->verify();
+        $this->assertLastRequestIs(
+          [
+            'method' => 'DELETE',
+            'endpoint' => 'tickets/destroy_many.json',
+            'queryParams' => ['ids' => implode(',', [ 123, 321 ])],
+          ]
+        );
     }
 
     public function testCreateWithAttachment()
@@ -146,29 +163,28 @@ class TicketsTest extends BasicTest
 
     public function testExport()
     {
-        $this->mockApiCall(
-            'GET',
-            'exports/tickets.json',
-            array( 'results' => [ ] ),
-            [ 'queryParams' => [ 'start_time' => '1332034771' ] ]
-        );
+        $this->mockAPIResponses([
+          new Response(200, [], '')
+        ]);
+
         $this->client->tickets()->export(array( 'start_time' => '1332034771' ));
-        $this->httpMock->verify();
+
+        $this->assertLastRequestIs(
+          [
+            'method' => 'GET',
+            'endpoint' => 'exports/tickets.json',
+            'queryParams' => [ 'start_time' => '1332034771' ],
+          ]
+        );
     }
 
     public function testUpdateManyWithQueryParams()
     {
         $ticketIds = [ $this->testTicket['id'], $this->testTicket2['id'] ];
 
-        $this->mockApiCall(
-            'PUT',
-            'tickets/update_many.json',
-            array( 'job_status' => [ 'job_status' => [ 'id' => 'bugger off' ] ] ),
-            [
-            'queryParams' => [ 'ids' => implode(',', $ticketIds) ],
-            'bodyParams'  => [ 'ticket' => [ 'status' => 'solved' ] ]
-            ]
-        );
+        $this->mockAPIResponses([
+          new Response(200, [], '')
+        ]);
 
         $this->client->tickets()->updateMany(
             [
@@ -176,38 +192,50 @@ class TicketsTest extends BasicTest
             'status' => 'solved'
             ]
         );
-        $this->httpMock->verify();
+
+        $this->assertLastRequestIs(
+          [
+            'method' => 'PUT',
+            'endpoint' => 'tickets/update_many.json',
+            'queryParams' => [ 'ids' => implode(',', $ticketIds) ],
+            'postFields'  => [ 'ticket' => [ 'status' => 'solved' ] ]
+          ]
+        );
     }
 
     public function testUpdateMany()
     {
         $tickets = [ $this->testTicket, $this->testTicket2 ];
 
-        $this->mockApiCall(
-            'PUT',
-            'tickets/update_many.json',
-            array( 'job_status' => [ 'job_status' => [ 'id' => 'bugger off' ] ] ),
-            [
-            'bodyParams' => [ 'tickets' => $tickets ]
-            ]
-        );
+        $this->mockAPIResponses([
+          new Response(200, [], '')
+        ]);
 
         $this->client->tickets()->updateMany($tickets);
-        $this->httpMock->verify();
+
+        $this->assertLastRequestIs(
+          [
+            'method' => 'PUT',
+            'endpoint' => 'tickets/update_many.json',
+            'postFields' => [ 'tickets' => $tickets ]
+          ]
+        );
     }
 
     public function testRelated()
     {
-        $this->mockApiCall(
-            'GET',
-            'tickets/12345/related.json',
-            array( 'topic_id' => 1 ),
-            array( 'statusCode' => 200 )
-        );
+        $this->mockAPIResponses([
+          new Response(200, [], json_encode(['topic_id' => 1]))
+        ]);
 
         $related = $this->client->tickets(12345)->related();
 
-        $this->httpMock->verify();
+        $this->assertLastRequestIs(
+          [
+            'method' => 'GET',
+            'endpoint' => 'tickets/12345/related.json',
+          ]
+        );
 
         // Test if the method returns readable data
         $this->assertEquals(is_object($related), true, 'Should return an object');
@@ -215,95 +243,106 @@ class TicketsTest extends BasicTest
 
     public function testCollaborators()
     {
-        $this->mockApiCall(
-            'GET',
-            'tickets/12345/collaborators.json',
-            array( 'topic_id' => 1 ),
-            array( 'statusCode' => 200 )
-        );
+        $this->mockAPIResponses([
+          new Response(200, [], json_encode(['topic_id' => 1]))
+        ]);
 
         $collaborators = $this->client->tickets()->collaborators(array( 'id' => 12345 ));
 
-        $this->httpMock->verify();
+        $this->assertLastRequestIs(
+          [
+            'method' => 'GET',
+            'endpoint' => 'tickets/12345/collaborators.json',
+          ]
+        );
 
         $this->assertEquals(is_object($collaborators), true, 'Should return an object');
     }
 
     public function testIncidents()
     {
-        $this->mockApiCall(
-            'GET',
-            'tickets/12345/incidents.json',
-            array( 'topic_id' => 1 ),
-            array( 'statusCode' => 200 )
-        );
+        $this->mockAPIResponses([
+          new Response(200, [], json_encode(['topic_id' => 1]))
+        ]);
 
         $incidents = $this->client->tickets()->incidents(array( 'id' => 12345 ));
 
-        $this->httpMock->verify();
+        $this->assertLastRequestIs(
+          [
+            'method' => 'GET',
+            'endpoint' => 'tickets/12345/incidents.json',
+          ]
+        );
 
         $this->assertEquals(is_object($incidents), true, 'Should return an object');
     }
 
     public function testProblems()
     {
-        $this->mockApiCall(
-            'GET',
-            'problems.json',
-            array( 'tickets' => [ ] ),
-            array( 'statusCode' => 200 )
-        );
+        $this->mockAPIResponses([
+          new Response(200, [], json_encode(['tickets' => []]))
+        ]);
 
         $problems = $this->client->tickets()->problems();
 
-        $this->httpMock->verify();
+        $this->assertLastRequestIs(
+          [
+            'method' => 'GET',
+            'endpoint' => 'problems.json',
+          ]
+        );
 
         $this->assertEquals(is_object($problems), true, 'Should return an object');
     }
 
     public function testProblemAutoComplete()
     {
-        $this->mockApiCall(
-            'POST',
-            'problems/autocomplete.json',
-            array( 'tickets' => [ ] ),
-            array(
-            'statusCode' => 200,
-            'bodyParams' => [ 'text' => 'foo' ]
-            )
-        );
+        $this->mockAPIResponses([
+          new Response(200, [], json_encode(['tickets' => []]))
+        ]);
 
         $this->client->tickets()->problemAutoComplete(array( 'text' => 'foo' ));
 
-        $this->httpMock->verify();
+        $this->assertLastRequestIs(
+          [
+            'method' => 'POST',
+            'endpoint' => 'problems/autocomplete.json',
+            'postFields' => ['text' => 'foo'],
+          ]
+        );
+
     }
 
     public function testMarkAsSpam()
     {
-        $this->mockApiCall(
-            'PUT',
-            'tickets/12345/mark_as_spam.json',
-            [ ],
-            [ 'statusCode' => 200 ]
-        );
+        $this->mockAPIResponses([
+          new Response(200, [], '')
+        ]);
 
         $this->client->tickets(12345)->markAsSpam();
-        $this->httpMock->verify();
+
+        $this->assertLastRequestIs(
+          [
+            'method' => 'PUT',
+            'endpoint' => 'tickets/12345/mark_as_spam.json',
+          ]
+        );
     }
 
     public function testMarkManyAsSpam()
     {
-        $this->mockApiCall(
-            'PUT',
-            'tickets/mark_many_as_spam.json',
-            [ ],
-            [
-            'statusCode'  => 200,
-            'queryParams' => [ 'ids' => '12345,54321' ]
-            ]
-        );
+        $this->mockAPIResponses([
+          new Response(200, [], '')
+        ]);
 
         $this->client->tickets()->markAsSpam([ 12345, 54321 ]);
-        $this->httpMock->verify();
+
+        $this->assertLastRequestIs(
+          [
+            'method' => 'PUT',
+            'endpoint' => 'tickets/mark_many_as_spam.json',
+            'queryParams' => [ 'ids' => '12345,54321' ]
+          ]
+        );
     }
 }

--- a/tests/Zendesk/API/UnitTests/UsersTest.php
+++ b/tests/Zendesk/API/UnitTests/UsersTest.php
@@ -30,11 +30,11 @@ class UsersTest extends BasicTest
         $user = $this->client->users()->create($testUser);
 
         $this->assertLastRequestIs(
-          [
+            [
             'method' => 'POST',
             'endpoint' => 'users.json',
             'postFields' => ['user' => $testUser],
-          ]
+            ]
         );
 
         $this->assertEquals(is_object($user), true, 'Should return an object');
@@ -51,21 +51,21 @@ class UsersTest extends BasicTest
         $this->client->users(12345)->delete();
 
         $this->assertLastRequestIs(
-          [
+            [
             'method' => 'DELETE',
             'endpoint' => 'users/12345.json',
-          ]
+            ]
         );
     }
 
     public function testAll()
     {
         $response = json_encode(
-          [
+            [
             'users' => [
               [ 'id' => 12345 ]
             ]
-          ]
+            ]
         );
 
         $this->mockAPIResponses([
@@ -75,10 +75,10 @@ class UsersTest extends BasicTest
         $users = $this->client->users()->findAll();
 
         $this->assertLastRequestIs(
-          [
+            [
             'method' => 'GET',
             'endpoint' => 'users.json',
-          ]
+            ]
         );
 
         $this->assertEquals(is_object($users), true, 'Should return an object');
@@ -100,10 +100,10 @@ class UsersTest extends BasicTest
         $user = $this->client->users(12345)->find();
 
         $this->assertLastRequestIs(
-          [
+            [
             'method' => 'GET',
             'endpoint' => 'users/12345.json',
-          ]
+            ]
         );
 
         $this->assertEquals(is_object($user), true, 'Should return an object');
@@ -128,11 +128,11 @@ class UsersTest extends BasicTest
         $users = $this->client->users($findIds)->findMany();
 
         $this->assertLastRequestIs(
-          [
+            [
             'method' => 'GET',
             'endpoint' => 'users/show_many.json',
             'queryParams' => ['ids' => implode(",", [$findIds[0], $findIds[1]])] ,
-          ]
+            ]
         );
         $this->assertEquals(is_object($users), true, 'Should return an object');
         $this->assertEquals(is_array($users->users), true, 'Should return an array called "users"');
@@ -182,11 +182,11 @@ class UsersTest extends BasicTest
         $users = $this->client->users()->showMany([ 'external_ids' => $findIds ]);
 
         $this->assertLastRequestIs(
-          [
+            [
             'method' => 'GET',
             'endpoint' => 'users/show_many.json',
             'queryParams' => ['external_ids' => implode(',', $findIds)]
-          ]
+            ]
         );
 
         $this->assertEquals(is_object($users), true, 'Should return an object');
@@ -207,10 +207,10 @@ class UsersTest extends BasicTest
         $related = $this->client->users(12345)->related();
 
         $this->assertLastRequestIs(
-          [
+            [
             'method' => 'GET',
             'endpoint' => 'users/12345/related.json',
-          ]
+            ]
         );
         $this->assertEquals(is_object($related), true, 'Should return an object');
         $this->assertEquals(
@@ -236,11 +236,11 @@ class UsersTest extends BasicTest
         $this->client->users('me')->merge($postFields);
 
         $this->assertLastRequestIs(
-          [
+            [
             'method' => 'PUT',
             'endpoint' => 'users/me/merge.json',
             'postFields' => [Users::OBJ_NAME => $postFields],
-          ]
+            ]
         );
     }
 
@@ -266,11 +266,11 @@ class UsersTest extends BasicTest
         $jobStatus = $this->client->users()->createMany($postFields);
 
         $this->assertLastRequestIs(
-          [
+            [
             'method' => 'POST',
             'endpoint' => 'users/create_many.json',
             'postFields' => [Users::OBJ_NAME_PLURAL => $postFields],
-          ]
+            ]
         );
 
         $this->assertEquals(is_object($jobStatus), true, 'Should return an object');
@@ -289,11 +289,11 @@ class UsersTest extends BasicTest
         $this->client->users(12345)->update(null, $postFields);
 
         $this->assertLastRequestIs(
-          [
+            [
             'method' => 'PUT',
             'endpoint' => 'users/12345.json',
             'postFields' => [Users::OBJ_NAME => $postFields],
-          ]
+            ]
         );
     }
 
@@ -312,12 +312,12 @@ class UsersTest extends BasicTest
         $jobStatus = $this->client->users()->updateMany($requestParams);
 
         $this->assertLastRequestIs(
-          [
+            [
             'method' => 'PUT',
             'endpoint' => 'users/update_many.json',
             'queryParams' => ['ids' => $requestParams['ids']],
             'postFields' => [Users::OBJ_NAME => ['phone' => $requestParams['phone']]]
-          ]
+            ]
         );
 
         $this->assertEquals(is_object($jobStatus), true, 'Should return an array');
@@ -346,11 +346,11 @@ class UsersTest extends BasicTest
         $jobStatus = $this->client->users()->updateManyIndividualUsers($requestParams);
 
         $this->assertLastRequestIs(
-          [
+            [
             'method' => 'PUT',
             'endpoint' => 'users/update_many.json',
             'postFields' => [Users::OBJ_NAME_PLURAL => $requestParams]
-          ]
+            ]
         );
 
         $this->assertEquals(is_object($jobStatus), true, 'Should return an array');
@@ -369,11 +369,11 @@ class UsersTest extends BasicTest
         $user = $this->client->users($userId)->suspend();
 
         $this->assertLastRequestIs(
-          [
+            [
             'method' => 'PUT',
             'endpoint' => 'users/12345.json',
             'postFields' => [Users::OBJ_NAME => ['id' => $userId, 'suspended' => true]],
-          ]
+            ]
         );
         
         $this->assertEquals(is_object($user), true, 'Should return an object');
@@ -392,11 +392,11 @@ class UsersTest extends BasicTest
         $users = $this->client->users()->search($queryParams);
 
         $this->assertLastRequestIs(
-          [
+            [
             'method' => 'GET',
             'endpoint' => 'users/search.json',
             'queryParams' => $queryParams,
-          ]
+            ]
         );
 
         $this->assertEquals(is_object($users), true, 'Should return an object');
@@ -422,11 +422,11 @@ class UsersTest extends BasicTest
         $users = $this->client->users()->autocomplete($queryParams);
 
         $this->assertLastRequestIs(
-          [
+            [
             'method' => 'POST',
             'endpoint' => 'users/autocomplete.json',
             'queryParams' => $queryParams,
-          ]
+            ]
         );
 
         $this->assertEquals(is_object($users), true, 'Should return an object');
@@ -465,10 +465,10 @@ class UsersTest extends BasicTest
         $user = $this->client->users()->me();
 
         $this->assertLastRequestIs(
-          [
+            [
             'method' => 'GET',
             'endpoint' => 'users/me.json',
-          ]
+            ]
         );
 
         $this->assertEquals(is_object($user), true, 'Should return an object');
@@ -487,11 +487,11 @@ class UsersTest extends BasicTest
         $this->client->users(12345)->setPassword($postFields);
 
         $this->assertLastRequestIs(
-          [
+            [
             'method' => 'POST',
             'endpoint' => 'users/12345/password.json',
             'postFields' => [Users::OBJ_NAME => $postFields],
-          ]
+            ]
         );
     }
 
@@ -509,11 +509,11 @@ class UsersTest extends BasicTest
         $this->client->users(421450109)->changePassword($postFields);
 
         $this->assertLastRequestIs(
-          [
+            [
             'method' => 'PUT',
             'endpoint' => 'users/421450109/password.json',
             'postFields' => $postFields,
-          ]
+            ]
         );
     }
 }

--- a/tests/Zendesk/API/UnitTests/ViewsTest.php
+++ b/tests/Zendesk/API/UnitTests/ViewsTest.php
@@ -2,6 +2,7 @@
 
 namespace Zendesk\API\UnitTests;
 
+use GuzzleHttp\Psr7\Response;
 use Zendesk\API\Resources\Views;
 
 /**
@@ -13,84 +14,109 @@ class ViewsTest extends BasicTest
 
     public function testActive()
     {
-        $this->mockApiCall(
-            'GET',
-            'views/active.json',
-            ['views' => [['id' => $this->id]]]
-        );
+        $this->mockAPIResponses([
+          new Response(200, [], json_encode(['views' => [['id' => $this->id]]]))
+        ]);
 
         $views = $this->client->views()->findAll(['active' => true]);
-        $this->httpMock->verify();
+
+        $this->assertLastRequestIs(
+            [
+            'method' => 'GET',
+            'endpoint' => 'views/active.json',
+            ]
+        );
+
         $this->assertEquals(
             is_array($views->views),
             true,
             'Should return an object containing an array called "views"'
         );
-        $this->assertGreaterThan(0, $views->views[0]->id, 'Returns a non-numeric id for views[0]');
+        $this->assertGreaterThan(0, $views->views[0]->id, 'Should return a numeric id for views[0]');
     }
 
     public function testCompact()
     {
-        $this->mockApiCall(
-            'GET',
-            'views/compact.json',
-            ['views' => [['id' => $this->id]]]
-        );
+        $this->mockAPIResponses([
+          new Response(200, [], json_encode(['views' => [['id' => $this->id]]]))
+        ]);
+
         $views = $this->client->views()->findAll(['compact' => true]);
-        $this->httpMock->verify();
+
+        $this->assertLastRequestIs(
+            [
+            'method' => 'GET',
+            'endpoint' => 'views/compact.json',
+            ]
+        );
         $this->assertEquals(is_object($views), true, 'Should return an object');
         $this->assertEquals(
             is_array($views->views),
             true,
             'Should return an object containing an array called "views"'
         );
-        $this->assertGreaterThan(0, $views->views[0]->id, 'Returns a non-numeric id for views[0]');
+        $this->assertGreaterThan(0, $views->views[0]->id, 'Should return a numeric id for views[0]');
     }
 
     public function testExecute()
     {
         $queryParams = ['per_page' => 1];
-        $this->mockApiCall(
-            'GET',
-            'views/' . $this->id . '/execute.json',
-            ['view' => ['id' => $this->id]],
-            ['queryParams' => $queryParams]
-        );
+        $this->mockAPIResponses([
+          new Response(200, [], json_encode(['view' => ['id' => $this->id]]))
+        ]);
 
         $view = $this->client->views($this->id)->execute($queryParams);
-        $this->httpMock->verify();
+
+        $this->assertLastRequestIs(
+            [
+            'method' => 'GET',
+            'endpoint' => 'views/' . $this->id . '/execute.json',
+            'queryParams' => $queryParams,
+            ]
+        );
+
         $this->assertEquals(is_object($view), true, 'Should return an object');
         $this->assertEquals(is_object($view->view), true, 'Should return an object called "view"');
-        $this->assertGreaterThan(0, $view->view->id, 'Returns a non-numeric id for view');
+        $this->assertGreaterThan(0, $view->view->id, 'Should return a numeric id for view');
     }
 
     public function testCount()
     {
-        $this->mockApiCall(
-            'GET',
-            'views/' . $this->id . '/count.json',
-            ['view_count' => ['view_id' => $this->id]]
-        );
+        $this->mockAPIResponses([
+          new Response(200, [], json_encode(['view_count' => ['view_id' => $this->id]]))
+        ]);
 
         $counts = $this->client->views($this->id)->count();
-        $this->httpMock->verify();
+
+        $this->assertLastRequestIs(
+            [
+            'method' => 'GET',
+            'endpoint' => 'views/' . $this->id . '/count.json',
+            ]
+        );
+
         $this->assertEquals(is_object($counts), true, 'Should return an object');
         $this->assertEquals(is_object($counts->view_count), true, 'Should return an object called "view_count"');
-        $this->assertGreaterThan(0, $counts->view_count->view_id, 'Returns a non-numeric view_id for view_count');
+        $this->assertGreaterThan(0, $counts->view_count->view_id, 'Should return a numeric view_id for view_count');
     }
 
     public function testCountMany()
     {
         $queryIds = [$this->id, 80085];
-        $this->mockApiCall(
-            'GET',
-            'views/count_many.json',
-            ['view_counts' => [['view_id' => $this->id]]],
-            ['queryParams' => ['ids' => implode(',', $queryIds)]]
-        );
+        $this->mockAPIResponses([
+          new Response(200, [], json_encode(['view_counts' => [['view_id' => $this->id]]]))
+        ]);
 
         $counts = $this->client->views($queryIds)->count();
-        $this->httpMock->verify();
+
+        $this->assertLastRequestIs(
+            [
+            'method' => 'GET',
+            'endpoint' => 'views/count_many.json',
+            'queryParams' => ['ids' => implode(',', $queryIds)]
+            ]
+        );
+
         $this->assertEquals(
             is_array($counts->view_counts),
             true,
@@ -99,27 +125,32 @@ class ViewsTest extends BasicTest
         $this->assertGreaterThan(
             0,
             $counts->view_counts[0]->view_id,
-            'Returns a non-numeric view_id for view_counts[0]'
+            'Should return a numeric view_id for view_counts[0]'
         );
     }
 
     public function testExport()
     {
-        $this->mockApiCall(
-            'GET',
-            'views/' . $this->id . '/export.json',
-            ['export' => ['view_id' => $this->id]]
-        );
+        $this->mockAPIResponses([
+          new Response(200, [], json_encode(['export' => ['view_id' => $this->id]]))
+        ]);
 
         $export = $this->client->views($this->id)->export();
-        $this->httpMock->verify();
+
+        $this->assertLastRequestIs(
+            [
+            'method' => 'GET',
+            'endpoint' => 'views/' . $this->id . '/export.json',
+            ]
+        );
+
         $this->assertEquals(is_object($export), true, 'Should return an object');
-        $this->assertGreaterThan(0, $export->export->view_id, 'Returns a non-numeric view_id for export');
+        $this->assertGreaterThan(0, $export->export->view_id, 'Should return a numeric view_id for export');
     }
 
     public function testPreview()
     {
-        $bodyParams = [
+        $postFields = [
           'all'    => [
             [
               'operator' => 'is',
@@ -132,15 +163,20 @@ class ViewsTest extends BasicTest
           ]
         ];
 
-        $this->mockApiCall(
-            'POST',
-            'views/preview.json',
-            ['rows' => [], 'columns' => []],
-            ['bodyParams' => [Views::OBJ_NAME => $bodyParams]]
+        $this->mockAPIResponses([
+          new Response(200, [], json_encode(['rows' => [], 'columns' => []]))
+        ]);
+
+        $preview = $this->client->views()->preview($postFields);
+
+        $this->assertLastRequestIs(
+            [
+            'method' => 'POST',
+            'endpoint' => 'views/preview.json',
+            'postFields' => [Views::OBJ_NAME => $postFields]
+            ]
         );
 
-        $preview = $this->client->views()->preview($bodyParams);
-        $this->httpMock->verify();
         $this->assertEquals(is_object($preview), true, 'Should return an object');
         $this->assertEquals(is_array($preview->rows), true, 'Should return an array of objects called "rows"');
         $this->assertEquals(is_array($preview->columns), true, 'Should return an array of objects called "columns"');
@@ -148,7 +184,7 @@ class ViewsTest extends BasicTest
 
     public function testPreviewCount()
     {
-        $bodyParams = [
+        $postFields = [
             'all' => [
                 [
                     'operator' => 'is',
@@ -161,29 +197,39 @@ class ViewsTest extends BasicTest
             ]
         ];
 
-        $this->mockApiCall(
-            'POST',
-            'views/preview/count.json',
-            ['view_count' => (new \stdClass())],
-            ['bodyParams' => [Views::OBJ_NAME => $bodyParams]]
+        $this->mockAPIResponses([
+          new Response(200, [], json_encode(['view_count' => (new \stdClass())]))
+        ]);
+
+        $preview = $this->client->views()->previewCount($postFields);
+
+        $this->assertLastRequestIs(
+            [
+            'method' => 'POST',
+            'endpoint' => 'views/preview/count.json',
+            'postFields' => [Views::OBJ_NAME => $postFields],
+            ]
         );
 
-        $preview = $this->client->views()->previewCount($bodyParams);
-        $this->httpMock->verify();
         $this->assertEquals(is_object($preview), true, 'Should return an object');
         $this->assertEquals(is_object($preview->view_count), true, 'Should return an object called "view_count"');
     }
 
     public function testGetTickets()
     {
-        $this->mockApiCall(
-            'GET',
-            "views/{$this->id}/tickets.json",
-            ['tickets' => ['id' => $this->id]]
-        );
+        $this->mockAPIResponses([
+          new Response(200, [], json_encode(['tickets' => ['id' => $this->id]]))
+        ]);
 
         $preview = $this->client->views($this->id)->tickets();
-        $this->httpMock->verify();
+
+        $this->assertLastRequestIs(
+            [
+            'method' => 'GET',
+            'endpoint' => "views/{$this->id}/tickets.json",
+            ]
+        );
+
         $this->assertEquals(is_object($preview), true, 'Should return an object');
         $this->assertEquals(is_object($preview->tickets), true, 'Should return an object called "tickets"');
     }


### PR DESCRIPTION
Updated guzzle to ~v6. This uses the PSR7 standard.
Additionally used the built in mocking mechanism of guzzle instead of an external library
Updating all the existing tests to use the guzzle mokcing mechanism

/cc @joseconsador @jwswj @mmolina @atroche 

### References
 - Jira link: 

### Risks
 - Requests might not be sent properly (medium)