### PR TITLE
[MI-105] Add support for authentication with the api client

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -8,17 +8,17 @@
         convertWarningsToExceptions="true"
         >
     <php>
-        <env name="SUBDOMAIN" value="" />
-        <env name="USERNAME" value="blah@zendesk.com" />
-        <env name="TOKEN" value="zgS0d8hrK13DgVs6OHT7OVS3G4MZQSUvleMyUJnC" />
-        <env name="OAUTH_SECRET" value="ea974e907f363a05c60be3120f336439bf4744c2285b4c8a9c902b5453497bae" />
-        <env name="OAUTH_TOKEN" value="4924186d99cfb4bb7a482a4307fb5f9a3a052d0c555ebb866f975b6084e38efd" />
-        <env name="END_USER_USERNAME" value="php@zendesk.com" />
-        <env name="END_USER_PASSWORD" value="123456" />
-        <env name="END_USER_OAUTH_TOKEN" value="e0a6eaa33ac9bbabc50a43ce388a35227e5d48975c1266006239ae0da4b3b9e1" />
-        <env name="SCHEME" value="http" />
-        <env name="HOSTNAME" value="localhost" />
-        <env name="PORT" value="8080" />
+        <env name="SUBDOMAIN" value=""/>
+        <env name="USERNAME" value="blah@zendesk.com"/>
+        <env name="TOKEN" value="zgS0d8hrK13DgVs6OHT7OVS3G4MZQSUvleMyUJnC"/>
+        <env name="OAUTH_SECRET" value="ea974e907f363a05c60be3120f336439bf4744c2285b4c8a9c902b5453497bae"/>
+        <env name="OAUTH_TOKEN" value="4924186d99cfb4bb7a482a4307fb5f9a3a052d0c555ebb866f975b6084e38efd"/>
+        <env name="END_USER_USERNAME" value="php@zendesk.com"/>
+        <env name="END_USER_PASSWORD" value="123456"/>
+        <env name="END_USER_OAUTH_TOKEN" value="e0a6eaa33ac9bbabc50a43ce388a35227e5d48975c1266006239ae0da4b3b9e1"/>
+        <env name="SCHEME" value="http"/>
+        <env name="HOSTNAME" value="localhost"/>
+        <env name="PORT" value="8080"/>
     </php>
 
     <testsuites>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -10,7 +10,6 @@
     <php>
         <env name="SUBDOMAIN" value="" />
         <env name="USERNAME" value="blah@zendesk.com" />
-        <env name="PASSWORD" value="123456" />
         <env name="TOKEN" value="zgS0d8hrK13DgVs6OHT7OVS3G4MZQSUvleMyUJnC" />
         <env name="OAUTH_SECRET" value="ea974e907f363a05c60be3120f336439bf4744c2285b4c8a9c902b5453497bae" />
         <env name="OAUTH_TOKEN" value="4924186d99cfb4bb7a482a4307fb5f9a3a052d0c555ebb866f975b6084e38efd" />

--- a/src/Zendesk/API/Exceptions/AuthException.php
+++ b/src/Zendesk/API/Exceptions/AuthException.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Zendesk\API\Exceptions;
+
+/**
+ * AuthException is for auth specific errors
+ * @package Zendesk\API
+ */
+class AuthException extends \Exception
+{
+}

--- a/src/Zendesk/API/Http.php
+++ b/src/Zendesk/API/Http.php
@@ -97,7 +97,7 @@ class Http
         }
 
         try {
-            $response = $client->guzzle->send($request);
+            $response = $client->guzzle->send($request, ['auth' => $client->getAuthOptions()]);
 
             $client->setDebug(
                 $response->getHeaders(),

--- a/src/Zendesk/API/Http.php
+++ b/src/Zendesk/API/Http.php
@@ -5,10 +5,10 @@ namespace Zendesk\API;
 use GuzzleHttp\Exception\RequestException;
 use GuzzleHttp\Psr7\Request;
 use Zendesk\API\Exceptions\ApiResponseException;
+use Zendesk\API\Exceptions\AuthException;
 
 /**
  * HTTP functions via curl
- *
  * @package Zendesk\API
  */
 class Http
@@ -18,9 +18,8 @@ class Http
     /**
      * Prepares an endpoint URL with optional side-loading
      *
-     * @param string $endPoint
-     * @param array  $sideload
-     * @param array  $iterators
+     * @param array $sideload
+     * @param array $iterators
      *
      * @return string
      */
@@ -48,8 +47,8 @@ class Http
      * Use the send method to call every endpoint except for oauth/tokens
      *
      * @param HttpClient $client
-     * @param string     $endPoint E.g. "/tickets.json"
-     * @param array      $options
+     * @param string $endPoint E.g. "/tickets.json"
+     * @param array $options
      *                             Available options are listed below:
      *                             array $queryParams Array of unencoded key-value pairs, e.g. ["ids" => "1,2,3,4"]
      *                             array $postFields Array of unencoded key-value pairs, e.g. ["filename" => "blah.png"]
@@ -57,6 +56,8 @@ class Http
      *                             string $contentType Default is "application/json"
      *
      * @return array The response body, parsed from JSON into an associative array
+     * @throws ApiResponseException
+     * @throws AuthException
      */
     public static function sendWithOptions(
         HttpClient $client,
@@ -84,20 +85,31 @@ class Http
             $headers
         );
 
-        if (!empty($options['postFields'])) {
+        if (! empty($options['postFields'])) {
             $request = $request->withBody(\GuzzleHttp\Psr7\stream_for(json_encode($options['postFields'])));
         }
 
-        if (!empty($options['queryParams'])) {
+        if (! empty($options['queryParams'])) {
             foreach ($options['queryParams'] as $queryKey => $queryValue) {
-                $uri = $request->getUri();
-                $uri = $uri->withQueryValue($uri, $queryKey, $queryValue);
+                $uri     = $request->getUri();
+                $uri     = $uri->withQueryValue($uri, $queryKey, $queryValue);
                 $request = $request->withUri($uri, true);
             }
         }
 
         try {
-            $response = $client->guzzle->send($request, ['auth' => $client->getAuthOptions()]);
+            if ($client->getAuthStrategy() === HttpClient::AUTH_BASIC) {
+                $authOptions = $client->getAuthOptions();
+                $options     = ['auth' => [$authOptions['username'] . '/token', $authOptions['token'], 'basic']];
+                $response    = $client->guzzle->send($request, $options);
+            } elseif ($client->getAuthStrategy() === HttpClient::AUTH_OAUTH) {
+                $authOptions = $client->getAuthOptions();
+                $oAuthToken  = $authOptions['token'];
+                $request     = $request->withAddedHeader('Authorization', ' Bearer ' . $oAuthToken);
+                $response    = $client->guzzle->send($request);
+            } else {
+                throw new AuthException('Please set authentication to send requests.');
+            }
 
             $client->setDebug(
                 $response->getHeaders(),
@@ -116,12 +128,11 @@ class Http
      * Specific case for OAuth. Run /oauth.php via your browser to get an access token
      *
      * @param HttpClient $client
-     * @param string     $code
-     * @param string     $oAuthId
-     * @param string     $oAuthSecret
+     * @param string $code
+     * @param string $oAuthId
+     * @param string $oAuthSecret
      *
      * @throws \Exception
-     *
      * @return mixed
      */
     public static function oauth(HttpClient $client, $code, $oAuthId, $oAuthSecret)
@@ -155,8 +166,8 @@ class Http
         if ($response === false) {
             throw new \Exception(sprintf('Curl error message: "%s" in %s', $curl->error(), __METHOD__));
         }
-        $headerSize = $curl->getinfo(CURLINFO_HEADER_SIZE);
-        $responseBody = substr($response, $headerSize);
+        $headerSize     = $curl->getinfo(CURLINFO_HEADER_SIZE);
+        $responseBody   = substr($response, $headerSize);
         $responseObject = json_decode($responseBody);
         $client->setDebug(
             $curl->getinfo(CURLINFO_HEADER_OUT),

--- a/src/Zendesk/API/HttpClient.php
+++ b/src/Zendesk/API/HttpClient.php
@@ -28,6 +28,7 @@ class HttpClient
 {
     use InstantiatorTrait;
 
+    protected $method;
     /**
      * @var string
      */
@@ -48,10 +49,6 @@ class HttpClient
      * @var integer
      */
     protected $port;
-    /**
-     * @var string
-     */
-    protected $password;
     /**
      * @var string
      */
@@ -143,27 +140,12 @@ class HttpClient
      * Configure the authorization method
      *
      * @param string $method
-     * @param string $value
+     * @param array  $options
      */
-    public function setAuth($method, $value)
+    public function setAuth($method, array $options)
     {
-        switch ($method) {
-            case 'password':
-                $this->password = $value;
-                $this->token = '';
-                $this->oAuthToken = '';
-                break;
-            case 'token':
-                $this->password = '';
-                $this->token = $value;
-                $this->oAuthToken = '';
-                break;
-            case 'oauth_token':
-                $this->password = '';
-                $this->token = '';
-                $this->oAuthToken = $value;
-                break;
-        }
+        $this->method = $method;
+        $this->authOptions = $options;
     }
 
     /**
@@ -191,9 +173,9 @@ class HttpClient
      *
      * @return string
      */
-    public function getAuthType()
+    public function getAuthOptions()
     {
-        return ($this->oAuthToken ? 'oauth_token' : ($this->token ? 'token' : 'password'));
+        return $this->authOptions;
     }
 
     /**

--- a/src/Zendesk/API/Resources/TicketForms.php
+++ b/src/Zendesk/API/Resources/TicketForms.php
@@ -18,8 +18,8 @@ class TicketForms extends ResourceAbstract
         parent::setUpRoutes();
 
         $this->setRoutes([
-            'clone'   => 'ticket_forms/{id}/clone.json',
-            'reorder' => 'ticket_forms/reorder.json'
+          'clone'   => 'ticket_forms/{id}/clone.json',
+          'reorder' => 'ticket_forms/reorder.json'
         ]);
     }
 
@@ -31,7 +31,6 @@ class TicketForms extends ResourceAbstract
      * @throws MissingParametersException
      * @throws ResponseException
      * @throws Zendesk\API\Exceptions\MissingParametersException
-     *
      * @return mixed
      */
     public function cloneForm($id = null)
@@ -63,7 +62,6 @@ class TicketForms extends ResourceAbstract
      *
      * @throws ResponseException
      * @throws \Exception
-     *
      * @return mixed
      */
     public function reorder(array $ticketFormIds)

--- a/tests/Zendesk/API/LiveTests/AuthTest.php
+++ b/tests/Zendesk/API/LiveTests/AuthTest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Zendesk\API\LiveTests;
+
+/**
+ * Users test class
+ */
+class UsersTest extends BasicTest
+{
+    /**
+     * Test the use of basic test
+     */
+    public function testBasicAuth()
+    {
+        $this->client->setAuth('basic', ['username' => $this->username, 'token' => $this->token]);
+        $users = $this->client->users()->findAll();
+        $this->assertTrue(isset($users->users), 'Should return a valid user object.');
+    }
+
+    /**
+     * Test the use of basic test
+     */
+    public function testOAuth()
+    {
+        $this->client->setAuth('oauth', ['token' => $this->oAuthToken]);
+        $users = $this->client->users()->findAll();
+        $this->assertTrue(isset($users->users), 'Should return a valid user object.');
+    }
+}

--- a/tests/Zendesk/API/LiveTests/BasicTest.php
+++ b/tests/Zendesk/API/LiveTests/BasicTest.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Zendesk\API\LiveTests;
+
+use Zendesk\API\HttpClient;
+
+/**
+ * Basic test class
+ */
+abstract class BasicTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var HttpClient
+     */
+    protected $client;
+    /**
+     * @var string
+     */
+    protected $subdomain;
+    /**
+     * @var string
+     */
+    protected $password;
+    /**
+     * @var string
+     */
+    protected $token;
+    /**
+     * @var string
+     */
+    protected $oAuthToken;
+    /**
+     * @var string
+     */
+    protected $hostname;
+    /**
+     * @var string
+     */
+    protected $scheme;
+    /**
+     * @var string
+     */
+    protected $port;
+    /**
+     * @var array
+     */
+    protected $mockedTransactionsContainer = [];
+
+    /**
+     * {@inheritdoc}
+     */
+    public function __construct()
+    {
+        $this->subdomain  = getenv('SUBDOMAIN');
+        $this->username   = getenv('USERNAME');
+        $this->password   = getenv('PASSWORD');
+        $this->token      = getenv('TOKEN');
+        $this->oAuthToken = getenv('OAUTH_TOKEN');
+        $this->scheme     = getenv('SCHEME');
+        $this->hostname   = getenv('HOSTNAME');
+        $this->port       = getenv('PORT');
+    }
+
+    /**
+     * Sets up the fixture, for example, open a network connection.
+     * This method is called before a test is executed.
+     */
+    protected function setUp()
+    {
+        $this->client = new HttpClient($this->subdomain, $this->username, $this->scheme, $this->hostname, $this->port);
+    }
+}

--- a/tests/Zendesk/API/UnitTests/BasicTest.php
+++ b/tests/Zendesk/API/UnitTests/BasicTest.php
@@ -13,16 +13,46 @@ use Zendesk\API\HttpClient;
  */
 abstract class BasicTest extends \PHPUnit_Framework_TestCase
 {
+    /**
+     * @var HttpClient
+     */
     protected $client;
+    /**
+     * @var string
+     */
     protected $subdomain;
+    /**
+     * @var string
+     */
     protected $password;
+    /**
+     * @var string
+     */
     protected $token;
+    /**
+     * @var string
+     */
     protected $oAuthToken;
+    /**
+     * @var string
+     */
     protected $hostname;
+    /**
+     * @var string
+     */
     protected $scheme;
+    /**
+     * @var string
+     */
     protected $port;
+    /**
+     * @var array
+     */
     protected $mockedTransactionsContainer = [];
 
+    /**
+     * {@inheritdoc}
+     */
     public function __construct()
     {
         $this->subdomain  = getenv('SUBDOMAIN');
@@ -67,25 +97,11 @@ abstract class BasicTest extends \PHPUnit_Framework_TestCase
 
     }
 
-    public function authTokenTest()
-    {
-        $tickets = $this->client->tickets()->findAll();
-        $this->assertEquals($this->client->getDebug()->lastResponseCode, '200', 'Does not return HTTP code 200');
-    }
-
-    public function credentialsTest()
-    {
-        $this->assertNotEmpty(
-            $this->subdomain,
-            'Expecting $this->subdomain parameter; does phpunit.xml exist?'
-        );
-        $this->assertNotEmpty($this->token, 'Expecting $this->token parameter; does phpunit.xml exist?');
-        $this->assertNotEmpty(
-            $this->username,
-            'Expecting $this->username parameter; does phpunit.xml exist?'
-        );
-    }
-
+    /**
+     * This checks the last request sent
+     *
+     * @param $options
+     */
     public function assertLastRequestIs($options)
     {
         $this->assertRequestIs($options, count($this->mockedTransactionsContainer) - 1);

--- a/tests/Zendesk/API/UnitTests/BasicTest.php
+++ b/tests/Zendesk/API/UnitTests/BasicTest.php
@@ -25,25 +25,23 @@ abstract class BasicTest extends \PHPUnit_Framework_TestCase
 
     public function __construct()
     {
-        $this->subdomain = getenv('SUBDOMAIN');
-        $this->username = getenv('USERNAME');
-        $this->password = getenv('PASSWORD');
-        $this->token = getenv('TOKEN');
+        $this->subdomain  = getenv('SUBDOMAIN');
+        $this->username   = getenv('USERNAME');
+        $this->token      = getenv('TOKEN');
         $this->oAuthToken = getenv('OAUTH_TOKEN');
-        $this->scheme = getenv('SCHEME');
-        $this->hostname = getenv('HOSTNAME');
-        $this->port = getenv('PORT');
+        $this->scheme     = getenv('SCHEME');
+        $this->hostname   = getenv('HOSTNAME');
+        $this->port       = getenv('PORT');
     }
 
     /**
      * Sets up the fixture, for example, open a network connection.
      * This method is called before a test is executed.
-     *
      */
     protected function setUp()
     {
         $this->client = new HttpClient($this->subdomain, $this->username, $this->scheme, $this->hostname, $this->port);
-        $this->client->setAuth('token', $this->token);
+        $this->client->setAuth('oauth', ['token' => $this->oAuthToken]);
     }
 
     /**
@@ -56,16 +54,17 @@ abstract class BasicTest extends \PHPUnit_Framework_TestCase
     {
         if (empty($responses)) {
             return;
-        } elseif (!is_array($responses)) {
+        } elseif (! is_array($responses)) {
             $responses = [$responses];
         }
 
         $history = Middleware::history($this->mockedTransactionsContainer);
-        $mock = new MockHandler($responses);
+        $mock    = new MockHandler($responses);
         $handler = HandlerStack::create($mock);
         $handler->push($history);
 
         $this->client->guzzle = new Client(['handler' => $handler]);
+
     }
 
     public function authTokenTest()
@@ -101,8 +100,8 @@ abstract class BasicTest extends \PHPUnit_Framework_TestCase
     public function assertRequestIs($options, $index = 0)
     {
         $transaction = $this->mockedTransactionsContainer[$index];
-        $request = $transaction['request'];
-        $response = $transaction['response'];
+        $request     = $transaction['request'];
+        $response    = $transaction['response'];
 
         $options = array_merge([
             'statusCode' => 200,

--- a/tests/Zendesk/API/UnitTests/UsersTest.php
+++ b/tests/Zendesk/API/UnitTests/UsersTest.php
@@ -31,8 +31,8 @@ class UsersTest extends BasicTest
 
         $this->assertLastRequestIs(
             [
-            'method' => 'POST',
-            'endpoint' => 'users.json',
+            'method'     => 'POST',
+            'endpoint'   => 'users.json',
             'postFields' => ['user' => $testUser],
             ]
         );
@@ -52,7 +52,7 @@ class UsersTest extends BasicTest
 
         $this->assertLastRequestIs(
             [
-            'method' => 'DELETE',
+            'method'   => 'DELETE',
             'endpoint' => 'users/12345.json',
             ]
         );
@@ -63,7 +63,7 @@ class UsersTest extends BasicTest
         $response = json_encode(
             [
             'users' => [
-              [ 'id' => 12345 ]
+              ['id' => 12345]
             ]
             ]
         );
@@ -76,7 +76,7 @@ class UsersTest extends BasicTest
 
         $this->assertLastRequestIs(
             [
-            'method' => 'GET',
+            'method'   => 'GET',
             'endpoint' => 'users.json',
             ]
         );
@@ -94,14 +94,14 @@ class UsersTest extends BasicTest
     public function testFind()
     {
         $this->mockAPIResponses([
-          new Response(200, [], json_encode(['user' => ['id' => 12345 ]]))
+          new Response(200, [], json_encode(['user' => ['id' => 12345]]))
         ]);
 
         $user = $this->client->users(12345)->find();
 
         $this->assertLastRequestIs(
             [
-            'method' => 'GET',
+            'method'   => 'GET',
             'endpoint' => 'users/12345.json',
             ]
         );
@@ -129,9 +129,9 @@ class UsersTest extends BasicTest
 
         $this->assertLastRequestIs(
             [
-            'method' => 'GET',
-            'endpoint' => 'users/show_many.json',
-            'queryParams' => ['ids' => implode(",", [$findIds[0], $findIds[1]])] ,
+            'method'      => 'GET',
+            'endpoint'    => 'users/show_many.json',
+            'queryParams' => ['ids' => implode(",", [$findIds[0], $findIds[1]])],
             ]
         );
         $this->assertEquals(is_object($users), true, 'Should return an object');
@@ -142,11 +142,11 @@ class UsersTest extends BasicTest
 
     public function testShowManyUsingIds()
     {
-        $findIds  = [ 12345, 80085 ];
+        $findIds  = [12345, 80085];
         $response = [
           'users' => [
-            [ 'id' => $findIds[0] ],
-            [ 'id' => $findIds[1] ],
+            ['id' => $findIds[0]],
+            ['id' => $findIds[1]],
           ]
         ];
 
@@ -167,11 +167,11 @@ class UsersTest extends BasicTest
 
     public function testShowManyUsingExternalIds()
     {
-        $findIds  = [ 12345, 80085 ];
+        $findIds  = [12345, 80085];
         $response = [
           'users' => [
-            [ 'id' => $findIds[0] ],
-            [ 'id' => $findIds[1] ],
+            ['id' => $findIds[0]],
+            ['id' => $findIds[1]],
           ]
         ];
 
@@ -179,12 +179,12 @@ class UsersTest extends BasicTest
           new Response(200, [], json_encode($response))
         ]);
 
-        $users = $this->client->users()->showMany([ 'external_ids' => $findIds ]);
+        $users = $this->client->users()->showMany(['external_ids' => $findIds]);
 
         $this->assertLastRequestIs(
             [
-            'method' => 'GET',
-            'endpoint' => 'users/show_many.json',
+            'method'      => 'GET',
+            'endpoint'    => 'users/show_many.json',
             'queryParams' => ['external_ids' => implode(',', $findIds)]
             ]
         );
@@ -208,7 +208,7 @@ class UsersTest extends BasicTest
 
         $this->assertLastRequestIs(
             [
-            'method' => 'GET',
+            'method'   => 'GET',
             'endpoint' => 'users/12345/related.json',
             ]
         );
@@ -230,15 +230,15 @@ class UsersTest extends BasicTest
         $postFields = ['id' => 12345];
 
         $this->mockAPIResponses([
-          new Response(200, [], json_encode(['user' => [ 'id' => 12345 ]]))
+          new Response(200, [], json_encode(['user' => ['id' => 12345]]))
         ]);
 
         $this->client->users('me')->merge($postFields);
 
         $this->assertLastRequestIs(
             [
-            'method' => 'PUT',
-            'endpoint' => 'users/me/merge.json',
+            'method'     => 'PUT',
+            'endpoint'   => 'users/me/merge.json',
             'postFields' => [Users::OBJ_NAME => $postFields],
             ]
         );
@@ -267,8 +267,8 @@ class UsersTest extends BasicTest
 
         $this->assertLastRequestIs(
             [
-            'method' => 'POST',
-            'endpoint' => 'users/create_many.json',
+            'method'     => 'POST',
+            'endpoint'   => 'users/create_many.json',
             'postFields' => [Users::OBJ_NAME_PLURAL => $postFields],
             ]
         );
@@ -290,8 +290,8 @@ class UsersTest extends BasicTest
 
         $this->assertLastRequestIs(
             [
-            'method' => 'PUT',
-            'endpoint' => 'users/12345.json',
+            'method'     => 'PUT',
+            'endpoint'   => 'users/12345.json',
             'postFields' => [Users::OBJ_NAME => $postFields],
             ]
         );
@@ -299,7 +299,7 @@ class UsersTest extends BasicTest
 
     public function testUpdateMany()
     {
-        $updateIds     = [ 12345, 80085 ];
+        $updateIds     = [12345, 80085];
         $requestParams = [
           'ids'   => implode(',', $updateIds),
           'phone' => '1234567890'
@@ -313,10 +313,10 @@ class UsersTest extends BasicTest
 
         $this->assertLastRequestIs(
             [
-            'method' => 'PUT',
-            'endpoint' => 'users/update_many.json',
+            'method'      => 'PUT',
+            'endpoint'    => 'users/update_many.json',
             'queryParams' => ['ids' => $requestParams['ids']],
-            'postFields' => [Users::OBJ_NAME => ['phone' => $requestParams['phone']]]
+            'postFields'  => [Users::OBJ_NAME => ['phone' => $requestParams['phone']]]
             ]
         );
 
@@ -347,8 +347,8 @@ class UsersTest extends BasicTest
 
         $this->assertLastRequestIs(
             [
-            'method' => 'PUT',
-            'endpoint' => 'users/update_many.json',
+            'method'     => 'PUT',
+            'endpoint'   => 'users/update_many.json',
             'postFields' => [Users::OBJ_NAME_PLURAL => $requestParams]
             ]
         );
@@ -370,12 +370,12 @@ class UsersTest extends BasicTest
 
         $this->assertLastRequestIs(
             [
-            'method' => 'PUT',
-            'endpoint' => 'users/12345.json',
+            'method'     => 'PUT',
+            'endpoint'   => 'users/12345.json',
             'postFields' => [Users::OBJ_NAME => ['id' => $userId, 'suspended' => true]],
             ]
         );
-        
+
         $this->assertEquals(is_object($user), true, 'Should return an object');
         $this->assertEquals(is_object($user->user), true, 'Should return an object called "user"');
         $this->assertGreaterThan(0, $user->user->id, 'Should return a numeric id for request');
@@ -386,15 +386,15 @@ class UsersTest extends BasicTest
         $queryParams = ['query' => 'Roger'];
 
         $this->mockAPIResponses([
-          new Response(200, [], json_encode(['users' =>[['id' => 12345]]]))
+          new Response(200, [], json_encode(['users' => [['id' => 12345]]]))
         ]);
 
         $users = $this->client->users()->search($queryParams);
 
         $this->assertLastRequestIs(
             [
-            'method' => 'GET',
-            'endpoint' => 'users/search.json',
+            'method'      => 'GET',
+            'endpoint'    => 'users/search.json',
             'queryParams' => $queryParams,
             ]
         );
@@ -416,15 +416,15 @@ class UsersTest extends BasicTest
         $queryParams = ['name' => 'joh'];
 
         $this->mockAPIResponses([
-          new Response(200, [], json_encode(['users' =>[['id' => 12345]]]))
+          new Response(200, [], json_encode(['users' => [['id' => 12345]]]))
         ]);
 
         $users = $this->client->users()->autocomplete($queryParams);
 
         $this->assertLastRequestIs(
             [
-            'method' => 'POST',
-            'endpoint' => 'users/autocomplete.json',
+            'method'      => 'POST',
+            'endpoint'    => 'users/autocomplete.json',
             'queryParams' => $queryParams,
             ]
         );
@@ -441,8 +441,8 @@ class UsersTest extends BasicTest
     public function testUpdateProfileImage()
     {
         $this->markTestSkipped('Need to allow file uploads with Guzzle.');
-        $this->mockApiCall('GET', '/users/12345.json?', array( 'id' => 12345 ));
-        $this->mockApiCall('PUT', '/users/12345.json', array( 'user' => array( 'id' => 12345 ) ));
+        $this->mockApiCall('GET', '/users/12345.json?', array('id' => 12345));
+        $this->mockApiCall('PUT', '/users/12345.json', array('user' => array('id' => 12345)));
 
         $user = $this->client->users(12345)->updateProfileImage(array(
           'file' => getcwd() . '/tests/assets/UK.png'
@@ -466,7 +466,7 @@ class UsersTest extends BasicTest
 
         $this->assertLastRequestIs(
             [
-            'method' => 'GET',
+            'method'   => 'GET',
             'endpoint' => 'users/me.json',
             ]
         );
@@ -488,8 +488,8 @@ class UsersTest extends BasicTest
 
         $this->assertLastRequestIs(
             [
-            'method' => 'POST',
-            'endpoint' => 'users/12345/password.json',
+            'method'     => 'POST',
+            'endpoint'   => 'users/12345/password.json',
             'postFields' => [Users::OBJ_NAME => $postFields],
             ]
         );
@@ -498,9 +498,9 @@ class UsersTest extends BasicTest
     public function testChangePassword()
     {
         $postFields = [
-            'previous_password' => '12346',
-            'password'          => '12345'
-          ];
+          'previous_password' => '12346',
+          'password'          => '12345'
+        ];
 
         $this->mockAPIResponses([
           new Response(200, [], '')
@@ -510,8 +510,8 @@ class UsersTest extends BasicTest
 
         $this->assertLastRequestIs(
             [
-            'method' => 'PUT',
-            'endpoint' => 'users/421450109/password.json',
+            'method'     => 'PUT',
+            'endpoint'   => 'users/421450109/password.json',
             'postFields' => $postFields,
             ]
         );


### PR DESCRIPTION
Add support for basic authentication and oauth token authentication in the client
Add live tests for checking authentication

/cc @joseconsador @jwswj @mmolina @atroche 

### References
 - Jira link: https://zendesk.atlassian.net/browse/MI-105

### Risks
 - We might not be able to authenticate properly with the client (medium)