### PR TITLE
[MI-107] Allow user to update profile photo using client

### DIFF
--- a/src/Zendesk/API/BulkTraits/BulkUpdateTrait.php
+++ b/src/Zendesk/API/BulkTraits/BulkUpdateTrait.php
@@ -7,7 +7,6 @@ use Zendesk\API\Http;
 
 /**
  * Allows resources to call a bulk show endpoint.
- *
  */
 trait BulkUpdateTrait
 {
@@ -15,7 +14,7 @@ trait BulkUpdateTrait
     /**
      * Update group of resources
      *
-     * @param array  $params
+     * @param array $params
      * @param string $key Could be `id` or `external_id`
      *
      * @return mixed
@@ -36,7 +35,7 @@ trait BulkUpdateTrait
         $resourceUpdateName = self::OBJ_NAME_PLURAL;
         $queryParams        = [];
         if (isset($params[$key]) && is_array($params[$key])) {
-            $queryParams[$key] = implode(",", $params[$key]);
+            $queryParams[$key] = implode(',', $params[$key]);
             unset($params[$key]);
 
             $resourceUpdateName = self::OBJ_NAME;

--- a/src/Zendesk/API/Resources/Users.php
+++ b/src/Zendesk/API/Resources/Users.php
@@ -217,7 +217,6 @@ class Users extends ResourceAbstract
      *
      * @throws MissingParametersException
      * @throws ResponseException
-     *
      * @return mixed
      */
     public function suspend(array $params = [])
@@ -329,8 +328,23 @@ class Users extends ResourceAbstract
      */
     public function updateProfileImageFromUrl(array $params)
     {
-        // TODO implement
-        return;
+        if (! isset($params['id']) || empty($params['id'])) {
+            $params = $this->addChainedParametersToParams($params, ['id' => self::class]);
+        }
+
+        if (! $this->hasKeys($params, ['id', 'url'])) {
+            throw new MissingParametersException(__METHOD__, ['id', 'url']);
+        }
+
+        $endpoint = $this->getRoute(__FUNCTION__, ['id' => $params['id']]);
+
+        $putData = [
+            self::OBJ_NAME => [
+                'remote_photo_url' => $params['url']
+            ]
+        ];
+
+        return $this->client->put($endpoint, $putData);
     }
 
     /**

--- a/src/Zendesk/API/UtilityTraits/ChainedParametersTrait.php
+++ b/src/Zendesk/API/UtilityTraits/ChainedParametersTrait.php
@@ -4,16 +4,13 @@ namespace Zendesk\API\UtilityTraits;
 
 /**
  * The chained parameters trait which has helper methods for getting the parameters passed through chaining.
- *
  * An example would be a call `$client->ticket(2)->comments(3)->author();` would create an Author object with
  * chained parameters (An Array):
  *  [
  *      'Zendesk\API\Tickets' => 2,
  *      'Zendesk\API\Comments' => 3
  *  ]
- *
  * @package Zendesk\API
- *
  */
 
 trait ChainedParametersTrait
@@ -43,7 +40,6 @@ trait ChainedParametersTrait
 
     /**
      * Returns chained parameters
-     *
      * @return $this
      */
     public function getChainedParameters()
@@ -57,7 +53,6 @@ trait ChainedParametersTrait
      * @param $params
      *
      * @return $this
-     *
      */
     public function setChainedParameters($params)
     {
@@ -90,7 +85,6 @@ trait ChainedParametersTrait
 
     /**
      * Returns the named chained parameter
-     *
      * @return array
      */
     public function getLatestChainedParameter()

--- a/tests/Zendesk/API/UnitTests/BasicTest.php
+++ b/tests/Zendesk/API/UnitTests/BasicTest.php
@@ -7,6 +7,7 @@ use GuzzleHttp\Handler\MockHandler;
 use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Middleware;
 use GuzzleHttp\Psr7\LazyOpenStream;
+use GuzzleHttp\Psr7\MultipartStream;
 use Zendesk\API\HttpClient;
 
 /**
@@ -156,6 +157,15 @@ abstract class BasicTest extends \PHPUnit_Framework_TestCase
         if (isset($options['postFields'])) {
             $this->assertEquals(json_encode($options['postFields']), $request->getBody()->getContents());
         }
+
+        if (isset($options['multipart'])) {
+            $body = $request->getBody();
+            $this->assertInstanceOf(MultipartStream::class, $body);
+            $this->assertGreaterThan(0, $body->getSize());
+            $this->assertNotEmpty($header = $request->getHeader('Content-Type'));
+            $this->assertContains('multipart/form-data', $header);
+        }
+
 
         if (isset($options['file'])) {
             $body = $request->getBody();

--- a/tests/Zendesk/API/UnitTests/BasicTest.php
+++ b/tests/Zendesk/API/UnitTests/BasicTest.php
@@ -166,7 +166,6 @@ abstract class BasicTest extends \PHPUnit_Framework_TestCase
             $this->assertContains('multipart/form-data', $header);
         }
 
-
         if (isset($options['file'])) {
             $body = $request->getBody();
             $this->assertInstanceOf(LazyOpenStream::class, $body);

--- a/tests/Zendesk/API/UnitTests/UsersTest.php
+++ b/tests/Zendesk/API/UnitTests/UsersTest.php
@@ -301,7 +301,7 @@ class UsersTest extends BasicTest
     {
         $updateIds     = [12345, 80085];
         $requestParams = [
-            'ids'   => $updateIds,
+            'ids'   => implode(',', $updateIds),
             'phone' => '1234567890'
         ];
 
@@ -315,7 +315,7 @@ class UsersTest extends BasicTest
             [
                 'method'      => 'PUT',
                 'endpoint'    => 'users/update_many.json',
-                'queryParams' => ['ids' => implode(',', $requestParams['ids'])],
+                'queryParams' => ['ids' => $requestParams['ids']],
                 'postFields'  => [Users::OBJ_NAME => ['phone' => $requestParams['phone']]]
             ]
         );
@@ -440,20 +440,25 @@ class UsersTest extends BasicTest
 
     public function testUpdateProfileImage()
     {
-        $this->markTestSkipped('Need to allow file uploads with Guzzle.');
-        $this->mockApiCall('GET', '/users/12345.json?', ['id' => 12345]);
-        $this->mockApiCall('PUT', '/users/12345.json', ['user' => ['id' => 12345]]);
-
-        $user = $this->client->users(12345)->updateProfileImage([
-            'file' => getcwd() . '/tests/assets/UK.png'
+        $this->mockAPIResponses([
+            new Response(200, [], '')
         ]);
 
-        $contentType = $this->http->requests->first()->getHeader("Content-Type")->toArray()[0];
-        $this->assertEquals($contentType, "application/binary");
+        $id = 915987427;
 
-        $this->assertEquals(is_object($user), true, 'Should return an object');
-        $this->assertEquals(is_object($user->user), true, 'Should return an object called "user"');
-        $this->assertGreaterThan(0, $user->user->id, 'Should return a numeric id for request');
+        $params = [
+            'file' => getcwd() . '/tests/assets/UK.png'
+        ];
+
+        $this->client->users($id)->updateProfileImageFromFile($params);
+
+        $this->assertLastRequestIs(
+            [
+                'method'   => 'PUT',
+                'endpoint' => "users/{$id}.json",
+                'multipart'
+            ]
+        );
     }
 
     public function testAuthenticatedUser()

--- a/tests/Zendesk/API/UnitTests/UsersTest.php
+++ b/tests/Zendesk/API/UnitTests/UsersTest.php
@@ -342,7 +342,6 @@ class UsersTest extends BasicTest
             new Response(200, [], json_encode(['job_status' => ['id' => 1]]))
         ]);
 
-
         $jobStatus = $this->client->users()->updateMany($requestParams);
 
         $this->assertLastRequestIs(
@@ -470,7 +469,7 @@ class UsersTest extends BasicTest
         $id = 915987427;
 
         $params = [
-            'url' => 'https://d16cvnquvjw7pr.cloudfront.net/www/img/p-brand/downloads/Logo/Zendesk_logo_RGB.png'
+            'url' => 'http://www.test.com/profile.png'
         ];
 
         $this->client->users($id)->updateProfileImageFromUrl($params);

--- a/tests/Zendesk/API/UnitTests/UsersTest.php
+++ b/tests/Zendesk/API/UnitTests/UsersTest.php
@@ -301,7 +301,7 @@ class UsersTest extends BasicTest
     {
         $updateIds     = [12345, 80085];
         $requestParams = [
-            'ids'   => implode(',', $updateIds),
+            'ids'   => $updateIds,
             'phone' => '1234567890'
         ];
 
@@ -315,7 +315,7 @@ class UsersTest extends BasicTest
             [
                 'method'      => 'PUT',
                 'endpoint'    => 'users/update_many.json',
-                'queryParams' => ['ids' => $requestParams['ids']],
+                'queryParams' => ['ids' => implode(',', $requestParams['ids'])],
                 'postFields'  => [Users::OBJ_NAME => ['phone' => $requestParams['phone']]]
             ]
         );
@@ -438,7 +438,7 @@ class UsersTest extends BasicTest
         $this->assertGreaterThan(0, $users->users[0]->id, 'Should return a numeric id for user');
     }
 
-    public function testUpdateProfileImage()
+    public function testUpdateProfileImageFromFile()
     {
         $this->mockAPIResponses([
             new Response(200, [], '')
@@ -457,6 +457,29 @@ class UsersTest extends BasicTest
                 'method'   => 'PUT',
                 'endpoint' => "users/{$id}.json",
                 'multipart'
+            ]
+        );
+    }
+
+    public function testUpdateProfileImageFromUrl()
+    {
+        $this->mockAPIResponses([
+            new Response(200, [], '')
+        ]);
+
+        $id = 915987427;
+
+        $params = [
+            'url' => 'https://d16cvnquvjw7pr.cloudfront.net/www/img/p-brand/downloads/Logo/Zendesk_logo_RGB.png'
+        ];
+
+        $this->client->users($id)->updateProfileImageFromUrl($params);
+
+        $this->assertLastRequestIs(
+            [
+                'method'     => 'PUT',
+                'endpoint'   => "users/{$id}.json",
+                'postFields' => [Users::OBJ_NAME => ['remote_photo_url' => $params['url']]],
             ]
         );
     }


### PR DESCRIPTION
Allow the user to update user profile photo with the api client.
This separates the updating by specifying a file and uploading it, and updating from a remote url.

/cc @joseconsador @jwswj @mmolina @atroche 

### References
 - Jira link: https://zendesk.atlassian.net/browse/MI-107

### Risks
 - The user might not be able to update his profile image (Low)