### PR TITLE
Add retry to composer install for dealing with network issues on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,8 @@ php:
   - 5.5
   # - 5.4
   # - hhvm
-install: composer self-update && composer install
+install:
+  - travis_retry composer self-update && composer install
 script:
   - vendor/bin/phpunit --testsuite "Zendesk API Unit Test Suites"
   - vendor/bin/phpcs --extensions=php --standard=PSR2 --report=summary -np src/ tests/


### PR DESCRIPTION
Add retry when installing composer dependencies to prevent composer network errors on travis.
This will retry the command three times before failing.

/cc @joseconsador @jwswj @mmolina @atroche 

### References
 - Jira link: 

### Risks
 - The travis builds might fail (Low)