### PR TITLE
Add bulk traits

### DIFF
--- a/src/Zendesk/API/BulkTraits/BulkCreateTrait.php
+++ b/src/Zendesk/API/BulkTraits/BulkCreateTrait.php
@@ -11,7 +11,7 @@ use Zendesk\API\Exceptions\RouteException;
 trait BulkCreateTrait
 {
     /**
-     * Create multiple new respirces
+     * Create multiple new resources
      *
      * @param array $params
      *

--- a/src/Zendesk/API/BulkTraits/BulkCreateTrait.php
+++ b/src/Zendesk/API/BulkTraits/BulkCreateTrait.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Zendesk\API\BulkTraits;
+
+use Zendesk\API\Exceptions\RouteException;
+
+/**
+ * Allows resources to call a bulk create endpoint.
+ *
+ * @package Zendesk\API\BulkTraits
+ */
+trait BulkCreateTrait
+{
+    /**
+     * Create multiple new respirces
+     *
+     * @param array $params
+     *
+     * @throws ResponseException
+     * @throws \Exception
+     *
+     * @return mixed
+     */
+    public function createMany(array $params)
+    {
+        try {
+            $route = $this->getRoute(__FUNCTION__);
+        } catch (RouteException $e) {
+            if (!isset($this->resourceName)) {
+                $this->resourceName = $this->getResourceNameFromClass();
+            }
+
+            $route = $this->resourceName . '/create_many.json';
+            $this->setRoute('createMany', $route);
+        }
+
+        return $this->client->post($route, [self::OBJ_NAME_PLURAL => $params]);
+    }
+}

--- a/src/Zendesk/API/BulkTraits/BulkCreateTrait.php
+++ b/src/Zendesk/API/BulkTraits/BulkCreateTrait.php
@@ -7,7 +7,6 @@ use Zendesk\API\Exceptions\RouteException;
 /**
  * Allows resources to call a bulk create endpoint.
  *
- * @package Zendesk\API\BulkTraits
  */
 trait BulkCreateTrait
 {
@@ -26,7 +25,7 @@ trait BulkCreateTrait
         try {
             $route = $this->getRoute(__FUNCTION__);
         } catch (RouteException $e) {
-            if (!isset($this->resourceName)) {
+            if (! isset($this->resourceName)) {
                 $this->resourceName = $this->getResourceNameFromClass();
             }
 

--- a/src/Zendesk/API/BulkTraits/BulkDeleteTrait.php
+++ b/src/Zendesk/API/BulkTraits/BulkDeleteTrait.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Zendesk\API\BulkTraits;
+
+use Zendesk\API\Exceptions\RouteException;
+use Zendesk\API\Http;
+
+/**
+ * Allows resources to call a bulk destrpu endpoint.
+ *
+ */
+trait BulkDeleteTrait
+{
+    /**
+     * Show multiple resources
+     *
+     * @param array  $ids Array of IDs to delete
+     * @param string $key Could be `id` or `external_id`
+     *
+     * @return mixed
+     *
+     */
+    public function deleteMany(array $ids = [], $key = 'ids')
+    {
+        try {
+            $route = $this->getRoute(__FUNCTION__);
+        } catch (RouteException $e) {
+            if (! isset($this->resourceName)) {
+                $this->resourceName = $this->getResourceNameFromClass();
+            }
+
+            $route = $this->resourceName . '/destroy_many.json';
+            $this->setRoute('', $route);
+        }
+
+        $response = Http::sendWithOptions(
+            $this->client,
+            $route,
+            [
+                'method'      => 'DELETE',
+                'queryParams' => [$key => implode(',', $ids)]
+            ]
+        );
+
+        $this->client->setSideload(null);
+
+        return $response;
+    }
+}

--- a/src/Zendesk/API/BulkTraits/BulkFindTrait.php
+++ b/src/Zendesk/API/BulkTraits/BulkFindTrait.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Zendesk\API\BulkTraits;
+
+use Zendesk\API\Exceptions\RouteException;
+
+/**
+ * Allows resources to call a bulk show endpoint.
+ *
+ */
+trait BulkFindTrait
+{
+    /**
+     * Show multiple resources
+     *
+     * @param array  $ids         Array of IDs to fetch
+     * @param array  $extraParams Extra query parameters such as sideloads and iterators
+     * @param string $key         Could be `id` or `external_id`
+     *
+     * @return mixed
+     * @internal param array $params Key-value pair of values to pass to the query string
+     *
+     */
+    public function findMany(array $ids = [], $extraParams = [], $key = 'ids')
+    {
+        try {
+            $route = $this->getRoute(__FUNCTION__);
+        } catch (RouteException $e) {
+            if (! isset($this->resourceName)) {
+                $this->resourceName = $this->getResourceNameFromClass();
+            }
+
+            $route = $this->resourceName . '/show_many.json';
+            $this->setRoute('findMany', $route);
+        }
+
+        $queryParams = [];
+
+        if (count($ids) > 0) {
+            $queryParams[$key] = implode(',', $ids);
+        }
+
+        return $this->client->get($route, array_merge($queryParams, $extraParams));
+    }
+}

--- a/src/Zendesk/API/BulkTraits/BulkUpdateTrait.php
+++ b/src/Zendesk/API/BulkTraits/BulkUpdateTrait.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Zendesk\API\BulkTraits;
+
+use Zendesk\API\Exceptions\RouteException;
+use Zendesk\API\Http;
+
+/**
+ * Allows resources to call a bulk show endpoint.
+ *
+ */
+trait BulkUpdateTrait
+{
+
+    /**
+     * Update group of resources
+     *
+     * @param array  $params
+     * @param string $key Could be `id` or `external_id`
+     *
+     * @return mixed
+     */
+    public function updateMany(array $params, $key = 'ids')
+    {
+        try {
+            $route = $this->getRoute(__FUNCTION__);
+        } catch (RouteException $e) {
+            if (! isset($this->resourceName)) {
+                $this->resourceName = $this->getResourceNameFromClass();
+            }
+
+            $route = $this->resourceName . '/update_many.json';
+            $this->setRoute('updateMany', $route);
+        }
+
+        $resourceUpdateName = self::OBJ_NAME_PLURAL;
+        $queryParams        = [];
+        if (isset($params[$key]) && is_array($params[$key])) {
+            $queryParams[$key] = implode(",", $params[$key]);
+            unset($params[$key]);
+
+            $resourceUpdateName = self::OBJ_NAME;
+        }
+
+        $response = Http::sendWithOptions(
+            $this->client,
+            $route,
+            [
+                'queryParams' => $queryParams,
+                'postFields'  => [$resourceUpdateName => $params],
+                'method'      => 'PUT'
+            ]
+        );
+
+        $this->client->setSideload(null);
+
+        return $response;
+    }
+}

--- a/src/Zendesk/API/Exceptions/RouteException.php
+++ b/src/Zendesk/API/Exceptions/RouteException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Zendesk\API\Exceptions;
+
+class RouteException extends \Exception
+{
+}

--- a/src/Zendesk/API/HttpClient.php
+++ b/src/Zendesk/API/HttpClient.php
@@ -144,10 +144,10 @@ class HttpClient
         }
 
         $this->subdomain = $subdomain;
-        $this->username = $username;
-        $this->hostname = $hostname;
-        $this->scheme = $scheme;
-        $this->port = $port;
+        $this->username  = $username;
+        $this->hostname  = $hostname;
+        $this->scheme    = $scheme;
+        $this->port      = $port;
 
         if (empty($subdomain)) {
             $this->apiUrl = "$scheme://$hostname:$port/api/{$this->apiVer}/";
@@ -186,7 +186,7 @@ class HttpClient
     public function setAuth($strategy, array $options)
     {
         $validAuthStrategies = [self::AUTH_BASIC, self::AUTH_OAUTH];
-        if (!in_array($strategy, $validAuthStrategies)) {
+        if (! in_array($strategy, $validAuthStrategies)) {
             throw new AuthException('Invalid auth strategy set, please use `'
                                     . implode('` or `', $validAuthStrategies)
                                     . '`');
@@ -195,11 +195,11 @@ class HttpClient
         $this->authStrategy = $strategy;
 
         if ($strategy == self::AUTH_BASIC) {
-            if (!array_key_exists('username', $options) || !array_key_exists('token', $options)) {
+            if (! array_key_exists('username', $options) || ! array_key_exists('token', $options)) {
                 throw new AuthException('Please supply `username` and `token` for basic auth.');
             }
         } elseif ($strategy == self::AUTH_OAUTH) {
-            if (!array_key_exists('token', $options)) {
+            if (! array_key_exists('token', $options)) {
                 throw new AuthException('Please supply `token` for oauth.');
             }
         }
@@ -253,10 +253,10 @@ class HttpClient
      */
     public function setDebug($lastRequestHeaders, $lastResponseCode, $lastResponseHeaders, $lastResponseError)
     {
-        $this->debug->lastRequestHeaders = $lastRequestHeaders;
-        $this->debug->lastResponseCode = $lastResponseCode;
+        $this->debug->lastRequestHeaders  = $lastRequestHeaders;
+        $this->debug->lastResponseCode    = $lastResponseCode;
         $this->debug->lastResponseHeaders = $lastResponseHeaders;
-        $this->debug->lastResponseError = $lastResponseError;
+        $this->debug->lastResponseError   = $lastResponseError;
     }
 
     /**

--- a/src/Zendesk/API/HttpClient.php
+++ b/src/Zendesk/API/HttpClient.php
@@ -370,7 +370,11 @@ class HttpClient
     {
         $sideloads = $this->getSideload($queryParams);
 
-        $queryParams = $queryParams + Http::prepareQueryParams($sideloads, $queryParams);
+        // TODO: filter allowed query params
+        if (is_array($sideloads)) {
+            $queryParams['include'] = implode(',', $sideloads);
+            unset($queryParams['sideload']);
+        }
 
         $response = Http::sendWithOptions(
             $this,

--- a/src/Zendesk/API/HttpClient.php
+++ b/src/Zendesk/API/HttpClient.php
@@ -144,10 +144,10 @@ class HttpClient
         }
 
         $this->subdomain = $subdomain;
-        $this->username  = $username;
-        $this->hostname  = $hostname;
-        $this->scheme    = $scheme;
-        $this->port      = $port;
+        $this->username = $username;
+        $this->hostname = $hostname;
+        $this->scheme = $scheme;
+        $this->port = $port;
 
         if (empty($subdomain)) {
             $this->apiUrl = "$scheme://$hostname:$port/api/{$this->apiVer}/";
@@ -186,7 +186,7 @@ class HttpClient
     public function setAuth($strategy, array $options)
     {
         $validAuthStrategies = [self::AUTH_BASIC, self::AUTH_OAUTH];
-        if (! in_array($strategy, $validAuthStrategies)) {
+        if (!in_array($strategy, $validAuthStrategies)) {
             throw new AuthException('Invalid auth strategy set, please use `'
                                     . implode('` or `', $validAuthStrategies)
                                     . '`');
@@ -195,11 +195,11 @@ class HttpClient
         $this->authStrategy = $strategy;
 
         if ($strategy == self::AUTH_BASIC) {
-            if (! array_key_exists('username', $options) || ! array_key_exists('token', $options)) {
+            if (!array_key_exists('username', $options) || !array_key_exists('token', $options)) {
                 throw new AuthException('Please supply `username` and `token` for basic auth.');
             }
         } elseif ($strategy == self::AUTH_OAUTH) {
-            if (! array_key_exists('token', $options)) {
+            if (!array_key_exists('token', $options)) {
                 throw new AuthException('Please supply `token` for oauth.');
             }
         }
@@ -253,10 +253,10 @@ class HttpClient
      */
     public function setDebug($lastRequestHeaders, $lastResponseCode, $lastResponseHeaders, $lastResponseError)
     {
-        $this->debug->lastRequestHeaders  = $lastRequestHeaders;
-        $this->debug->lastResponseCode    = $lastResponseCode;
+        $this->debug->lastRequestHeaders = $lastRequestHeaders;
+        $this->debug->lastResponseCode = $lastResponseCode;
         $this->debug->lastResponseHeaders = $lastResponseHeaders;
-        $this->debug->lastResponseError   = $lastResponseError;
+        $this->debug->lastResponseError = $lastResponseError;
     }
 
     /**
@@ -364,5 +364,64 @@ class HttpClient
     public function anonymousSearch(array $params)
     {
         return $this->search->anonymousSearch($params);
+    }
+
+    public function get($endpoint, $queryParams = [])
+    {
+        $sideloads = $this->getSideload($queryParams);
+
+        $queryParams = $queryParams + Http::prepareQueryParams($sideloads, $queryParams);
+
+        $response = Http::sendWithOptions(
+            $this,
+            $endpoint,
+            ['queryParams' => $queryParams]
+        );
+
+        $this->setSideload(null);
+
+        return $response;
+    }
+
+    public function post($endpoint, $postData = [])
+    {
+        $response = Http::sendWithOptions(
+            $this,
+            $endpoint,
+            [
+                'postFields' => $postData,
+                'method'     => 'POST'
+            ]
+        );
+
+        $this->setSideload(null);
+
+        return $response;
+    }
+
+    public function put($endpoint, $putData = [])
+    {
+        $response = Http::sendWithOptions(
+            $this,
+            $endpoint,
+            ['postFields' => $putData, 'method' => 'PUT']
+        );
+
+        $this->setSideload(null);
+
+        return $response;
+    }
+
+    public function delete($endpoint)
+    {
+        $response = Http::sendWithOptions(
+            $this,
+            $endpoint,
+            ['method' => 'DELETE']
+        );
+
+        $this->setSideload(null);
+
+        return $response;
     }
 }

--- a/src/Zendesk/API/Resources/Automations.php
+++ b/src/Zendesk/API/Resources/Automations.php
@@ -2,10 +2,9 @@
 
 namespace Zendesk\API\Resources;
 
-use Zendesk\API\Http;
-
 /**
  * The Automations class exposes methods seen at http://developer.zendesk.com/documentation/rest_api/automations.html
+ *
  * @package Zendesk\API
  */
 class Automations extends ResourceAbstract
@@ -30,20 +29,8 @@ class Automations extends ResourceAbstract
      * @throws \Exception
      * @return mixed
      */
-    public function findActive(array $params = array())
+    public function findActive(array $params = [])
     {
-        $sideloads = $this->client->getSideload($params);
-
-        $queryParams = Http::prepareQueryParams($sideloads, $params);
-
-        $response = Http::sendWithOptions(
-            $this->client,
-            $this->getRoute(__FUNCTION__, $params),
-            ['queryParams' => $queryParams]
-        );
-
-        $this->client->setSideload(null);
-
-        return $response;
+        return $this->client->get($this->getRoute(__FUNCTION__), $params);
     }
 }

--- a/src/Zendesk/API/Resources/Groups.php
+++ b/src/Zendesk/API/Resources/Groups.php
@@ -2,7 +2,6 @@
 
 namespace Zendesk\API\Resources;
 
-use Zendesk\API\Http;
 use Zendesk\API\UtilityTraits\InstantiatorTrait;
 
 class Groups extends ResourceAbstract
@@ -41,7 +40,7 @@ class Groups extends ResourceAbstract
         if (empty($lastChained) || $name !== 'findAll') {
             return parent::getRoute($name, $params);
         } else {
-            $id = reset($lastChained);
+            $id       = reset($lastChained);
             $resource = $chainedResourceNames[0]::OBJ_NAME_PLURAL;
 
             if ('users' === $resource) {
@@ -59,12 +58,6 @@ class Groups extends ResourceAbstract
      */
     public function assignable()
     {
-        $response = Http::sendWithOptions(
-            $this->client,
-            $this->getRoute(__FUNCTION__)
-        );
-        $this->client->setSideload(null);
-
-        return $response;
+        return $this->client->get($this->getRoute(__FUNCTION__));
     }
 }

--- a/src/Zendesk/API/Resources/HelpCenter/Categories.php
+++ b/src/Zendesk/API/Resources/HelpCenter/Categories.php
@@ -1,9 +1,0 @@
-<?php
- Zendesk\API\Resources\HelpCenter;
-
-use Zendesk\API\Resources\ResourceAbstract;
-
-class Categories extends ResourceAbstract
-{
-    public function
-}

--- a/src/Zendesk/API/Resources/HelpCenter/Categories.php
+++ b/src/Zendesk/API/Resources/HelpCenter/Categories.php
@@ -1,0 +1,9 @@
+<?php
+ Zendesk\API\Resources\HelpCenter;
+
+use Zendesk\API\Resources\ResourceAbstract;
+
+class Categories extends ResourceAbstract
+{
+    public function
+}

--- a/src/Zendesk/API/Resources/Macros.php
+++ b/src/Zendesk/API/Resources/Macros.php
@@ -37,15 +37,7 @@ class Macros extends ResourceAbstract
      */
     public function findAllActive(array $params = [])
     {
-        $sideloads = $this->client->getSideload($params);
-
-        $queryParams = Http::prepareQueryParams($sideloads, $params);
-
-        $response = Http::sendWithOptions(
-            $this->client,
-            $this->getRoute(__FUNCTION__, $params),
-            ['queryParams' => $queryParams]
-        );
+        return $this->client->get($this->getRoute(__FUNCTION__), $params);
 
         $this->client->setSideload(null);
 
@@ -106,12 +98,6 @@ class Macros extends ResourceAbstract
             throw new MissingParametersException(__METHOD__, ['id', 'ticketId']);
         }
 
-        $response = Http::sendWithOptions(
-            $this->client,
-            $this->getRoute(__FUNCTION__, ['id' => $id, 'ticketId' => $ticketId])
-        );
-        $this->client->setSideload(null);
-
-        return $response;
+        return $this->client->get($this->getRoute(__FUNCTION__, ['id' => $id, 'ticketId' => $ticketId]));
     }
 }

--- a/src/Zendesk/API/Resources/Macros.php
+++ b/src/Zendesk/API/Resources/Macros.php
@@ -3,7 +3,6 @@
 namespace Zendesk\API\Resources;
 
 use Zendesk\API\Exceptions\MissingParametersException;
-use Zendesk\API\Http;
 
 /**
  * The Macros class exposes methods seen at http://developer.zendesk.com/documentation/rest_api/macros.html
@@ -38,10 +37,6 @@ class Macros extends ResourceAbstract
     public function findAllActive(array $params = [])
     {
         return $this->client->get($this->getRoute(__FUNCTION__), $params);
-
-        $this->client->setSideload(null);
-
-        return $response;
     }
 
     /**
@@ -64,13 +59,9 @@ class Macros extends ResourceAbstract
             throw new MissingParametersException(__METHOD__, ['id']);
         }
 
-        $response = Http::sendWithOptions(
-            $this->client,
+        return $this->client->get(
             $this->getRoute(__FUNCTION__, ['id' => $id])
         );
-        $this->client->setSideload(null);
-
-        return $response;
     }
 
     /**
@@ -98,6 +89,8 @@ class Macros extends ResourceAbstract
             throw new MissingParametersException(__METHOD__, ['id', 'ticketId']);
         }
 
-        return $this->client->get($this->getRoute(__FUNCTION__, ['id' => $id, 'ticketId' => $ticketId]));
+        return $this->client->get(
+            $this->getRoute(__FUNCTION__, ['id' => $id, 'ticketId' => $ticketId])
+        );
     }
 }

--- a/src/Zendesk/API/Resources/ResourceAbstract.php
+++ b/src/Zendesk/API/Resources/ResourceAbstract.php
@@ -9,6 +9,7 @@ use Zendesk\API\UtilityTraits\ChainedParametersTrait;
 
 /**
  * Abstract class for all endpoints
+ *
  * @package Zendesk\API
  */
 abstract class ResourceAbstract
@@ -62,6 +63,7 @@ abstract class ResourceAbstract
      *    Where ticket would have a comments as a valid sub resource.
      *    The array would look like:
      *      ['comments' => '\Zendesk\API\Resources\TicketComments']
+     *
      * @return array
      */
     public static function getValidSubResource()
@@ -71,6 +73,7 @@ abstract class ResourceAbstract
 
     /**
      * Return the resource name using the name of the class (used for endpoints)
+     *
      * @return string
      */
     private function getResourceNameFromClass()
@@ -120,6 +123,7 @@ abstract class ResourceAbstract
 
     /**
      * Saves an id for future methods in the chain
+     *
      * @return int
      */
     public function getLastId()
@@ -204,6 +208,7 @@ abstract class ResourceAbstract
 
     /**
      * Return all routes for this resource
+     *
      * @return array
      */
     public function getRoutes()
@@ -223,7 +228,7 @@ abstract class ResourceAbstract
      */
     public function getRoute($name, array $params = [])
     {
-        if (!isset($this->routes[$name])) {
+        if (! isset($this->routes[$name])) {
             throw new RouteException('Route not found.');
         }
 

--- a/src/Zendesk/API/Resources/TicketAudits.php
+++ b/src/Zendesk/API/Resources/TicketAudits.php
@@ -6,6 +6,7 @@ use Zendesk\API\Exceptions\MissingParametersException;
 
 /**
  * The TicketAudits class exposes read only audit methods
+ *
  * @package Zendesk\API
  */
 class TicketAudits extends ResourceAbstract
@@ -22,8 +23,8 @@ class TicketAudits extends ResourceAbstract
         parent::setUpRoutes();
 
         $this->setRoutes([
-          'findAll' => 'tickets/{ticket_id}/audits.json',
-          'find'    => 'tickets/{ticket_id}/audits/{id}.json',
+            'findAll' => 'tickets/{ticket_id}/audits.json',
+            'find'    => 'tickets/{ticket_id}/audits/{id}.json',
         ]);
     }
 
@@ -35,12 +36,15 @@ class TicketAudits extends ResourceAbstract
      * @return mixed
      * @throws MissingParametersException
      */
-    public function findAll(array $params = array())
+    public function findAll(array $params = [])
     {
-        $params = $this->addChainedParametersToParams($params, ['ticket_id' => Tickets::class]);
-        if (! $this->hasKeys($params, array('ticket_id'))) {
-            throw new MissingParametersException(__METHOD__, array('ticket_id'));
+        $routeParams = $this->addChainedParametersToParams($params, ['ticket_id' => Tickets::class]);
+
+        if (!$this->hasKeys($routeParams, ['ticket_id'])) {
+            throw new MissingParametersException(__METHOD__, ['ticket_id']);
         }
+
+        $this->setAdditionalRouteParams($routeParams);
 
         return parent::findAll($params);
     }
@@ -55,7 +59,7 @@ class TicketAudits extends ResourceAbstract
      *
      * @return mixed
      */
-    public function find($id = null, array $params = array())
+    public function find($id = null, array $params = [])
     {
         if (empty($id)) {
             $id = $this->getChainedParameter(get_class($this));
@@ -64,12 +68,12 @@ class TicketAudits extends ResourceAbstract
         $params = $this->addChainedParametersToParams(
             $params,
             [
-            'ticket_id' => Tickets::class,
+                'ticket_id' => Tickets::class,
             ]
         );
 
-        if (! $this->hasKeys($params, array('ticket_id'))) {
-            throw new MissingParametersException(__METHOD__, array('ticket_id'));
+        if (!$this->hasKeys($params, ['ticket_id'])) {
+            throw new MissingParametersException(__METHOD__, ['ticket_id']);
         }
 
         $this->setAdditionalRouteParams(['ticket_id' => $params['ticket_id']]);

--- a/src/Zendesk/API/Resources/TicketComments.php
+++ b/src/Zendesk/API/Resources/TicketComments.php
@@ -4,10 +4,10 @@ namespace Zendesk\API\Resources;
 
 use Zendesk\API\Exceptions\CustomException;
 use Zendesk\API\Exceptions\MissingParametersException;
-use Zendesk\API\Http;
 
 /**
  * The TicketComments class exposes comment methods for tickets
+ *
  * @package Zendesk\API
  */
 class TicketComments extends ResourceAbstract
@@ -20,8 +20,8 @@ class TicketComments extends ResourceAbstract
     {
         $this->setRoutes(
             [
-            'findAll'     => 'tickets/{ticket_id}/comments.json',
-            'makePrivate' => 'tickets/{ticket_id}/comments/{id}/make_private.json'
+                'findAll'     => 'tickets/{ticket_id}/comments.json',
+                'makePrivate' => 'tickets/{ticket_id}/comments/{id}/make_private.json'
             ]
         );
     }
@@ -36,12 +36,12 @@ class TicketComments extends ResourceAbstract
      *
      * @return mixed
      */
-    public function findAll(array $queryParams = array())
+    public function findAll(array $queryParams = [])
     {
-        $queryParams = $this->addChainedParametersToParams($queryParams, [ 'ticket_id' => Tickets::class ]);
+        $queryParams = $this->addChainedParametersToParams($queryParams, ['ticket_id' => Tickets::class]);
 
-        if (! $this->hasKeys($queryParams, array( 'ticket_id' ))) {
-            throw new MissingParametersException(__METHOD__, array( 'ticket_id' ));
+        if (!$this->hasKeys($queryParams, ['ticket_id'])) {
+            throw new MissingParametersException(__METHOD__, ['ticket_id']);
         }
 
         return parent::findAll($queryParams);
@@ -57,26 +57,18 @@ class TicketComments extends ResourceAbstract
      *
      * @return mixed
      */
-    public function makePrivate(array $params = array())
+    public function makePrivate(array $params = [])
     {
         $params = $this->addChainedParametersToParams(
             $params,
-            [ 'id' => get_class($this), 'ticket_id' => Tickets::class ]
+            ['id' => get_class($this), 'ticket_id' => Tickets::class]
         );
 
-        if (! $this->hasKeys($params, array( 'id', 'ticket_id' ))) {
-            throw new MissingParametersException(__METHOD__, array( 'id', 'ticket_id' ));
+        if (!$this->hasKeys($params, ['id', 'ticket_id'])) {
+            throw new MissingParametersException(__METHOD__, ['id', 'ticket_id']);
         }
 
-        $response = Http::sendWithOptions(
-            $this->client,
-            $this->getRoute(__FUNCTION__, $params),
-            [ 'method' => 'PUT' ]
-        );
-
-        $this->client->setSideload(null);
-
-        return $response;
+        return $this->client->put($this->getRoute(__FUNCTION__, $params), $params);
     }
 
     /*
@@ -90,8 +82,9 @@ class TicketComments extends ResourceAbstract
      * @return mixed|void
      * @throws CustomException
      */
-    public function find($id = null, array $queryQueryParams = array())
+    public function find($id = null, array $queryQueryParams = [])
     {
-        throw new CustomException('Method ' . __METHOD__ . ' does not exist. Try $client->ticket(ticket_id)->comments()->findAll() instead.');
+        throw new CustomException('Method ' . __METHOD__
+            . ' does not exist. Try $client->ticket(ticket_id)->comments()->findAll() instead.');
     }
 }

--- a/src/Zendesk/API/Resources/TicketForms.php
+++ b/src/Zendesk/API/Resources/TicketForms.php
@@ -18,8 +18,8 @@ class TicketForms extends ResourceAbstract
         parent::setUpRoutes();
 
         $this->setRoutes([
-          'clone'   => 'ticket_forms/{id}/clone.json',
-          'reorder' => 'ticket_forms/reorder.json'
+            'clone'   => 'ticket_forms/{id}/clone.json',
+            'reorder' => 'ticket_forms/reorder.json'
         ]);
     }
 
@@ -44,15 +44,7 @@ class TicketForms extends ResourceAbstract
             throw new MissingParametersException(__METHOD__, ['id']);
         }
 
-        $response = Http::sendWithOptions(
-            $this->client,
-            $this->getRoute('clone', ['id' => $id]),
-            ['method' => 'POST']
-        );
-
-        $this->client->setSideload(null);
-
-        return $response;
+        return $this->client->post($this->getRoute('clone', ['id' => $id]));
     }
 
     /**

--- a/src/Zendesk/API/Resources/Triggers.php
+++ b/src/Zendesk/API/Resources/Triggers.php
@@ -1,8 +1,6 @@
 <?php
 namespace Zendesk\API\Resources;
 
-use Zendesk\API\Http;
-
 /**
  * The Triggers class exposes field management methods for triggers
  */
@@ -20,18 +18,6 @@ class Triggers extends ResourceAbstract
 
     public function findActive($params = [])
     {
-        $sideloads = $this->client->getSideload($params);
-
-        $queryParams = Http::prepareQueryParams($sideloads, $params);
-
-        $response = Http::sendWithOptions(
-            $this->client,
-            $this->getRoute(__FUNCTION__, $params),
-            ['queryParams' => $queryParams]
-        );
-
-        $this->client->setSideload(null);
-
-        return $response;
+        return $this->client->get($this->getRoute(__FUNCTION__), $params);
     }
 }

--- a/src/Zendesk/API/Resources/Users.php
+++ b/src/Zendesk/API/Resources/Users.php
@@ -3,6 +3,7 @@
 namespace Zendesk\API\Resources;
 
 use Zendesk\API\BulkTraits\BulkCreateTrait;
+use Zendesk\API\BulkTraits\BulkUpdateTrait;
 use Zendesk\API\Exceptions\CustomException;
 use Zendesk\API\Exceptions\MissingParametersException;
 use Zendesk\API\Exceptions\ResponseException;
@@ -22,6 +23,7 @@ class Users extends ResourceAbstract
     const OBJ_NAME_PLURAL = 'users';
 
     use BulkCreateTrait;
+    use BulkUpdateTrait;
 
     /**
      * @var UserIdentities
@@ -213,60 +215,7 @@ class Users extends ResourceAbstract
      *
      * @throws MissingParametersException
      * @throws ResponseException
-     * @throws \Exception
-     * @return mixed
-     */
-
-    public function updateMany(array $params)
-    {
-        if (! $this->hasKeys($params, ['ids'])) {
-            throw new MissingParametersException(__METHOD__, ['ids']);
-        }
-        $ids = $params['ids'];
-        unset($params['ids']);
-        $response = Http::sendWithOptions(
-            $this->client,
-            $this->getRoute(__FUNCTION__),
-            ['postFields' => [self::OBJ_NAME => $params], 'queryParams' => ['ids' => $ids], 'method' => 'PUT']
-        );
-
-        $this->client->setSideload(null);
-
-        return $response;
-    }
-
-    /**
-     * Update multiple individual users
      *
-     * @param array $params
-     *
-     * @throws MissingParametersException
-     * @throws ResponseException
-     * @throws \Exception
-     * @return mixed
-     */
-
-    public function updateManyIndividualUsers(array $params)
-    {
-        $this->setRoute(__METHOD__, 'users/update_many.json');
-        $response = Http::sendWithOptions(
-            $this->client,
-            $this->getRoute(__METHOD__),
-            ['postFields' => [self::OBJ_NAME_PLURAL => $params], 'method' => 'PUT']
-        );
-        $this->client->setSideload(null);
-
-        return $response;
-    }
-
-
-    /**
-     * Suspend a user
-     *
-     * @param array $params
-     *
-     * @throws MissingParametersException
-     * @throws ResponseException
      * @return mixed
      */
     public function suspend(array $params = [])

--- a/src/Zendesk/API/Resources/Users.php
+++ b/src/Zendesk/API/Resources/Users.php
@@ -2,6 +2,7 @@
 
 namespace Zendesk\API\Resources;
 
+use Zendesk\API\BulkTraits\BulkCreateTrait;
 use Zendesk\API\Exceptions\CustomException;
 use Zendesk\API\Exceptions\MissingParametersException;
 use Zendesk\API\Exceptions\ResponseException;
@@ -19,6 +20,8 @@ class Users extends ResourceAbstract
 
     const OBJ_NAME = 'user';
     const OBJ_NAME_PLURAL = 'users';
+
+    use BulkCreateTrait;
 
     /**
      * @var UserIdentities
@@ -204,28 +207,6 @@ class Users extends ResourceAbstract
     }
 
     /**
-     * Create multiple new users
-     *
-     * @param array $params
-     *
-     * @throws ResponseException
-     * @throws \Exception
-     * @return mixed
-     */
-    public function createMany(array $params)
-    {
-        $response = Http::sendWithOptions(
-            $this->client,
-            $this->getRoute(__FUNCTION__),
-            ['postFields' => [self::OBJ_NAME_PLURAL => $params], 'method' => 'POST']
-        );
-
-        $this->client->setSideload(null);
-
-        return $response;
-    }
-
-    /**
      * Update multiple users
      *
      * @param array $params
@@ -313,15 +294,7 @@ class Users extends ResourceAbstract
         $queryParams = isset($params['query']) ? ['query' => $params['query']] : [];
         $extraParams = Http::prepareQueryParams($this->client->getSideload($params), $params);
 
-        $response = Http::sendWithOptions(
-            $this->client,
-            $this->getRoute(__FUNCTION__),
-            ['queryParams' => array_merge($extraParams, $queryParams)]
-        );
-
-        $this->client->setSideload(null);
-
-        return $response;
+        return $this->client->get($this->getRoute(__FUNCTION__), array_merge($extraParams, $queryParams));
     }
 
     /**
@@ -431,15 +404,7 @@ class Users extends ResourceAbstract
         $id = $params['id'];
         unset($params['id']);
 
-        $response = Http::sendWithOptions(
-            $this->client,
-            $this->getRoute(__FUNCTION__, ['id' => $id]),
-            ['postFields' => [self::OBJ_NAME => $params], 'method' => 'POST']
-        );
-
-        $this->client->setSideload(null);
-
-        return $response;
+        return $this->client->post($this->getRoute(__FUNCTION__, ['id' => $id]), [self::OBJ_NAME => $params]);
     }
 
     /**
@@ -461,14 +426,7 @@ class Users extends ResourceAbstract
         $id = $params['id'];
         unset($params['id']);
 
-        $response = Http::sendWithOptions(
-            $this->client,
-            $this->getRoute(__FUNCTION__, ['id' => $id]),
-            ['postFields' => $params, 'method' => 'PUT']
-        );
+        return $this->client->put($this->getRoute(__FUNCTION__, ['id' => $id]), $params);
 
-        $this->client->setSideload(null);
-
-        return $response;
     }
 }

--- a/src/Zendesk/API/Resources/Views.php
+++ b/src/Zendesk/API/Resources/Views.php
@@ -41,7 +41,7 @@ class Views extends ResourceAbstract
      *
      * @return mixed
      */
-    public function findAll(array $params = array())
+    public function findAll(array $params = [])
     {
         if (isset($params['active'])) {
             $params['modifier'] = '/active';
@@ -62,7 +62,7 @@ class Views extends ResourceAbstract
      *
      * @return mixed
      */
-    public function find($id = null, array $queryParams = array())
+    public function find($id = null, array $queryParams = [])
     {
         $queryParams = Http::prepareQueryParams(
             $this->client->getSideload($queryParams),
@@ -83,8 +83,8 @@ class Views extends ResourceAbstract
      */
     public function delete($id = null)
     {
-        if (( empty($id) ) && ! ( $this->getChainedParameter('id', false) )) {
-            throw new MissingParametersException(__METHOD__, array( 'id' ));
+        if ((empty($id)) && ! ($this->getChainedParameter('id', false))) {
+            throw new MissingParametersException(__METHOD__, ['id']);
         }
 
         $endPoint = 'views/' . $id . '.json';
@@ -92,7 +92,7 @@ class Views extends ResourceAbstract
         $response = Http::sendWithOptions(
             $this->client,
             $endPoint,
-            [ 'method' => 'DELETE' ]
+            ['method' => 'DELETE']
         );
 
         $this->client->setSideload(null);
@@ -111,15 +111,15 @@ class Views extends ResourceAbstract
      *
      * @return mixed
      */
-    public function execute(array $params = array())
+    public function execute(array $params = [])
     {
         $params = $this->addChainedParametersToParams(
             $params,
             ['id' => get_class($this)]
         );
 
-        if (! $this->hasKeys($params, array( 'id' ))) {
-            throw new MissingParametersException(__METHOD__, array( 'id' ));
+        if (! $this->hasKeys($params, ['id'])) {
+            throw new MissingParametersException(__METHOD__, ['id']);
         }
 
         $queryParams = Http::prepareQueryParams(
@@ -127,15 +127,7 @@ class Views extends ResourceAbstract
             $params
         );
 
-        $response = Http::sendWithOptions(
-            $this->client,
-            $this->getRoute(__FUNCTION__, ['id' => $params['id']]),
-            ['queryParams' => $queryParams]
-        );
-
-        $this->client->setSideload(null);
-
-        return $response;
+        return $this->client->get($this->getRoute(__FUNCTION__, ['id' => $params['id']]), $queryParams);
     }
 
     /**
@@ -149,15 +141,15 @@ class Views extends ResourceAbstract
      *
      * @return mixed
      */
-    public function tickets(array $params = array())
+    public function tickets(array $params = [])
     {
         $params = $this->addChainedParametersToParams(
             $params,
             ['id' => get_class($this)]
         );
 
-        if (!$this->hasKeys($params, array('id'))) {
-            throw new MissingParametersException(__METHOD__, array('id'));
+        if (! $this->hasKeys($params, ['id'])) {
+            throw new MissingParametersException(__METHOD__, ['id']);
         }
 
         $queryParams = Http::prepareQueryParams(
@@ -165,14 +157,7 @@ class Views extends ResourceAbstract
             $params
         );
 
-        $response = Http::sendWithOptions(
-            $this->client,
-            $this->getRoute(__FUNCTION__, ['id' => $params['id']]),
-            ['queryParams' => $queryParams]
-        );
-        $this->client->setSideload(null);
-
-        return $response;
+        return $this->client->get($this->getRoute(__FUNCTION__, ['id' => $params['id']]), $queryParams);
     }
 
     /**
@@ -186,14 +171,14 @@ class Views extends ResourceAbstract
      *
      * @return mixed
      */
-    public function count(array $params = array())
+    public function count(array $params = [])
     {
         $params = $this->addChainedParametersToParams(
             $params,
             ['id' => get_class($this)]
         );
-        if (!$this->hasKeys($params, array('id'))) {
-            throw new MissingParametersException(__METHOD__, array('id'));
+        if (! $this->hasKeys($params, ['id'])) {
+            throw new MissingParametersException(__METHOD__, ['id']);
         }
 
         $queryParams = $routeParams = [];
@@ -203,7 +188,7 @@ class Views extends ResourceAbstract
             unset($params['id']);
         } else {
             $this->setRoute(__FUNCTION__, 'views/{id}/count.json');
-            $routeParams = [ 'id' => $params['id'] ];
+            $routeParams = ['id' => $params['id']];
         }
 
         $extraParams = Http::prepareQueryParams(
@@ -211,15 +196,7 @@ class Views extends ResourceAbstract
             $params
         );
 
-        $response = Http::sendWithOptions(
-            $this->client,
-            $this->getRoute(__FUNCTION__, $routeParams),
-            ['queryParams' => array_merge($queryParams, $extraParams)]
-        );
-
-        $this->client->setSideload(null);
-
-        return $response;
+        return $this->client->get($this->getRoute(__FUNCTION__, $routeParams), $queryParams);
     }
 
     /**
@@ -233,14 +210,14 @@ class Views extends ResourceAbstract
      *
      * @return mixed
      */
-    public function export(array $params = array())
+    public function export(array $params = [])
     {
         $params = $this->addChainedParametersToParams(
             $params,
             ['id' => get_class($this)]
         );
-        if (!$this->hasKeys($params, array('id'))) {
-            throw new MissingParametersException(__METHOD__, array('id'));
+        if (! $this->hasKeys($params, ['id'])) {
+            throw new MissingParametersException(__METHOD__, ['id']);
         }
 
         $queryParams = Http::prepareQueryParams(
@@ -248,15 +225,7 @@ class Views extends ResourceAbstract
             $params
         );
 
-        $response = Http::sendWithOptions(
-            $this->client,
-            $this->getRoute(__FUNCTION__, [ 'id' => $params['id'] ]),
-            [ 'queryParams' => $queryParams ]
-        );
-
-        $this->client->setSideload(null);
-
-        return $response;
+        return $this->client->get($this->getRoute(__FUNCTION__, ['id' => $params['id']]), $queryParams);
     }
 
     /**
@@ -280,7 +249,7 @@ class Views extends ResourceAbstract
             $this->client,
             $this->getRoute(__FUNCTION__),
             [
-                'postFields'  => array('view' => $params),
+                'postFields'  => ['view' => $params],
                 'queryParams' => $extraParams,
                 'method'      => 'POST'
             ]
@@ -312,7 +281,7 @@ class Views extends ResourceAbstract
             $this->client,
             $this->getRoute(__FUNCTION__),
             [
-                'postFields'  => array('view' => $params),
+                'postFields'  => ['view' => $params],
                 'queryParams' => $extraParams,
                 'method'      => 'POST'
             ]

--- a/tests/Zendesk/API/UnitTests/DummyResource.php
+++ b/tests/Zendesk/API/UnitTests/DummyResource.php
@@ -1,10 +1,19 @@
 <?php
 namespace Zendesk\API\UnitTests;
 
+use Zendesk\API\BulkTraits\BulkCreateTrait;
+use Zendesk\API\BulkTraits\BulkDeleteTrait;
+use Zendesk\API\BulkTraits\BulkFindTrait;
+use Zendesk\API\BulkTraits\BulkUpdateTrait;
 use Zendesk\API\Resources\ResourceAbstract;
 
 class DummyResource extends ResourceAbstract
 {
     const OBJ_NAME = 'dummy';
     const OBJ_NAME_PLURAL = 'dummies';
+
+    use BulkFindTrait;
+    use BulkUpdateTrait;
+    use BulkDeleteTrait;
+    use BulkCreateTrait;
 }

--- a/tests/Zendesk/API/UnitTests/MacrosTest.php
+++ b/tests/Zendesk/API/UnitTests/MacrosTest.php
@@ -58,7 +58,7 @@ class MacrosTest extends BasicTest
      */
     public function testApplyToTicket()
     {
-        $id       = 1;
+        $id = 1;
         $ticketId = 3;
 
         $this->mockAPIResponses([
@@ -69,8 +69,9 @@ class MacrosTest extends BasicTest
 
         $this->assertLastRequestIs(
             [
-                'method'   => 'GET',
-                'endpoint' => "tickets/{$ticketId}/macros/{$id}/apply.json",
+                'method'      => 'GET',
+                'endpoint'    => "tickets/{$ticketId}/macros/{$id}/apply.json",
+                'queryParams' => []
             ]
         );
     }

--- a/tests/Zendesk/API/UnitTests/ResourceTest.php
+++ b/tests/Zendesk/API/UnitTests/ResourceTest.php
@@ -37,7 +37,7 @@ class ResourceTest extends BasicTest
 
         $this->assertLastRequestIs([
             'method'      => 'GET',
-            'endpoint'    => 'dummyresource/1.json',
+            'endpoint'    => 'dummy_resource/1.json',
             'queryParams' => []
         ]);
     }
@@ -55,7 +55,7 @@ class ResourceTest extends BasicTest
 
         $this->assertLastRequestIs([
             'method'      => 'GET',
-            'endpoint'    => 'dummyresource.json',
+            'endpoint'    => 'dummy_resource.json',
             'queryParams' => $iterators
         ]);
     }
@@ -125,7 +125,7 @@ class ResourceTest extends BasicTest
 
         $this->assertLastRequestIs([
             'method'      => 'GET',
-            'endpoint'    => 'dummyresource.json',
+            'endpoint'    => 'dummy_resource.json',
             'queryParams' => ['include' => implode(',', $sideloads)]
         ]);
     }
@@ -143,7 +143,7 @@ class ResourceTest extends BasicTest
         $this->assertLastRequestIs(
             [
                 'method'     => 'POST',
-                'endpoint'   => 'dummyresource/create_many.json',
+                'endpoint'   => 'dummy_resource/create_many.json',
                 'postFields' => [DummyResource::OBJ_NAME_PLURAL => $postFields]
             ]
         );
@@ -160,7 +160,7 @@ class ResourceTest extends BasicTest
 
         $this->assertLastRequestIs([
             'method'      => 'GET',
-            'endpoint'    => 'dummyresource/show_many.json',
+            'endpoint'    => 'dummy_resource/show_many.json',
             'queryParams' => ['ids' => implode(',', $ids)]
         ]);
     }
@@ -179,7 +179,7 @@ class ResourceTest extends BasicTest
         $this->assertLastRequestIs(
             [
                 'method'      => 'PUT',
-                'endpoint'    => 'dummyresource/update_many.json',
+                'endpoint'    => 'dummy_resource/update_many.json',
                 'queryParams' => ['ids' => implode(',', $ids)],
                 'postFields'  => [DummyResource::OBJ_NAME => $postFields],
             ]
@@ -204,7 +204,7 @@ class ResourceTest extends BasicTest
         $this->assertLastRequestIs(
             [
                 'method'     => 'PUT',
-                'endpoint'   => 'dummyresource/update_many.json',
+                'endpoint'   => 'dummy_resource/update_many.json',
                 'postFields' => [DummyResource::OBJ_NAME_PLURAL => $postFields],
             ]
         );
@@ -222,7 +222,7 @@ class ResourceTest extends BasicTest
         $this->assertLastRequestIs(
             [
                 'method'      => 'DELETE',
-                'endpoint'    => 'dummyresource/destroy_many.json',
+                'endpoint'    => 'dummy_resource/destroy_many.json',
                 'queryParams' => ['ids' => implode(',', $ids)]
             ]
         );

--- a/tests/Zendesk/API/UnitTests/ResourceTest.php
+++ b/tests/Zendesk/API/UnitTests/ResourceTest.php
@@ -130,6 +130,104 @@ class ResourceTest extends BasicTest
         ]);
     }
 
+    public function testCreateMany()
+    {
+        $this->mockAPIResponses([
+            new Response(200, [], '')
+        ]);
+
+        $postFields = [['foo' => 'test body'], ['foo2' => 'test body 2'], ['foo3' => 'test body3']];
+
+        $this->dummyResource->createMany($postFields);
+
+        $this->assertLastRequestIs(
+            [
+                'method'     => 'POST',
+                'endpoint'   => 'dummyresource/create_many.json',
+                'postFields' => [DummyResource::OBJ_NAME_PLURAL => $postFields]
+            ]
+        );
+    }
+
+    public function testFindMany()
+    {
+        $this->mockAPIResponses([
+            new Response(200, [], json_encode(['dummy' => true]))
+        ]);
+
+        $ids = [1, 2, 3, 4, 5];
+        $this->dummyResource->findMany($ids);
+
+        $this->assertLastRequestIs([
+            'method'      => 'GET',
+            'endpoint'    => 'dummyresource/show_many.json',
+            'queryParams' => ['ids' => implode(',', $ids)]
+        ]);
+    }
+
+    public function testUpdateManySameData()
+    {
+        $this->mockAPIResponses([
+            new Response(200, [], '')
+        ]);
+
+        $ids        = [1, 2, 3, 4, 5];
+        $postFields = ['foo' => 'test body'];
+
+        $this->dummyResource->updateMany(array_merge(['ids' => $ids], $postFields));
+
+        $this->assertLastRequestIs(
+            [
+                'method'      => 'PUT',
+                'endpoint'    => 'dummyresource/update_many.json',
+                'queryParams' => ['ids' => implode(',', $ids)],
+                'postFields'  => [DummyResource::OBJ_NAME => $postFields],
+            ]
+        );
+    }
+
+    public function testUpdateManyDifferentData()
+    {
+        $this->mockAPIResponses([
+            new Response(200, [], '')
+        ]);
+
+        $postFields = [
+            ['id' => 1, 'foo' => 'bar', 'hello' => 'world'],
+            ['id' => 2, 'foo' => 'bar', 'hello' => 'world'],
+            ['id' => 3, 'foo' => 'bar', 'hello' => 'world'],
+            ['id' => 4, 'foo' => 'bar', 'hello' => 'world']
+        ];
+
+        $this->dummyResource->updateMany($postFields);
+
+        $this->assertLastRequestIs(
+            [
+                'method'     => 'PUT',
+                'endpoint'   => 'dummyresource/update_many.json',
+                'postFields' => [DummyResource::OBJ_NAME_PLURAL => $postFields],
+            ]
+        );
+    }
+
+    public function testDeleteMany()
+    {
+        $this->mockAPIResponses([
+            new Response(200, [], '')
+        ]);
+
+        $ids = [1, 2, 3, 4, 5];
+        $this->dummyResource->deleteMany($ids);
+
+        $this->assertLastRequestIs(
+            [
+                'method'      => 'DELETE',
+                'endpoint'    => 'dummyresource/destroy_many.json',
+                'queryParams' => ['ids' => implode(',', $ids)]
+            ]
+        );
+    }
+
     /**
      * @expectedException Zendesk\API\Exceptions\ApiResponseException
      * @expectedExceptionMessage Zendesk may be experiencing internal issues or undergoing scheduled maintenance.

--- a/tests/Zendesk/API/UnitTests/ResourceTest.php
+++ b/tests/Zendesk/API/UnitTests/ResourceTest.php
@@ -36,8 +36,27 @@ class ResourceTest extends BasicTest
         $this->dummyResource->find(1);
 
         $this->assertLastRequestIs([
-            'method'   => 'GET',
-            'endpoint' => 'dummy_resource/1.json',
+            'method'      => 'GET',
+            'endpoint'    => 'dummyresource/1.json',
+            'queryParams' => []
+        ]);
+    }
+
+    public function testCanSetIteratorParams()
+    {
+        $this->mockAPIResponses([
+            new Response(200, [], json_encode(['dummy' => true]))
+        ]);
+
+        $iterators = ['per_page' => 1, 'page' => 2, 'sort_order' => 'desc', 'sort_by' => 'date'];
+
+        $this->dummyResource->findAll($iterators);
+
+
+        $this->assertLastRequestIs([
+            'method'      => 'GET',
+            'endpoint'    => 'dummyresource.json',
+            'queryParams' => $iterators
         ]);
     }
 
@@ -92,6 +111,23 @@ class ResourceTest extends BasicTest
                 'endpoint' => 'dummy_resource/1.json'
             ]
         );
+    }
+
+    public function testSideLoad()
+    {
+        $this->mockAPIResponses([
+            new Response(200, [], json_encode(['dummy' => true]))
+        ]);
+
+        $sideloads = ['foo', 'bar', 'hello', 'world'];
+        $this->dummyResource->sideload($sideloads);
+        $this->dummyResource->findAll();
+
+        $this->assertLastRequestIs([
+            'method'      => 'GET',
+            'endpoint'    => 'dummyresource.json',
+            'queryParams' => ['include' => implode(',', $sideloads)]
+        ]);
     }
 
     /**

--- a/tests/Zendesk/API/UnitTests/TicketAuditsTest.php
+++ b/tests/Zendesk/API/UnitTests/TicketAuditsTest.php
@@ -14,15 +14,16 @@ class TicketAuditsTest extends BasicTest
     public function testFindAllWithChainedParams()
     {
         $this->mockAPIResponses([
-          new Response(200, [], '')
+            new Response(200, [], '')
         ]);
 
-        $this->client->tickets($this->ticket_id)->audits()->findAll();
+        $this->client->tickets($this->ticket_id)->audits()->findAll(['per_page' => 1]);
 
         $this->assertLastRequestIs(
             [
-            'method'   => 'GET',
-            'endpoint' => 'tickets/12345/audits.json',
+                'method'      => 'GET',
+                'endpoint'    => 'tickets/12345/audits.json',
+                'queryParams' => ['per_page' => 1]
             ]
         );
     }
@@ -32,20 +33,20 @@ class TicketAuditsTest extends BasicTest
         $audit_id = 1;
 
         $response = [
-          'audit' => [
-            'id' => '1'
-          ]
+            'audit' => [
+                'id' => '1'
+            ]
         ];
         $this->mockAPIResponses([
-          new Response(200, [], json_encode($response))
+            new Response(200, [], json_encode($response))
         ]);
 
         $audits = $this->client->tickets($this->ticket_id)->audits($audit_id)->find();
 
         $this->assertLastRequestIs(
             [
-            'method'   => 'GET',
-            'endpoint' => 'tickets/12345/audits/1.json',
+                'method'   => 'GET',
+                'endpoint' => 'tickets/12345/audits/1.json',
             ]
         );
 

--- a/tests/Zendesk/API/UnitTests/TicketCommentsTest.php
+++ b/tests/Zendesk/API/UnitTests/TicketCommentsTest.php
@@ -13,14 +13,14 @@ class TicketCommentsTest extends BasicTest
 
     public function setUp()
     {
-        $this->testTicket = array(
-            'id' => "12345",
-            'subject' => 'Ticket comment test',
-            'comment' => array(
+        $this->testTicket = [
+            'id'       => "12345",
+            'subject'  => 'Ticket comment test',
+            'comment'  => [
                 'body' => 'Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.'
-            ),
+            ],
             'priority' => 'normal'
-        );
+        ];
         $this->ticket_id = $this->testTicket['id'];
 
         parent::setUp();
@@ -29,15 +29,15 @@ class TicketCommentsTest extends BasicTest
     public function testAll()
     {
         $this->mockAPIResponses([
-          new Response(200, [], json_encode(['comments' => [['id' => 1]]]))
+            new Response(200, [], json_encode(['comments' => [['id' => 1]]]))
         ]);
 
         $comments = $this->client->tickets($this->ticket_id)->comments()->findAll();
 
         $this->assertLastRequestIs(
             [
-            'method' => 'GET',
-            'endpoint' => 'tickets/12345/comments.json',
+                'method'   => 'GET',
+                'endpoint' => 'tickets/12345/comments.json',
             ]
         );
 
@@ -56,15 +56,15 @@ class TicketCommentsTest extends BasicTest
     public function testMakePrivate()
     {
         $this->mockAPIResponses([
-          new Response(200, [], '')
+            new Response(200, [], '')
         ]);
 
         $this->client->tickets(12345)->comments(1)->makePrivate();
 
         $this->assertLastRequestIs(
             [
-            'method' => 'PUT',
-            'endpoint' => 'tickets/12345/comments/1/make_private.json',
+                'method'   => 'PUT',
+                'endpoint' => 'tickets/12345/comments/1/make_private.json',
             ]
         );
     }

--- a/tests/Zendesk/API/UnitTests/UsersTest.php
+++ b/tests/Zendesk/API/UnitTests/UsersTest.php
@@ -14,26 +14,26 @@ class UsersTest extends BasicTest
 
     public function testCreate()
     {
-        $testUser = array(
-          'id'          => '12345',
-          'name'        => 'Roger Wilco',
-          'email'       => 'roge@example.org',
-          'role'        => 'agent',
-          'verified'    => true,
-          'external_id' => '3000'
-        );
+        $testUser = [
+            'id'          => '12345',
+            'name'        => 'Roger Wilco',
+            'email'       => 'roge@example.org',
+            'role'        => 'agent',
+            'verified'    => true,
+            'external_id' => '3000'
+        ];
 
         $this->mockAPIResponses([
-          new Response(200, [], json_encode(['user' => $testUser]))
+            new Response(200, [], json_encode(['user' => $testUser]))
         ]);
 
         $user = $this->client->users()->create($testUser);
 
         $this->assertLastRequestIs(
             [
-            'method'     => 'POST',
-            'endpoint'   => 'users.json',
-            'postFields' => ['user' => $testUser],
+                'method'     => 'POST',
+                'endpoint'   => 'users.json',
+                'postFields' => ['user' => $testUser],
             ]
         );
 
@@ -45,15 +45,15 @@ class UsersTest extends BasicTest
     public function testDelete()
     {
         $this->mockAPIResponses([
-          new Response(200, [], '')
+            new Response(200, [], '')
         ]);
 
         $this->client->users(12345)->delete();
 
         $this->assertLastRequestIs(
             [
-            'method'   => 'DELETE',
-            'endpoint' => 'users/12345.json',
+                'method'   => 'DELETE',
+                'endpoint' => 'users/12345.json',
             ]
         );
     }
@@ -62,22 +62,22 @@ class UsersTest extends BasicTest
     {
         $response = json_encode(
             [
-            'users' => [
-              ['id' => 12345]
-            ]
+                'users' => [
+                    ['id' => 12345]
+                ]
             ]
         );
 
         $this->mockAPIResponses([
-          new Response(200, [], $response)
+            new Response(200, [], $response)
         ]);
 
         $users = $this->client->users()->findAll();
 
         $this->assertLastRequestIs(
             [
-            'method'   => 'GET',
-            'endpoint' => 'users.json',
+                'method'   => 'GET',
+                'endpoint' => 'users.json',
             ]
         );
 
@@ -94,15 +94,15 @@ class UsersTest extends BasicTest
     public function testFind()
     {
         $this->mockAPIResponses([
-          new Response(200, [], json_encode(['user' => ['id' => 12345]]))
+            new Response(200, [], json_encode(['user' => ['id' => 12345]]))
         ]);
 
         $user = $this->client->users(12345)->find();
 
         $this->assertLastRequestIs(
             [
-            'method'   => 'GET',
-            'endpoint' => 'users/12345.json',
+                'method'   => 'GET',
+                'endpoint' => 'users/12345.json',
             ]
         );
 
@@ -115,23 +115,23 @@ class UsersTest extends BasicTest
     {
         $findIds  = [12345, 80085];
         $response = [
-          'users' => [
-            ['id' => $findIds[0]],
-            ['id' => $findIds[1]],
-          ]
+            'users' => [
+                ['id' => $findIds[0]],
+                ['id' => $findIds[1]],
+            ]
         ];
 
         $this->mockAPIResponses([
-          new Response(200, [], json_encode($response))
+            new Response(200, [], json_encode($response))
         ]);
 
         $users = $this->client->users($findIds)->findMany();
 
         $this->assertLastRequestIs(
             [
-            'method'      => 'GET',
-            'endpoint'    => 'users/show_many.json',
-            'queryParams' => ['ids' => implode(",", [$findIds[0], $findIds[1]])],
+                'method'      => 'GET',
+                'endpoint'    => 'users/show_many.json',
+                'queryParams' => ['ids' => implode(",", [$findIds[0], $findIds[1]])],
             ]
         );
         $this->assertEquals(is_object($users), true, 'Should return an object');
@@ -144,14 +144,14 @@ class UsersTest extends BasicTest
     {
         $findIds  = [12345, 80085];
         $response = [
-          'users' => [
-            ['id' => $findIds[0]],
-            ['id' => $findIds[1]],
-          ]
+            'users' => [
+                ['id' => $findIds[0]],
+                ['id' => $findIds[1]],
+            ]
         ];
 
         $this->mockAPIResponses([
-          new Response(200, [], json_encode($response))
+            new Response(200, [], json_encode($response))
         ]);
 
         $users = $this->client->users()->showMany(['ids' => $findIds]);
@@ -169,23 +169,23 @@ class UsersTest extends BasicTest
     {
         $findIds  = [12345, 80085];
         $response = [
-          'users' => [
-            ['id' => $findIds[0]],
-            ['id' => $findIds[1]],
-          ]
+            'users' => [
+                ['id' => $findIds[0]],
+                ['id' => $findIds[1]],
+            ]
         ];
 
         $this->mockAPIResponses([
-          new Response(200, [], json_encode($response))
+            new Response(200, [], json_encode($response))
         ]);
 
         $users = $this->client->users()->showMany(['external_ids' => $findIds]);
 
         $this->assertLastRequestIs(
             [
-            'method'      => 'GET',
-            'endpoint'    => 'users/show_many.json',
-            'queryParams' => ['external_ids' => implode(',', $findIds)]
+                'method'      => 'GET',
+                'endpoint'    => 'users/show_many.json',
+                'queryParams' => ['external_ids' => implode(',', $findIds)]
             ]
         );
 
@@ -201,15 +201,15 @@ class UsersTest extends BasicTest
     public function testRelated()
     {
         $this->mockAPIResponses([
-          new Response(200, [], json_encode(['user_related' => ['requested_tickets' => 1]]))
+            new Response(200, [], json_encode(['user_related' => ['requested_tickets' => 1]]))
         ]);
 
         $related = $this->client->users(12345)->related();
 
         $this->assertLastRequestIs(
             [
-            'method'   => 'GET',
-            'endpoint' => 'users/12345/related.json',
+                'method'   => 'GET',
+                'endpoint' => 'users/12345/related.json',
             ]
         );
         $this->assertEquals(is_object($related), true, 'Should return an object');
@@ -230,46 +230,46 @@ class UsersTest extends BasicTest
         $postFields = ['id' => 12345];
 
         $this->mockAPIResponses([
-          new Response(200, [], json_encode(['user' => ['id' => 12345]]))
+            new Response(200, [], json_encode(['user' => ['id' => 12345]]))
         ]);
 
         $this->client->users('me')->merge($postFields);
 
         $this->assertLastRequestIs(
             [
-            'method'     => 'PUT',
-            'endpoint'   => 'users/me/merge.json',
-            'postFields' => [Users::OBJ_NAME => $postFields],
+                'method'     => 'PUT',
+                'endpoint'   => 'users/me/merge.json',
+                'postFields' => [Users::OBJ_NAME => $postFields],
             ]
         );
     }
 
     public function testCreateMany()
     {
-        $postFields = array(
-          array(
-            'name'     => 'Roger Wilco 3',
-            'email'    => 'roge3@example.org',
-            'verified' => true
-          ),
-          array(
-            'name'     => 'Roger Wilco 4',
-            'email'    => 'roge4@example.org',
-            'verified' => true
-          )
-        );
+        $postFields = [
+            [
+                'name'     => 'Roger Wilco 3',
+                'email'    => 'roge3@example.org',
+                'verified' => true
+            ],
+            [
+                'name'     => 'Roger Wilco 4',
+                'email'    => 'roge4@example.org',
+                'verified' => true
+            ]
+        ];
 
         $this->mockAPIResponses([
-          new Response(200, [], json_encode(['job_status' => ['id' => 1]]))
+            new Response(200, [], json_encode(['job_status' => ['id' => 1]]))
         ]);
 
         $jobStatus = $this->client->users()->createMany($postFields);
 
         $this->assertLastRequestIs(
             [
-            'method'     => 'POST',
-            'endpoint'   => 'users/create_many.json',
-            'postFields' => [Users::OBJ_NAME_PLURAL => $postFields],
+                'method'     => 'POST',
+                'endpoint'   => 'users/create_many.json',
+                'postFields' => [Users::OBJ_NAME_PLURAL => $postFields],
             ]
         );
 
@@ -283,16 +283,16 @@ class UsersTest extends BasicTest
         $postFields = ['name' => 'Joe Soap'];
 
         $this->mockAPIResponses([
-          new Response(200, [], json_encode([Users::OBJ_NAME => []]))
+            new Response(200, [], json_encode([Users::OBJ_NAME => []]))
         ]);
 
         $this->client->users(12345)->update(null, $postFields);
 
         $this->assertLastRequestIs(
             [
-            'method'     => 'PUT',
-            'endpoint'   => 'users/12345.json',
-            'postFields' => [Users::OBJ_NAME => $postFields],
+                'method'     => 'PUT',
+                'endpoint'   => 'users/12345.json',
+                'postFields' => [Users::OBJ_NAME => $postFields],
             ]
         );
     }
@@ -301,22 +301,22 @@ class UsersTest extends BasicTest
     {
         $updateIds     = [12345, 80085];
         $requestParams = [
-          'ids'   => implode(',', $updateIds),
-          'phone' => '1234567890'
+            'ids'   => $updateIds,
+            'phone' => '1234567890'
         ];
 
         $this->mockAPIResponses([
-          new Response(200, [], json_encode(['job_status' => ['id' => 1]]))
+            new Response(200, [], json_encode(['job_status' => ['id' => 1]]))
         ]);
 
         $jobStatus = $this->client->users()->updateMany($requestParams);
 
         $this->assertLastRequestIs(
             [
-            'method'      => 'PUT',
-            'endpoint'    => 'users/update_many.json',
-            'queryParams' => ['ids' => $requestParams['ids']],
-            'postFields'  => [Users::OBJ_NAME => ['phone' => $requestParams['phone']]]
+                'method'      => 'PUT',
+                'endpoint'    => 'users/update_many.json',
+                'queryParams' => ['ids' => implode(',', $requestParams['ids'])],
+                'postFields'  => [Users::OBJ_NAME => ['phone' => $requestParams['phone']]]
             ]
         );
 
@@ -328,28 +328,28 @@ class UsersTest extends BasicTest
     public function testUpdateManyIndividualUsers()
     {
         $requestParams = [
-          [
-            'id'    => 12345,
-            'phone' => '1234567890'
-          ],
-          [
-            'id'    => 80085,
-            'phone' => '0987654321'
-          ]
+            [
+                'id'    => 12345,
+                'phone' => '1234567890'
+            ],
+            [
+                'id'    => 80085,
+                'phone' => '0987654321'
+            ]
         ];
 
         $this->mockAPIResponses([
-          new Response(200, [], json_encode(['job_status' => ['id' => 1]]))
+            new Response(200, [], json_encode(['job_status' => ['id' => 1]]))
         ]);
 
 
-        $jobStatus = $this->client->users()->updateManyIndividualUsers($requestParams);
+        $jobStatus = $this->client->users()->updateMany($requestParams);
 
         $this->assertLastRequestIs(
             [
-            'method'     => 'PUT',
-            'endpoint'   => 'users/update_many.json',
-            'postFields' => [Users::OBJ_NAME_PLURAL => $requestParams]
+                'method'     => 'PUT',
+                'endpoint'   => 'users/update_many.json',
+                'postFields' => [Users::OBJ_NAME_PLURAL => $requestParams]
             ]
         );
 
@@ -363,16 +363,16 @@ class UsersTest extends BasicTest
         $userId = 12345;
 
         $this->mockAPIResponses([
-          new Response(200, [], json_encode(['user' => ['id' => $userId]]))
+            new Response(200, [], json_encode(['user' => ['id' => $userId]]))
         ]);
 
         $user = $this->client->users($userId)->suspend();
 
         $this->assertLastRequestIs(
             [
-            'method'     => 'PUT',
-            'endpoint'   => 'users/12345.json',
-            'postFields' => [Users::OBJ_NAME => ['id' => $userId, 'suspended' => true]],
+                'method'     => 'PUT',
+                'endpoint'   => 'users/12345.json',
+                'postFields' => [Users::OBJ_NAME => ['id' => $userId, 'suspended' => true]],
             ]
         );
 
@@ -386,16 +386,16 @@ class UsersTest extends BasicTest
         $queryParams = ['query' => 'Roger'];
 
         $this->mockAPIResponses([
-          new Response(200, [], json_encode(['users' => [['id' => 12345]]]))
+            new Response(200, [], json_encode(['users' => [['id' => 12345]]]))
         ]);
 
         $users = $this->client->users()->search($queryParams);
 
         $this->assertLastRequestIs(
             [
-            'method'      => 'GET',
-            'endpoint'    => 'users/search.json',
-            'queryParams' => $queryParams,
+                'method'      => 'GET',
+                'endpoint'    => 'users/search.json',
+                'queryParams' => $queryParams,
             ]
         );
 
@@ -416,16 +416,16 @@ class UsersTest extends BasicTest
         $queryParams = ['name' => 'joh'];
 
         $this->mockAPIResponses([
-          new Response(200, [], json_encode(['users' => [['id' => 12345]]]))
+            new Response(200, [], json_encode(['users' => [['id' => 12345]]]))
         ]);
 
         $users = $this->client->users()->autocomplete($queryParams);
 
         $this->assertLastRequestIs(
             [
-            'method'      => 'POST',
-            'endpoint'    => 'users/autocomplete.json',
-            'queryParams' => $queryParams,
+                'method'      => 'POST',
+                'endpoint'    => 'users/autocomplete.json',
+                'queryParams' => $queryParams,
             ]
         );
 
@@ -441,12 +441,12 @@ class UsersTest extends BasicTest
     public function testUpdateProfileImage()
     {
         $this->markTestSkipped('Need to allow file uploads with Guzzle.');
-        $this->mockApiCall('GET', '/users/12345.json?', array('id' => 12345));
-        $this->mockApiCall('PUT', '/users/12345.json', array('user' => array('id' => 12345)));
+        $this->mockApiCall('GET', '/users/12345.json?', ['id' => 12345]);
+        $this->mockApiCall('PUT', '/users/12345.json', ['user' => ['id' => 12345]]);
 
-        $user = $this->client->users(12345)->updateProfileImage(array(
-          'file' => getcwd() . '/tests/assets/UK.png'
-        ));
+        $user = $this->client->users(12345)->updateProfileImage([
+            'file' => getcwd() . '/tests/assets/UK.png'
+        ]);
 
         $contentType = $this->http->requests->first()->getHeader("Content-Type")->toArray()[0];
         $this->assertEquals($contentType, "application/binary");
@@ -459,15 +459,15 @@ class UsersTest extends BasicTest
     public function testAuthenticatedUser()
     {
         $this->mockAPIResponses([
-          new Response(200, [], json_encode(['user' => ['id' => 12345]]))
+            new Response(200, [], json_encode(['user' => ['id' => 12345]]))
         ]);
 
         $user = $this->client->users()->me();
 
         $this->assertLastRequestIs(
             [
-            'method'   => 'GET',
-            'endpoint' => 'users/me.json',
+                'method'   => 'GET',
+                'endpoint' => 'users/me.json',
             ]
         );
 
@@ -481,16 +481,16 @@ class UsersTest extends BasicTest
         $postFields = ['password' => 'aBc12345'];
 
         $this->mockAPIResponses([
-          new Response(200, [], '')
+            new Response(200, [], '')
         ]);
 
         $this->client->users(12345)->setPassword($postFields);
 
         $this->assertLastRequestIs(
             [
-            'method'     => 'POST',
-            'endpoint'   => 'users/12345/password.json',
-            'postFields' => [Users::OBJ_NAME => $postFields],
+                'method'     => 'POST',
+                'endpoint'   => 'users/12345/password.json',
+                'postFields' => [Users::OBJ_NAME => $postFields],
             ]
         );
     }
@@ -498,21 +498,21 @@ class UsersTest extends BasicTest
     public function testChangePassword()
     {
         $postFields = [
-          'previous_password' => '12346',
-          'password'          => '12345'
+            'previous_password' => '12346',
+            'password'          => '12345'
         ];
 
         $this->mockAPIResponses([
-          new Response(200, [], '')
+            new Response(200, [], '')
         ]);
 
         $this->client->users(421450109)->changePassword($postFields);
 
         $this->assertLastRequestIs(
             [
-            'method'     => 'PUT',
-            'endpoint'   => 'users/421450109/password.json',
-            'postFields' => $postFields,
+                'method'     => 'PUT',
+                'endpoint'   => 'users/421450109/password.json',
+                'postFields' => $postFields,
             ]
         );
     }


### PR DESCRIPTION
Adds traits for bulk actions. This way special cases can be handled individually.
Adds another wrapper for http requests under HttpClient . This serves to reduce repetition in some methods that only require a change in endpoint, so we don't have to call the ResourceAbstract methods like create() or find() . Instead $this->client->post() / get() / delete() / put() can be used.

/cc @miogalang @jwswj @mmolina @atroche 

### References
 - Jira link: 

### Risks
 - High - query parameters may not get passed to the api request