### PR TITLE
[MI-168] Make exception class display the actual errors returned from the API

### DIFF
--- a/src/Zendesk/API/Exceptions/ApiResponseException.php
+++ b/src/Zendesk/API/Exceptions/ApiResponseException.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Zendesk\API\Exceptions;
+
+use GuzzleHttp\Exception\RequestException;
+
+/**
+ * Class ApiResponseException
+ *
+ * @package Zendesk\API\Exceptions
+ */
+class ApiResponseException extends \Exception
+{
+    /**
+     * @var array
+     */
+    protected $errorDetails = [];
+
+    public function __construct(RequestException $e)
+    {
+        $response = $e->getResponse();
+        $message = $response->getReasonPhrase();
+
+        $level = floor($response->getStatusCode() / 100);
+        // Check if business-level error message
+        // https://developer.zendesk.com/rest_api/docs/core/introduction#requests
+        if ($response->getHeaderLine('Content-Type') == 'application/json; charset=UTF-8') {
+            $responseBody = json_decode($response->getBody()->getContents());
+
+            $this->errorDetails = $responseBody->details;
+            $message = $responseBody->description . "\n" . 'Errors: ' . print_r($this->errorDetails, true);
+        } elseif ($level == '5') {
+            $message = 'Zendesk may be experiencing internal issues or undergoing scheduled maintenance.';
+        }
+
+        parent::__construct($message, $response->getStatusCode());
+    }
+
+    /**
+     * Returns an array of error fields with descriptions.
+     *
+     * {
+     *   "email": [{
+     *       "description": "Email: roge@example.org is already being used by another user",
+     *       "error": "DuplicateValue"
+     *   }],
+     *   "external_id":[{
+     *       "description": "External has already been taken",
+     *       "error": "DuplicateValue"
+     *   }]
+     * }
+     *
+     * @return array
+     */
+    public function getErrorDetails()
+    {
+        return $this->errorDetails;
+    }
+}

--- a/src/Zendesk/API/Exceptions/ResponseException.php
+++ b/src/Zendesk/API/Exceptions/ResponseException.php
@@ -4,15 +4,17 @@ namespace Zendesk\API\Exceptions;
 
 /**
  * ResponseException extends the Exception class with simplified messaging
+ *
  * @package Zendesk\API
  */
 class ResponseException extends \Exception
 {
 
+
     /**
-     * @param string $method
-     * @param string $detail
-     * @param int $code
+     * @param string     $method
+     * @param string     $detail
+     * @param int        $code
      * @param \Exception $previous
      */
     public function __construct($method, $detail = '', $code = 0, \Exception $previous = null)

--- a/src/Zendesk/API/Http.php
+++ b/src/Zendesk/API/Http.php
@@ -2,8 +2,9 @@
 
 namespace Zendesk\API;
 
+use GuzzleHttp\Exception\RequestException;
 use GuzzleHttp\Psr7\Request;
-use Zendesk\API\Exceptions\ResponseException;
+use Zendesk\API\Exceptions\ApiResponseException;
 
 /**
  * HTTP functions via curl
@@ -74,7 +75,7 @@ class Http
 
         $headers = [
             'Accept'       => 'application/json',
-            'Content-Type' => $options['contentType']
+            'Content-Type' => $options['contentType'],
         ];
 
         $request = new Request(
@@ -98,16 +99,14 @@ class Http
         try {
             $response = $client->guzzle->send($request);
 
-            $responseCode = $response->getStatusCode();
-
             $client->setDebug(
                 $response->getHeaders(),
-                $responseCode,
+                $response->getStatusCode(),
                 10,
                 null
             );
-        } catch (\GuzzleHttp\Exception\ClientException $e) {
-            throw new ResponseException($endPoint, null, null, $e);
+        } catch (RequestException $e) {
+            throw new ApiResponseException($e);
         }
 
         return json_decode($response->getBody()->getContents());

--- a/src/Zendesk/API/Resources/TicketForms.php
+++ b/src/Zendesk/API/Resources/TicketForms.php
@@ -74,10 +74,6 @@ class TicketForms extends ResourceAbstract
             ['postFields' => ['ticket_form_ids' => $ticketFormIds], 'method' => 'PUT']
         );
 
-        if ($this->client->getDebug()->lastResponseCode != 200) {
-            throw new ResponseException(__METHOD__);
-        }
-
         $this->client->setSideload(null);
 
         return $response;

--- a/src/Zendesk/API/Resources/Tickets.php
+++ b/src/Zendesk/API/Resources/Tickets.php
@@ -86,11 +86,6 @@ class Tickets extends ResourceAbstract
             ['queryParams' => $queryParams]
         );
 
-        if ((!is_object($response))
-            || ($this->client->getDebug()->lastResponseCode != 200)
-        ) {
-            throw new ResponseException(__METHOD__);
-        }
         $this->client->setSideload(null);
 
         return $response;
@@ -170,9 +165,7 @@ class Tickets extends ResourceAbstract
             $this->client->getSideload($params)
         );
         $response = Http::sendWithOptions($this->client, $endPoint);
-        if ((!is_object($response)) || ($this->client->getDebug()->lastResponseCode != 200)) {
-            throw new ResponseException(__METHOD__);
-        }
+
         $this->client->setSideload(null);
 
         return $response;
@@ -323,16 +316,6 @@ class Tickets extends ResourceAbstract
             $options
         );
 
-        $lastResponseCode = $this->client->getDebug()->lastResponseCode;
-        // Seems to be a bug in the service, it may respond with 422 even when it succeeds
-        if ($lastResponseCode != 200) {
-            $notice = ' (note: there\'s currently a bug in the service so this call may have succeeded;' .
-                'call tickets->find to see if it still exists.)';
-            throw new ResponseException(
-                __METHOD__,
-                ($lastResponseCode == 422 ? $notice : '')
-            );
-        }
         $this->client->setSideload(null);
 
         return $response;
@@ -468,10 +451,6 @@ class Tickets extends ResourceAbstract
                 'postFields' => ['text' => $params['text']]
             ]
         );
-
-        if ((!is_object($response)) || ($this->client->getDebug()->lastResponseCode != 200)) {
-            throw new ResponseException(__METHOD__);
-        }
 
         $this->client->setSideload(null);
 

--- a/src/Zendesk/API/Resources/Users.php
+++ b/src/Zendesk/API/Resources/Users.php
@@ -383,9 +383,7 @@ class Users extends ResourceAbstract
                 ( isset($params['type']) ? $params['type'] : 'application/binary' )
             );
         }
-        if (( ! is_object($response) ) || ( $this->client->getDebug()->lastResponseCode != 200 )) {
-            throw new ResponseException(__METHOD__);
-        }
+
         $this->client->setSideload(null);
 
         return $response;

--- a/tests/Zendesk/API/UnitTests/BasicTest.php
+++ b/tests/Zendesk/API/UnitTests/BasicTest.php
@@ -92,6 +92,12 @@ abstract class BasicTest extends \PHPUnit_Framework_TestCase
         $this->assertRequestIs($options, count($this->mockedTransactionsContainer) - 1);
     }
 
+    /**
+     * This checks the response with the given index
+     *
+     * @param     $options
+     * @param int $index
+     */
     public function assertRequestIs($options, $index = 0)
     {
         $transaction = $this->mockedTransactionsContainer[$index];
@@ -99,11 +105,11 @@ abstract class BasicTest extends \PHPUnit_Framework_TestCase
         $response = $transaction['response'];
 
         $options = array_merge([
-          'statusCode' => 200,
-          'headers' => [
-            'Accept'       => 'application/json',
-            'Content-Type' => 'application/json'
-          ]
+            'statusCode' => 200,
+            'headers'    => [
+                'Accept'       => 'application/json',
+                'Content-Type' => 'application/json'
+            ]
         ], $options);
 
         $this->assertEquals($options['statusCode'], $response->getStatusCode());

--- a/tests/Zendesk/API/UnitTests/ResourceTest.php
+++ b/tests/Zendesk/API/UnitTests/ResourceTest.php
@@ -5,38 +5,38 @@ use GuzzleHttp\Psr7\Response;
 
 class ResourceTest extends BasicTest
 {
-    private $_dummyResource;
+    private $dummyResource;
 
     public function setUp()
     {
         parent::setUp();
-        $this->_dummyResource = new DummyResource($this->client);
+        $this->dummyResource = new DummyResource($this->client);
     }
 
     public function testFindAll()
     {
         $this->mockAPIResponses([
-          new Response(200, [], '')
+            new Response(200, [], '')
         ]);
 
-        $this->_dummyResource->findAll();
+        $this->dummyResource->findAll();
 
         $this->assertLastRequestIs([
-            'method' => 'GET',
+            'method'   => 'GET',
             'endpoint' => 'dummyresource.json',
-          ]);
+        ]);
     }
 
     public function testFind()
     {
         $this->mockAPIResponses([
-          new Response(200, [], json_encode(['dummy' => true]))
+            new Response(200, [], json_encode(['dummy' => true]))
         ]);
 
-        $this->_dummyResource->find(1);
+        $this->dummyResource->find(1);
 
         $this->assertLastRequestIs([
-            'method' => 'GET',
+            'method'   => 'GET',
             'endpoint' => 'dummyresource/1.json',
         ]);
     }
@@ -44,18 +44,18 @@ class ResourceTest extends BasicTest
     public function testCreate()
     {
         $this->mockAPIResponses([
-          new Response(200, [], '')
+            new Response(200, [], '')
         ]);
 
         $postFields = ['foo' => 'test body'];
 
-        $this->_dummyResource->create($postFields);
+        $this->dummyResource->create($postFields);
 
         $this->assertLastRequestIs(
             [
-            'method' => 'POST',
-            'endpoint' => 'dummyresource.json',
-            'postFields' => ['dummy' => $postFields]
+                'method'     => 'POST',
+                'endpoint'   => 'dummyresource.json',
+                'postFields' => ['dummy' => $postFields]
             ]
         );
     }
@@ -63,17 +63,17 @@ class ResourceTest extends BasicTest
     public function testUpdate()
     {
         $this->mockAPIResponses([
-          new Response(200, [], '')
+            new Response(200, [], '')
         ]);
 
         $postFields = ['foo' => 'test body'];
-        $this->_dummyResource->update(1, $postFields);
+        $this->dummyResource->update(1, $postFields);
 
         $this->assertLastRequestIs(
             [
-              'method' => 'PUT',
-              'endpoint' => 'dummyresource/1.json',
-              'postFields' => ['dummy' => $postFields],
+                'method'     => 'PUT',
+                'endpoint'   => 'dummyresource/1.json',
+                'postFields' => ['dummy' => $postFields],
             ]
         );
     }
@@ -81,16 +81,42 @@ class ResourceTest extends BasicTest
     public function testDelete()
     {
         $this->mockAPIResponses([
-          new Response(200, [], '')
+            new Response(200, [], '')
         ]);
 
-        $this->_dummyResource->delete(1);
+        $this->dummyResource->delete(1);
 
         $this->assertLastRequestIs(
             [
-              'method' => 'DELETE',
-              'endpoint' => 'dummyresource/1.json'
+                'method'   => 'DELETE',
+                'endpoint' => 'dummyresource/1.json'
             ]
         );
+    }
+
+    /**
+     * @expectedException Zendesk\API\Exceptions\ApiResponseException
+     * @expectedExceptionMessage Zendesk may be experiencing internal issues or undergoing scheduled maintenance.
+     */
+    public function testHandlesServerException()
+    {
+        $this->mockApiResponses(
+            new Response(500, [], '')
+        );
+
+        $this->dummyResource->create(['foo' => 'bar']);
+    }
+
+    /**
+     * @expectedException Zendesk\API\Exceptions\ApiResponseException
+     * @expectedExceptionMessage Unprocessable Entity
+     */
+    public function testHandlesApiException()
+    {
+        $this->mockApiResponses(
+            new Response(422, [], '')
+        );
+
+        $this->dummyResource->create(['foo' => 'bar']);
     }
 }

--- a/tests/Zendesk/API/UnitTests/TicketFormsTest.php
+++ b/tests/Zendesk/API/UnitTests/TicketFormsTest.php
@@ -10,7 +10,7 @@ use GuzzleHttp\Psr7\Response;
 class TicketFormsTest extends BasicTest
 {
     /**
-     * @expectedException Zendesk\API\Exceptions\ResponseException
+     * @expectedException Zendesk\API\Exceptions\ApiResponseException
      */
     public function testDeleteThrowsException()
     {


### PR DESCRIPTION
Make the exception class display the actual errors returned from the API
This gives more readability to the thrown error.

Sample exception:

![screen shot 2015-06-26 at 3 26 36 pm](https://cloud.githubusercontent.com/assets/1302819/8373344/8d1c3d7a-1c1e-11e5-9f41-d00e064b3220.png)

/cc @miogalang @jwswj @mmolina @atroche 
 
### References
 - Jira link: https://zendesk.atlassian.net/browse/MI-168

### Risks
 - Medium - The API or codebase might return an error that is not in the expected json format