### PR TITLE
[MI-105] Move Auth operations to it's own utility class

### DIFF
--- a/src/Zendesk/API/Http.php
+++ b/src/Zendesk/API/Http.php
@@ -7,6 +7,7 @@ use GuzzleHttp\Psr7\LazyOpenStream;
 use GuzzleHttp\Psr7\Request;
 use Zendesk\API\Exceptions\ApiResponseException;
 use Zendesk\API\Exceptions\AuthException;
+use Zendesk\API\Utilities\Auth;
 
 /**
  * HTTP functions via curl
@@ -75,11 +76,11 @@ class Http
             $options
         );
 
-        $headers = [
+        $headers        = [
             'Accept'       => 'application/json',
             'Content-Type' => $options['contentType'],
         ];
-
+        $requestOptions = [];
 
         $request = new Request(
             $options['method'],
@@ -105,18 +106,8 @@ class Http
         }
 
         try {
-            if ($client->getAuthStrategy() === HttpClient::AUTH_BASIC) {
-                $authOptions = $client->getAuthOptions();
-                $options     = ['auth' => [$authOptions['username'] . '/token', $authOptions['token'], 'basic']];
-                $response    = $client->guzzle->send($request, $options);
-            } elseif ($client->getAuthStrategy() === HttpClient::AUTH_OAUTH) {
-                $authOptions = $client->getAuthOptions();
-                $oAuthToken  = $authOptions['token'];
-                $request     = $request->withAddedHeader('Authorization', ' Bearer ' . $oAuthToken);
-                $response    = $client->guzzle->send($request);
-            } else {
-                throw new AuthException('Please set authentication to send requests.');
-            }
+            list ($request, $requestOptions) = Auth::prepareRequest($client, $request, $requestOptions);
+            $response = $client->guzzle->send($request, $requestOptions);
 
             $client->setDebug(
                 $response->getHeaders(),

--- a/src/Zendesk/API/HttpClient.php
+++ b/src/Zendesk/API/HttpClient.php
@@ -20,6 +20,7 @@ use Zendesk\API\Resources\Triggers;
 use Zendesk\API\Resources\UserFields;
 use Zendesk\API\Resources\Users;
 use Zendesk\API\Resources\Views;
+use Zendesk\API\Utilities\Auth;
 use Zendesk\API\UtilityTraits\InstantiatorTrait;
 
 /**
@@ -33,9 +34,6 @@ use Zendesk\API\UtilityTraits\InstantiatorTrait;
 class HttpClient
 {
     use InstantiatorTrait;
-
-    const AUTH_OAUTH = 'oauth';
-    const AUTH_BASIC = 'basic';
 
     /**
      * @var string
@@ -191,7 +189,7 @@ class HttpClient
      */
     public function setAuth($strategy, array $options)
     {
-        $validAuthStrategies = [self::AUTH_BASIC, self::AUTH_OAUTH];
+        $validAuthStrategies = [Auth::BASIC, Auth::OAUTH];
         if (! in_array($strategy, $validAuthStrategies)) {
             throw new AuthException('Invalid auth strategy set, please use `'
                                     . implode('` or `', $validAuthStrategies)
@@ -200,11 +198,11 @@ class HttpClient
 
         $this->authStrategy = $strategy;
 
-        if ($strategy == self::AUTH_BASIC) {
+        if ($strategy == Auth::BASIC) {
             if (! array_key_exists('username', $options) || ! array_key_exists('token', $options)) {
                 throw new AuthException('Please supply `username` and `token` for basic auth.');
             }
-        } elseif ($strategy == self::AUTH_OAUTH) {
+        } elseif ($strategy == Auth::OAUTH) {
             if (! array_key_exists('token', $options)) {
                 throw new AuthException('Please supply `token` for oauth.');
             }

--- a/src/Zendesk/API/Utilities/Auth.php
+++ b/src/Zendesk/API/Utilities/Auth.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Zendesk\API\Utilities;
+
+use Psr\Http\Message\RequestInterface;
+use Zendesk\API\Exceptions\AuthException;
+use Zendesk\API\HttpClient;
+
+/**
+ * Class Auth
+ * This helper would manage all Authentication related operations.
+ */
+class Auth
+{
+    /**
+     * The authentication setting to use an OAuth Token.
+     */
+    const OAUTH = 'oauth';
+    /**
+     * The authentication setting to use Basic authentication with a username and API Token.
+     */
+    const BASIC = 'basic';
+
+    public static function prepareRequest(HttpClient $client, RequestInterface $request, array $requestOptions = [])
+    {
+        if ($client->getAuthStrategy() === self::BASIC) {
+            $authOptions    = $client->getAuthOptions();
+            $requestOptions = array_merge($requestOptions, [
+                'auth' => [
+                    $authOptions['username'] . '/token',
+                    $authOptions['token'],
+                    'basic'
+                ]
+            ]);
+        } elseif ($client->getAuthStrategy() === Auth::OAUTH) {
+            $authOptions = $client->getAuthOptions();
+            $oAuthToken  = $authOptions['token'];
+            $request     = $request->withAddedHeader('Authorization', ' Bearer ' . $oAuthToken);
+        } else {
+            throw new AuthException('Please set authentication to send requests.');
+        }
+
+        return [$request, $requestOptions];
+
+    }
+}

--- a/tests/Zendesk/API/UnitTests/AuthTest.php
+++ b/tests/Zendesk/API/UnitTests/AuthTest.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Zendesk\API\UnitTests;
+
+use GuzzleHttp\Psr7\Request;
+use Zendesk\API\Utilities\Auth;
+
+/**
+ * Auth test class
+ */
+class AuthTest extends BasicTest
+{
+    /**
+     * Test the preparing of a request for basic authentication.
+     */
+    public function testPrepareBasicAuth()
+    {
+        $this->client->setAuth('basic', ['username' => $this->username, 'token' => $this->token]);
+
+        $currentRequest        = new Request('GET', 'http://www.endpoint.com/test.json');
+        $currentRequestOptions = ['existing' => 'option'];
+
+        list ($request, $requestOptions) = Auth::prepareRequest($this->client, $currentRequest, $currentRequestOptions);
+
+        $this->assertInstanceOf(Request::class, $request, 'Should have returned a request');
+
+        $this->assertArrayHasKey('existing', $requestOptions);
+        $this->assertArrayHasKey('auth', $requestOptions);
+        $this->assertEquals($this->username . '/token', $requestOptions['auth'][0]);
+        $this->assertEquals($this->token, $requestOptions['auth'][1]);
+        $this->assertEquals(Auth::BASIC, $requestOptions['auth'][2]);
+    }
+
+    /**
+     * Test the preparing of a request for oauth authentication.
+     */
+    public function testPrepareOAuth()
+    {
+        $this->client->setAuth('oauth', ['token' => $this->oAuthToken]);
+
+        $currentRequest        = new Request('GET', 'http://www.endpoint.com/test.json');
+        $currentRequestOptions = ['existing' => 'option'];
+
+        list ($request, $requestOptions) = Auth::prepareRequest($this->client, $currentRequest, $currentRequestOptions);
+
+        $this->assertEquals($currentRequestOptions, $requestOptions);
+        $this->assertNotEmpty($authHeader = $request->getHeader('Authorization'));
+        $this->assertEquals('Bearer ' . $this->oAuthToken, $authHeader[0]);
+    }
+}


### PR DESCRIPTION
Move the auth operations to utility class
Add unit test for auth

/cc @joseconsador @jwswj @mmolina @atroche 

### References
 - Jira link: https://zendesk.atlassian.net/browse/MI-105

### Risks
 - We might not be able to make authenticated calls with the client (High)