### PR TITLE
[MI-135] Add organization fields resource

### DIFF
--- a/src/Zendesk/API/HttpClient.php
+++ b/src/Zendesk/API/HttpClient.php
@@ -13,6 +13,7 @@ use Zendesk\API\Resources\AuditLogs;
 use Zendesk\API\Resources\Automations;
 use Zendesk\API\Resources\Groups;
 use Zendesk\API\Resources\Macros;
+use Zendesk\API\Resources\OrganizationFields;
 use Zendesk\API\Resources\Tags;
 use Zendesk\API\Resources\Targets;
 use Zendesk\API\Resources\Tickets;
@@ -166,18 +167,19 @@ class HttpClient
     public static function getValidRelations()
     {
         return [
-            'tickets'     => Tickets::class,
-            'users'       => Users::class,
-            'views'       => Views::class,
-            'tags'        => Tags::class,
-            'macros'      => Macros::class,
-            'attachments' => Attachments::class,
-            'groups'      => Groups::class,
-            'automations' => Automations::class,
-            'triggers'    => Triggers::class,
-            'targets'     => Targets::class,
-            'userFields'  => UserFields::class,
-            'auditLogs'   => AuditLogs::class,
+            'tickets'            => Tickets::class,
+            'users'              => Users::class,
+            'views'              => Views::class,
+            'tags'               => Tags::class,
+            'macros'             => Macros::class,
+            'attachments'        => Attachments::class,
+            'groups'             => Groups::class,
+            'automations'        => Automations::class,
+            'triggers'           => Triggers::class,
+            'targets'            => Targets::class,
+            'userFields'         => UserFields::class,
+            'auditLogs'          => AuditLogs::class,
+            'organizationFields' => OrganizationFields::class,
         ];
     }
 
@@ -252,10 +254,10 @@ class HttpClient
     /**
      * Set debug information as an object
      *
-     * @param mixed $lastRequestHeaders
-     * @param mixed $lastResponseCode
+     * @param mixed  $lastRequestHeaders
+     * @param mixed  $lastResponseCode
      * @param string $lastResponseHeaders
-     * @param mixed $lastResponseError
+     * @param mixed  $lastResponseError
      */
     public function setDebug($lastRequestHeaders, $lastResponseCode, $lastResponseHeaders, $lastResponseError)
     {

--- a/src/Zendesk/API/Resources/OrganizationFields.php
+++ b/src/Zendesk/API/Resources/OrganizationFields.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Zendesk\API\Resources;
+
+use Zendesk\API\Exceptions\MissingParametersException;
+
+/**
+ * The OrganizationFields class exposes methods as detailed on
+ * http://developer.zendesk.com/documentation/rest_api/organization_fields.html
+ */
+class OrganizationFields extends ResourceAbstract
+{
+    const OBJ_NAME = 'organization_field';
+    const OBJ_NAME_PLURAL = 'organization_fields';
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function setUpRoutes()
+    {
+        parent::setUpRoutes();
+
+        $this->setRoute('reorder', 'organization_fields/reorder.json');
+    }
+
+    /**
+     * Reorder organization fields
+     *
+     * @param array $params
+     *
+     * @throws MissingParametersException
+     * @throws \Exception
+     *
+     * @return mixed
+     */
+    public function reorder(array $params)
+    {
+        if (! $this->hasKeys($params, ['organization_field_ids'])) {
+            throw new MissingParametersException(__METHOD__, ['organization_field_ids']);
+        }
+
+        $putData = ['organization_field_ids' => $params['organization_field_ids']];
+
+        $endpoint = $this->getRoute(__FUNCTION__);
+        $response = $this->client->put($endpoint, $putData);
+
+        $this->client->setSideload(null);
+
+        return $response;
+    }
+}

--- a/tests/Zendesk/API/UnitTests/OrganizationFieldsTest.php
+++ b/tests/Zendesk/API/UnitTests/OrganizationFieldsTest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Zendesk\API\UnitTests;
+
+use GuzzleHttp\Psr7\Response;
+
+/**
+ * OrganizationFields test class
+ */
+class OrganizationFieldsTest extends BasicTest
+{
+    public function testReorder()
+    {
+        $this->mockAPIResponses([
+            new Response(200, [], '')
+        ]);
+
+        $postFields = ['organization_field_ids' => [14382, 14342]];
+
+        $this->client->organizationFields()->reorder($postFields);
+
+        $this->assertLastRequestIs(
+            [
+                'method'     => 'PUT',
+                'endpoint'   => 'organization_fields/reorder.json',
+                'postFields' => $postFields,
+            ]
+        );
+    }
+}


### PR DESCRIPTION
Add the organization fields resource so it can be used with the client

/cc @joseconsador @jwswj @mmolina @atroche 

### References
 - Jira link: https://zendesk.atlassian.net/browse/MI-135

### Risks
 - We might not be able to call the organization resource endpoints using the client (low)