### PR TITLE
[MI-112] Allow the client to use the audit logs resource

### DIFF
--- a/src/Zendesk/API/HttpClient.php
+++ b/src/Zendesk/API/HttpClient.php
@@ -9,6 +9,7 @@ namespace Zendesk\API;
 
 use Zendesk\API\Exceptions\AuthException;
 use Zendesk\API\Resources\Attachments;
+use Zendesk\API\Resources\AuditLogs;
 use Zendesk\API\Resources\Automations;
 use Zendesk\API\Resources\Groups;
 use Zendesk\API\Resources\Macros;
@@ -116,6 +117,10 @@ class HttpClient
      */
     protected $userFields;
     /**
+     * @var AuditLogs
+     */
+    protected $auditLogs;
+    /**
      * @var Debug
      */
     protected $debug;
@@ -172,6 +177,7 @@ class HttpClient
             'triggers'    => Triggers::class,
             'targets'     => Targets::class,
             'userFields'  => UserFields::class,
+            'auditLogs'   => AuditLogs::class,
         ];
     }
 

--- a/src/Zendesk/API/Resources/AuditLogs.php
+++ b/src/Zendesk/API/Resources/AuditLogs.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Zendesk\API\Resources;
+
+use Zendesk\API\Http;
+
+/**
+ * The AuditLogs class is as per http://developer.zendesk.com/documentation/rest_api/audit_logs.html
+ */
+class AuditLogs extends ResourceAbstract
+{
+    const OBJ_NAME = 'audit_log';
+    const OBJ_NAME_PLURAL = 'audit_logs';
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function setUpRoutes()
+    {
+        $this->setRoutes([
+            'findAll' => "{$this->resourceName}.json",
+            'find'    => "{$this->resourceName}/{id}.json",
+        ]);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function findAll(array $params = [])
+    {
+        $sideloads = $this->client->getSideload($params);
+
+        $extraParams = Http::prepareQueryParams($sideloads, $params);
+        $queryParams = array_filter(array_flip($params), [$this, 'filterParams']);
+        $queryParams = array_flip($queryParams);
+
+        $queryParams = array_merge($queryParams, $extraParams);
+
+        $response = Http::sendWithOptions(
+            $this->client,
+            $this->getRoute(__FUNCTION__, $params),
+            ['queryParams' => $queryParams]
+        );
+
+        $this->client->setSideload(null);
+
+        return $response;
+    }
+
+    /**
+     * Filter parameters passed and only allow valid query parameters.
+     */
+    private function filterParams($param)
+    {
+        return preg_match("/^filter[\"[a-zA-Z_]*\"]/", $param);
+    }
+}

--- a/src/Zendesk/API/Resources/ResourceAbstract.php
+++ b/src/Zendesk/API/Resources/ResourceAbstract.php
@@ -93,6 +93,9 @@ abstract class ResourceAbstract
         return $this->resourceName;
     }
 
+    /**
+     * Sets up the available routes for the resource.
+     */
     protected function setUpRoutes()
     {
         $this->setRoutes([

--- a/tests/Zendesk/API/UnitTests/AuditLogsTest.php
+++ b/tests/Zendesk/API/UnitTests/AuditLogsTest.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Zendesk\API\UnitTests;
+
+use GuzzleHttp\Psr7\Response;
+
+/**
+ * AuditLogs test class
+ */
+class AuditLogsTest extends BasicTest
+{
+    /**
+     * Test find all method
+     */
+    public function testFindAll()
+    {
+        $this->mockAPIResponses([
+            new Response(200, [], '')
+        ]);
+
+        $queryParams = [
+            'filter["source_type"]' => 'rule',
+            'filter["valid"]'       => 'somerule',
+            'invalid'               => 'invalidrule',
+        ];
+
+        $this->client->auditLogs()->findAll($queryParams);
+
+        // We expect invalid parameters are removed.
+        // We also expect url encoded keys and values
+        $expectedQueryParams = [];
+        foreach ($queryParams as $key => $value) {
+            if ($key == 'invalid') {
+                continue;
+            }
+
+            $expectedQueryParams = array_merge($expectedQueryParams, [urlencode($key) => urlencode($value)]);
+        }
+
+        $this->assertLastRequestIs(
+            [
+                'method'      => 'GET',
+                'endpoint'    => 'audit_logs.json',
+                'queryParams' => $expectedQueryParams,
+            ]
+        );
+    }
+}


### PR DESCRIPTION
Allow the client to use the audit logs resource

/cc @joseconsador @jwswj @mmolina @atroche 

### References
 - Jira link: https://zendesk.atlassian.net/browse/MI-112

### Risks
 - We might not be able to use the audit logs endpoints (low)