### PR TITLE
Use BasicTest::assertEndpointCalled() for most mocked tests

### DIFF
--- a/tests/Zendesk/API/UnitTests/AppInstallationsTest.php
+++ b/tests/Zendesk/API/UnitTests/AppInstallationsTest.php
@@ -2,7 +2,6 @@
 
 namespace Zendesk\API\UnitTests;
 
-use GuzzleHttp\Psr7\Response;
 use Zendesk\API\Resources\AppInstallations;
 
 class AppInstallationsTest extends BasicTest
@@ -12,34 +11,23 @@ class AppInstallationsTest extends BasicTest
      */
     public function testResourceNameIsCorrectRoute()
     {
-        $this->mockAPIResponses([
-            new Response(200, [], '')
-        ]);
+        $resourceId = 1;
 
-        $this->client->appInstallations()->find(1);
+        $this->assertEndpointCalled(function () use ($resourceId) {
+            $this->client->appInstallations()->find($resourceId);
+        }, "apps/installations/{$resourceId}.json");
 
-        $this->assertLastRequestIs(
-            [
-                'method'   => 'GET',
-                'endpoint' => 'apps/installations/1.json'
+        $postParams = [
+            'settings' => [
+                'name'      => 'Helpful App - Updated',
+                'api_token' => '659323ngt4ut9an'
             ]
-        );
+        ];
 
-        $this->mockAPIResponses([
-            new Response(200, [], '')
-        ]);
+        $this->assertEndpointCalled(function () use ($postParams) {
+            $this->client->appInstallations()->create($postParams);
+        }, 'apps/installations.json', 'POST', ['postFields' => [AppInstallations::OBJ_NAME => $postParams]]);
 
-        $postParams = ['settings' => ['name' => 'Helpful App - Updated', 'api_token' => '659323ngt4ut9an']];
-
-        $this->client->appInstallations()->create($postParams);
-
-        $this->assertLastRequestIs(
-            [
-                'method'     => 'POST',
-                'endpoint'   => 'apps/installations.json',
-                'postFields' => [AppInstallations::OBJ_NAME => $postParams]
-            ]
-        );
     }
 
     /**
@@ -47,18 +35,10 @@ class AppInstallationsTest extends BasicTest
      */
     public function testJobStatuses()
     {
-        $this->mockAPIResponses([
-            new Response(200, [], '')
-        ]);
-
-        $this->client->appInstallations()->jobStatuses(1);
-
-        $this->assertLastRequestIs(
-            [
-                'method'   => 'GET',
-                'endpoint' => 'apps/installations/job_statuses/1.json'
-            ]
-        );
+        $resourceId = 1;
+        $this->assertEndpointCalled(function () use ($resourceId) {
+            $this->client->appInstallations()->jobStatuses($resourceId);
+        }, "apps/installations/job_statuses/{$resourceId}.json");
     }
 
     /**
@@ -66,18 +46,11 @@ class AppInstallationsTest extends BasicTest
      */
     public function testRequirements()
     {
-        $this->mockAPIResponses([
-            new Response(200, [], '')
-        ]);
+        $queryParams = ['per_page' => 50];
+        $resourceId  = 2727;
 
-        $this->client->appInstallations()->requirements(1, ['per_page' => 50]);
-
-        $this->assertLastRequestIs(
-            [
-                'method'      => 'GET',
-                'endpoint'    => 'apps/installations/1/requirements.json',
-                'queryParams' => ['per_page' => 50]
-            ]
-        );
+        $this->assertEndpointCalled(function () use ($resourceId, $queryParams) {
+            $this->client->appInstallations()->requirements($resourceId, $queryParams);
+        }, "apps/installations/{$resourceId}/requirements.json", 'GET', ['queryParams' => $queryParams]);
     }
 }

--- a/tests/Zendesk/API/UnitTests/AttachmentsTest.php
+++ b/tests/Zendesk/API/UnitTests/AttachmentsTest.php
@@ -2,8 +2,6 @@
 
 namespace Zendesk\API\UnitTests;
 
-use GuzzleHttp\Psr7\Response;
-
 /**
  * Attachments test class
  */
@@ -15,23 +13,19 @@ class AttachmentsTest extends BasicTest
      */
     public function testUploadAttachment()
     {
-        $this->mockAPIResponses([
-            new Response(201, [], '')
-        ]);
-
         $attachmentData = [
             'file' => getcwd() . '/tests/assets/UK.png',
             'type' => 'image/png',
             'name' => 'UK test non-alpha chars.png'
         ];
 
-        $this->client->attachments()->upload($attachmentData);
-
-        $this->assertLastRequestIs(
+        $this->assertEndpointCalled(
+            function () use ($attachmentData) {
+                $this->client->attachments()->upload($attachmentData);
+            },
+            'uploads.json',
+            'POST',
             [
-                'method'      => 'POST',
-                'endpoint'    => 'uploads.json',
-                'statusCode'  => 201,
                 'queryParams' => ['filename' => rawurlencode($attachmentData['name'])],
                 'file'        => $attachmentData['file'],
             ]
@@ -43,22 +37,18 @@ class AttachmentsTest extends BasicTest
      */
     public function testUploadAttachmentWithNoName()
     {
-        $this->mockAPIResponses([
-            new Response(201, [], '')
-        ]);
-
         $attachmentData = [
             'file' => getcwd() . '/tests/assets/UK.png',
             'type' => 'image/png',
         ];
 
-        $this->client->attachments()->upload($attachmentData);
-
-        $this->assertLastRequestIs(
+        $this->assertEndpointCalled(
+            function () use ($attachmentData) {
+                $this->client->attachments()->upload($attachmentData);
+            },
+            'uploads.json',
+            'POST',
             [
-                'method'      => 'POST',
-                'endpoint'    => 'uploads.json',
-                'statusCode'  => 201,
                 'queryParams' => ['filename' => 'UK.png'], // Taken from file path
                 'file'        => $attachmentData['file'],
             ]
@@ -70,19 +60,10 @@ class AttachmentsTest extends BasicTest
      */
     public function testDeleteAttachment()
     {
-        $this->mockAPIResponses([
-            new Response(200, [], '')
-        ]);
-
         $token = 'validToken';
 
-        $this->client->attachments()->deleteUpload($token);
-
-        $this->assertLastRequestIs(
-            [
-                'method'   => 'DELETE',
-                'endpoint' => "uploads/{$token}.json",
-            ]
-        );
+        $this->assertEndpointCalled(function () use ($token) {
+            $this->client->attachments()->deleteUpload($token);
+        }, "uploads/{$token}.json", 'DELETE');
     }
 }

--- a/tests/Zendesk/API/UnitTests/AuditLogsTest.php
+++ b/tests/Zendesk/API/UnitTests/AuditLogsTest.php
@@ -2,8 +2,6 @@
 
 namespace Zendesk\API\UnitTests;
 
-use GuzzleHttp\Psr7\Response;
-
 /**
  * AuditLogs test class
  */
@@ -14,17 +12,11 @@ class AuditLogsTest extends BasicTest
      */
     public function testFindAll()
     {
-        $this->mockAPIResponses([
-            new Response(200, [], '')
-        ]);
-
         $queryParams = [
             'filter["source_type"]' => 'rule',
             'filter["valid"]'       => 'somerule',
             'invalid'               => 'invalidrule',
         ];
-
-        $this->client->auditLogs()->findAll($queryParams);
 
         // We expect invalid parameters are removed.
         // We also expect url encoded keys and values
@@ -37,12 +29,13 @@ class AuditLogsTest extends BasicTest
             $expectedQueryParams = array_merge($expectedQueryParams, [urlencode($key) => urlencode($value)]);
         }
 
-        $this->assertLastRequestIs(
-            [
-                'method'      => 'GET',
-                'endpoint'    => 'audit_logs.json',
-                'queryParams' => $expectedQueryParams,
-            ]
+        $this->assertEndpointCalled(
+            function () use ($queryParams) {
+                $this->client->auditLogs()->findAll($queryParams);
+            },
+            'audit_logs.json',
+            'GET',
+            ['queryParams' => $expectedQueryParams]
         );
     }
 }

--- a/tests/Zendesk/API/UnitTests/AutomationsTest.php
+++ b/tests/Zendesk/API/UnitTests/AutomationsTest.php
@@ -2,8 +2,6 @@
 
 namespace Zendesk\API\UnitTests;
 
-use GuzzleHttp\Psr7\Response;
-
 /**
  * Automations test class
  */
@@ -15,17 +13,8 @@ class AutomationsTest extends BasicTest
      */
     public function testActive()
     {
-        $this->mockAPIResponses([
-            new Response(200, [], '')
-        ]);
-
-        $this->client->automations()->findActive();
-
-        $this->assertLastRequestIs(
-            [
-                'method'   => 'GET',
-                'endpoint' => 'automations/active.json',
-            ]
-        );
+        $this->assertEndpointCalled(function () {
+            $this->client->automations()->findActive();
+        }, 'automations/active.json');
     }
 }

--- a/tests/Zendesk/API/UnitTests/DynamicContentItemVariantsTest.php
+++ b/tests/Zendesk/API/UnitTests/DynamicContentItemVariantsTest.php
@@ -2,37 +2,34 @@
 
 namespace Zendesk\API\UnitTests;
 
-use GuzzleHttp\Psr7\Response;
-
+/**
+ * Class DynamicContentItemVariantsTest
+ */
 class DynamicContentItemVariantsTest extends BasicTest
 {
+    /**
+     * Test item id is in route
+     */
     public function testItemIdIsAddedToRoute()
     {
-        // Test the chaining
-        $this->mockAPIResponses([new Response(200, [], '')]);
+        $itemId = 12345;
+        $this->assertEndpointCalled(function () use ($itemId) {
+            $this->client->dynamicContent()->items($itemId)->variants()->findAll();
+        }, "dynamic_content/items/{$itemId}/variants.json");
 
-        $this->client->dynamicContent()->items(12345)->variants()->findAll();
-
-        $this->assertLastRequestIs(
-            [
-                'method'   => 'GET',
-                'endpoint' => 'dynamic_content/items/12345/variants.json',
-            ]
-        );
     }
 
+    /**
+     * Test variant id is added to route.
+     *
+     * @throws \Zendesk\API\Exceptions\MissingParametersException
+     */
     public function testItemIdVariantIdIsAddedToRoute()
     {
-        // Test the chaining
-        $this->mockAPIResponses([new Response(200, [], '')]);
-
-        $this->client->dynamicContent()->items(12345)->variants()->find(2);
-
-        $this->assertLastRequestIs(
-            [
-                'method'   => 'GET',
-                'endpoint' => 'dynamic_content/items/12345/variants/2.json',
-            ]
-        );
+        $itemId    = 12345;
+        $variantId = 3332;
+        $this->assertEndpointCalled(function () use ($itemId, $variantId) {
+            $this->client->dynamicContent()->items($itemId)->variants()->find($variantId);
+        }, "dynamic_content/items/{$itemId}/variants/{$variantId}.json");
     }
 }

--- a/tests/Zendesk/API/UnitTests/GroupsTest.php
+++ b/tests/Zendesk/API/UnitTests/GroupsTest.php
@@ -2,36 +2,29 @@
 
 namespace Zendesk\API\UnitTests;
 
-use GuzzleHttp\Psr7\Response;
-
+/**
+ * Class GroupsTest
+ */
 class GroupsTest extends BasicTest
 {
+    /**
+     * Test the assignable method
+     */
     public function testAssignableEndpoint()
     {
-        $this->mockAPIResponses([
-            new Response(200, [], '')
-        ]);
-
-        $this->client->groups()->assignable();
-
-        $this->assertLastRequestIs([
-            'method'   => 'GET',
-            'endpoint' => 'groups/assignable.json',
-        ]);
+        $this->assertEndpointCalled(function () {
+            $this->client->groups()->assignable();
+        }, 'groups/assignable.json');
     }
 
+    /**
+     * Test finding of user groups
+     */
     public function testFindUserGroups()
     {
-        $this->mockAPIResponses([
-            new Response(200, [], '')
-        ]);
-
-        $this->client->users(123)->groups()->findAll();
-
-        $this->assertLastRequestIs([
-            'method'   => 'GET',
-            'endpoint' => 'users/123/groups.json',
-        ]);
+        $this->assertEndpointCalled(function () {
+            $this->client->users(123)->groups()->findAll();
+        }, 'users/123/groups.json');
     }
 
     /**
@@ -39,15 +32,8 @@ class GroupsTest extends BasicTest
      */
     public function testFindAllGroups()
     {
-        $this->mockAPIResponses([
-            new Response(200, [], '')
-        ]);
-
-        $this->client->groups()->findAll();
-
-        $this->assertLastRequestIs([
-            'method'   => 'GET',
-            'endpoint' => 'groups.json',
-        ]);
+        $this->assertEndpointCalled(function () {
+            $this->client->groups()->findAll();
+        }, 'groups.json');
     }
 }

--- a/tests/Zendesk/API/UnitTests/LocalesTest.php
+++ b/tests/Zendesk/API/UnitTests/LocalesTest.php
@@ -2,19 +2,19 @@
 
 namespace Zendesk\API\UnitTests;
 
-use GuzzleHttp\Psr7\Response;
-
 /**
- * Locals test class
+ * Locales test class
  */
-class LocalsTest extends BasicTest
+class LocalesTest extends BasicTest
 {
     /**
      * Test findAllPublic method
      */
     public function testFindAllPublic()
     {
-        $this->getEndpointTest('findAllPublic', 'locales/public.json');
+        $this->assertEndpointCalled(function () {
+            $this->client->locales()->findAllPublic();
+        }, 'locales/public.json');
     }
 
     /**
@@ -22,7 +22,9 @@ class LocalsTest extends BasicTest
      */
     public function testFindAllAgent()
     {
-        $this->getEndpointTest('findAllAgent', 'locales/agent.json');
+        $this->assertEndpointCalled(function () {
+            $this->client->locales()->findAllAgent();
+        }, 'locales/agent.json');
     }
 
     /**
@@ -30,7 +32,9 @@ class LocalsTest extends BasicTest
      */
     public function testFindCurrent()
     {
-        $this->getEndpointTest('findCurrent', 'locales/current.json');
+        $this->assertEndpointCalled(function () {
+            $this->client->locales()->findCurrent();
+        }, 'locales/current.json');
     }
 
     /**
@@ -38,28 +42,8 @@ class LocalsTest extends BasicTest
      */
     public function testFindBest()
     {
-        $this->getEndpointTest('findBest', 'locales/detect_best_locale.json');
-    }
-
-    /**
-     * Test for the get endpoint using the given method and endpoint
-     *
-     * @param $method
-     * @param $endpoint
-     */
-    private function getEndpointTest($method, $endpoint)
-    {
-        $this->mockAPIResponses([
-            new Response(200, [], '')
-        ]);
-
-        $this->client->locales()->$method();
-
-        $this->assertLastRequestIs(
-            [
-                'method'   => 'GET',
-                'endpoint' => $endpoint,
-            ]
-        );
+        $this->assertEndpointCalled(function () {
+            $this->client->locales()->findBest();
+        }, 'locales/detect_best_locale.json');
     }
 }

--- a/tests/Zendesk/API/UnitTests/MacrosTest.php
+++ b/tests/Zendesk/API/UnitTests/MacrosTest.php
@@ -2,8 +2,6 @@
 
 namespace Zendesk\API\UnitTests;
 
-use GuzzleHttp\Psr7\Response;
-
 /**
  * Macros test class
  * Class MacrosTest
@@ -16,18 +14,9 @@ class MacrosTest extends BasicTest
      */
     public function testActive()
     {
-        $this->mockAPIResponses([
-            new Response(200, [], '')
-        ]);
-
-        $this->client->macros()->findAllActive();
-
-        $this->assertLastRequestIs(
-            [
-                'method'   => 'GET',
-                'endpoint' => 'macros/active.json',
-            ]
-        );
+        $this->assertEndpointCalled(function () {
+            $this->client->macros()->findAllActive();
+        }, 'macros/active.json');
     }
 
     /**
@@ -38,18 +27,9 @@ class MacrosTest extends BasicTest
     {
         $id = 1;
 
-        $this->mockAPIResponses([
-            new Response(200, [], '')
-        ]);
-
-        $this->client->macros()->apply($id);
-
-        $this->assertLastRequestIs(
-            [
-                'method'   => 'GET',
-                'endpoint' => "macros/{$id}/apply.json",
-            ]
-        );
+        $this->assertEndpointCalled(function () use ($id) {
+            $this->client->macros()->apply($id);
+        }, "macros/{$id}/apply.json");
     }
 
     /**
@@ -58,21 +38,11 @@ class MacrosTest extends BasicTest
      */
     public function testApplyToTicket()
     {
-        $id = 1;
+        $id       = 1;
         $ticketId = 3;
 
-        $this->mockAPIResponses([
-            new Response(200, [], '')
-        ]);
-
-        $this->client->macros()->applyToTicket($id, $ticketId);
-
-        $this->assertLastRequestIs(
-            [
-                'method'      => 'GET',
-                'endpoint'    => "tickets/{$ticketId}/macros/{$id}/apply.json",
-                'queryParams' => []
-            ]
-        );
+        $this->assertEndpointCalled(function () use ($id, $ticketId) {
+            $this->client->macros()->applyToTicket($id, $ticketId);
+        }, "tickets/{$ticketId}/macros/{$id}/apply.json");
     }
 }

--- a/tests/Zendesk/API/UnitTests/OAuthClientsTest.php
+++ b/tests/Zendesk/API/UnitTests/OAuthClientsTest.php
@@ -2,8 +2,6 @@
 
 namespace Zendesk\API\UnitTests;
 
-use GuzzleHttp\Psr7\Response;
-
 /**
  * OAuthClients test class
  */
@@ -26,17 +24,8 @@ class OAuthClientsTest extends BasicTest
      */
     public function testFindAllMine()
     {
-        $this->mockAPIResponses([
-            new Response(200, [], '')
-        ]);
-
-        $this->client->oauthClients()->findAllMine();
-
-        $this->assertLastRequestIs(
-            [
-                'method'   => 'GET',
-                'endpoint' => 'users/me/oauth/clients.json',
-            ]
-        );
+        $this->assertEndpointCalled(function () {
+            $this->client->oauthClients()->findAllMine();
+        }, 'users/me/oauth/clients.json');
     }
 }

--- a/tests/Zendesk/API/UnitTests/OAuthTokensTest.php
+++ b/tests/Zendesk/API/UnitTests/OAuthTokensTest.php
@@ -2,39 +2,29 @@
 
 namespace Zendesk\API\UnitTests;
 
-use GuzzleHttp\Psr7\Response;
-
+/**
+ * Class OAuthTokensTest
+ */
 class OAuthTokensTest extends BasicTest
 {
+    /**
+     * Test for revoke method
+     */
     public function testRevokeEndpoint()
     {
-        $this->mockAPIResponses([
-            new Response(200, [], '')
-        ]);
-
-        $this->client->oauthTokens()->revoke(1);
-
-        $this->assertLastRequestIs(
-            [
-                'method'   => 'DELETE',
-                'endpoint' => 'oauth/tokens/1.json'
-            ]
-        );
+        $resourceId = 183;
+        $this->assertEndpointCalled(function () use ($resourceId) {
+            $this->client->oauthTokens()->revoke($resourceId);
+        }, "oauth/tokens/{$resourceId}.json", 'DELETE');
     }
 
+    /**
+     * Test for current method
+     */
     public function testCurrentEndpoint()
     {
-        $this->mockAPIResponses([
-            new Response(200, [], '')
-        ]);
-
-        $this->client->oauthTokens()->current();
-
-        $this->assertLastRequestIs(
-            [
-                'method'   => 'GET',
-                'endpoint' => 'oauth/tokens/current.json'
-            ]
-        );
+        $this->assertEndpointCalled(function () {
+            $this->client->oauthTokens()->current();
+        }, 'oauth/tokens/current.json');
     }
 }

--- a/tests/Zendesk/API/UnitTests/OrganizationFieldsTest.php
+++ b/tests/Zendesk/API/UnitTests/OrganizationFieldsTest.php
@@ -2,29 +2,20 @@
 
 namespace Zendesk\API\UnitTests;
 
-use GuzzleHttp\Psr7\Response;
-
 /**
  * OrganizationFields test class
  */
 class OrganizationFieldsTest extends BasicTest
 {
+    /**
+     * Test reorder method
+     */
     public function testReorder()
     {
-        $this->mockAPIResponses([
-            new Response(200, [], '')
-        ]);
-
         $postFields = ['organization_field_ids' => [14382, 14342]];
 
-        $this->client->organizationFields()->reorder($postFields);
-
-        $this->assertLastRequestIs(
-            [
-                'method'     => 'PUT',
-                'endpoint'   => 'organization_fields/reorder.json',
-                'postFields' => $postFields,
-            ]
-        );
+        $this->assertEndpointCalled(function () use ($postFields) {
+            $this->client->organizationFields()->reorder($postFields);
+        }, 'organization_fields/reorder.json', 'PUT', ['postFields' => $postFields]);
     }
 }

--- a/tests/Zendesk/API/UnitTests/OrganizationMembershipsTest.php
+++ b/tests/Zendesk/API/UnitTests/OrganizationMembershipsTest.php
@@ -2,107 +2,90 @@
 
 namespace Zendesk\API\UnitTests;
 
-use GuzzleHttp\Psr7\Response;
 use Zendesk\API\Resources\OrganizationMemberships;
 
+/**
+ * Class OrganizationMembershipsTest
+ */
 class OrganizationMembershipsTest extends BasicTest
 {
+    /**
+     * Test find method
+     */
     public function testFind()
     {
-        $this->mockAPIResponses([
-            new Response(200, [], '')
-        ]);
         $resourceId = 299283;
 
-        $this->client->organizationMemberships($resourceId)->find();
-
-        $this->assertLastRequestIs([
-            'method'   => 'GET',
-            'endpoint' => "organization_memberships/{$resourceId}.json",
-        ]);
+        $this->assertEndpointCalled(function () use ($resourceId) {
+            $this->client->organizationMemberships($resourceId)->find();
+        }, "organization_memberships/{$resourceId}.json");
     }
 
+    /**
+     * Test find method with chained user
+     */
     public function testFindUserOrganizationMemberships()
     {
-        $this->mockAPIResponses([
-            new Response(200, [], '')
-        ]);
         $resourceId = 299283;
         $userId     = 28261;
 
-        $this->client->users($userId)->organizationMemberships()->find($resourceId);
-
-        $this->assertLastRequestIs([
-            'method'   => 'GET',
-            'endpoint' => "users/{$userId}/organization_memberships/{$resourceId}.json",
-        ]);
+        $this->assertEndpointCalled(function () use ($resourceId, $userId) {
+            $this->client->users($userId)->organizationMemberships()->find($resourceId);
+        }, "users/{$userId}/organization_memberships/{$resourceId}.json");
     }
 
+    /**
+     * Test find with organization memberships is passed when instantiating the resource.
+     */
     public function testFindUserOrganizationMembershipsChained()
     {
-        $this->mockAPIResponses([
-            new Response(200, [], '')
-        ]);
         $resourceId = 299283;
         $userId     = 28261;
 
-        $this->client->users($userId)->organizationMemberships($resourceId)->find();
-
-        $this->assertLastRequestIs([
-            'method'   => 'GET',
-            'endpoint' => "users/{$userId}/organization_memberships/{$resourceId}.json",
-        ]);
+        $this->assertEndpointCalled(function () use ($userId, $resourceId) {
+            $this->client->users($userId)->organizationMemberships($resourceId)->find();
+        }, "users/{$userId}/organization_memberships/{$resourceId}.json");
     }
 
+    /**
+     * Test findAll method
+     */
     public function testFindAll()
     {
-        $this->mockAPIResponses([
-            new Response(200, [], '')
-        ]);
-
-        $this->client->organizationMemberships()->findAll();
-
-        $this->assertLastRequestIs([
-            'method'   => 'GET',
-            'endpoint' => 'organization_memberships.json',
-        ]);
+        $this->assertEndpointCalled(function () {
+            $this->client->organizationMemberships()->findAll();
+        }, 'organization_memberships.json');
     }
 
+    /**
+     * Test findAll with user resource chained
+     */
     public function testFindAllUserOrganizationMemberships()
     {
-        $this->mockAPIResponses([
-            new Response(200, [], '')
-        ]);
-
         $userId = 123;
 
-        $this->client->users($userId)->organizationMemberships()->findAll();
+        $this->assertEndpointCalled(function () use ($userId) {
+            $this->client->users($userId)->organizationMemberships()->findAll();
+        }, "users/{$userId}/organization_memberships.json");
 
-        $this->assertLastRequestIs([
-            'method'   => 'GET',
-            'endpoint' => "users/{$userId}/organization_memberships.json",
-        ]);
     }
 
+    /**
+     * Test findAll with organizations chained
+     */
     public function testFindAllOrganizationMemberships()
     {
-        $this->mockAPIResponses([
-            new Response(200, [], '')
-        ]);
-
-        $this->client->organizations(123)->organizationMemberships()->findAll();
-
-        $this->assertLastRequestIs([
-            'method'   => 'GET',
-            'endpoint' => 'organizations/123/organization_memberships.json',
-        ]);
+        $resourceId = 123;
+        $this->assertEndpointCalled(function () use ($resourceId) {
+            $this->client->organizations($resourceId)->organizationMemberships()->findAll();
+        }, "organizations/{$resourceId}/organization_memberships.json");
     }
 
+    /**
+     * Test create endpoint
+     */
     public function testCreateOrganizationMemberships()
     {
-        $this->mockAPIResponses([
-            new Response(200, [], '')
-        ]);
         $postFields = [
             'id'              => 461,
             'user_id'         => 72,
@@ -112,21 +95,23 @@ class OrganizationMembershipsTest extends BasicTest
             'updated_at'      => '2012-04-03T12:34:01Z'
         ];
 
-        $this->client->organizationMemberships()->create($postFields);
-
-        $this->assertLastRequestIs([
-            'method'     => 'POST',
-            'endpoint'   => 'organization_memberships.json',
-            'postFields' => [OrganizationMemberships::OBJ_NAME => $postFields],
-        ]);
+        $this->assertEndpointCalled(
+            function () use ($postFields) {
+                $this->client->organizationMemberships()->create($postFields);
+            },
+            'organization_memberships.json',
+            'POST',
+            [
+                'postFields' => [OrganizationMemberships::OBJ_NAME => $postFields],
+            ]
+        );
     }
 
+    /**
+     * Test create endpoint with user resource chained
+     */
     public function testCreateUserOrganizationMemberships()
     {
-        $this->mockAPIResponses([
-            new Response(200, [], '')
-        ]);
-
         $userId     = 282;
         $postFields = [
             'id'              => 461,
@@ -137,21 +122,24 @@ class OrganizationMembershipsTest extends BasicTest
             'updated_at'      => '2012-04-03T12:34:01Z'
         ];
 
-        $this->client->users($userId)->organizationMemberships()->create($postFields);
+        $this->assertEndpointCalled(
+            function () use ($userId, $postFields) {
+                $this->client->users($userId)->organizationMemberships()->create($postFields);
+            },
+            "users/{$userId}/organization_memberships.json",
+            'POST',
+            [
+                'postFields' => [OrganizationMemberships::OBJ_NAME => $postFields],
+            ]
+        );
 
-        $this->assertLastRequestIs([
-            'method'     => 'POST',
-            'endpoint'   => "users/{$userId}/organization_memberships.json",
-            'postFields' => [OrganizationMemberships::OBJ_NAME => $postFields],
-        ]);
     }
 
+    /**
+     * Test createMany method
+     */
     public function testCreateMany()
     {
-        $this->mockAPIResponses([
-            new Response(200, [], '')
-        ]);
-
         $postFields = [
             [
                 'user_id'         => 72,
@@ -163,113 +151,107 @@ class OrganizationMembershipsTest extends BasicTest
             ],
         ];
 
-        $this->client->organizationMemberships()->createMany($postFields);
+        $this->assertEndpointCalled(
+            function () use ($postFields) {
+                $this->client->organizationMemberships()->createMany($postFields);
+            },
+            'organization_memberships/create_many.json',
+            'POST',
+            [
+                'postFields' => [OrganizationMemberships::OBJ_NAME_PLURAL => $postFields],
+            ]
+        );
 
-        $this->assertLastRequestIs([
-            'method'     => 'POST',
-            'endpoint'   => 'organization_memberships/create_many.json',
-            'postFields' => [OrganizationMemberships::OBJ_NAME_PLURAL => $postFields],
-        ]);
     }
 
+    /**
+     * Test delete method
+     */
     public function testDelete()
     {
-        $this->mockAPIResponses([
-            new Response(200, [], '')
-        ]);
         $resourceId = 299283;
 
-        $this->client->organizationMemberships($resourceId)->delete();
-
-        $this->assertLastRequestIs([
-            'method'   => 'DELETE',
-            'endpoint' => "organization_memberships/{$resourceId}.json",
-        ]);
+        $this->assertEndpointCalled(function () use ($resourceId) {
+            $this->client->organizationMemberships($resourceId)->delete();
+        }, "organization_memberships/{$resourceId}.json", 'DELETE');
     }
 
+    /**
+     * Test delete method with chained user resource
+     */
     public function testDeleteUserOrganizationMemberships()
     {
-        $this->mockAPIResponses([
-            new Response(200, [], '')
-        ]);
         $resourceId = 299283;
         $userId     = 28261;
 
-        $this->client->users($userId)->organizationMemberships()->delete($resourceId);
-
-        $this->assertLastRequestIs([
-            'method'   => 'DELETE',
-            'endpoint' => "users/{$userId}/organization_memberships/{$resourceId}.json",
-        ]);
+        $this->assertEndpointCalled(function () use ($userId, $resourceId) {
+            $this->client->users($userId)->organizationMemberships()->delete($resourceId);
+        }, "users/{$userId}/organization_memberships/{$resourceId}.json", 'DELETE');
     }
 
+    /**
+     * Test delete with chained user resource and passing the membership id when instantiating.
+     */
     public function testDeleteUserOrganizationMembershipsChained()
     {
-        $this->mockAPIResponses([
-            new Response(200, [], '')
-        ]);
         $resourceId = 299283;
         $userId     = 28261;
 
-        $this->client->users($userId)->organizationMemberships($resourceId)->delete();
-
-        $this->assertLastRequestIs([
-            'method'   => 'DELETE',
-            'endpoint' => "users/{$userId}/organization_memberships/{$resourceId}.json",
-        ]);
+        $this->assertEndpointCalled(function () use ($resourceId, $userId) {
+            $this->client->users($userId)->organizationMemberships($resourceId)->delete();
+        }, "users/{$userId}/organization_memberships/{$resourceId}.json", 'DELETE');
     }
 
+    /**
+     * Test delete many method
+     */
     public function testDeleteMany()
     {
-        $this->mockAPIResponses([
-            new Response(200, [], '')
-        ]);
         $resourceIds = [299283, 2331];
 
-        $this->client->organizationMemberships()->deleteMany($resourceIds);
-
-        $this->assertLastRequestIs([
-            'method'      => 'DELETE',
-            'endpoint'    => "organization_memberships/destroy_many.json",
-            'queryParams' => ['ids' => implode(',', $resourceIds)],
-        ]);
+        $this->assertEndpointCalled(
+            function () use ($resourceIds) {
+                $this->client->organizationMemberships()->deleteMany($resourceIds);
+            },
+            "organization_memberships/destroy_many.json",
+            'DELETE',
+            [
+                'queryParams' => ['ids' => implode(',', $resourceIds)],
+            ]
+        );
     }
 
+    /**
+     * Test for make default method
+     */
     public function testMakeDefault()
     {
-        $this->mockAPIResponses([
-            new Response(200, [], '')
-        ]);
-
         $params = [
             'id'     => 1122,
             'userId' => 2341,
         ];
 
-        $this->client->organizationMemberships()->makeDefault($params);
-
-        $this->assertLastRequestIs([
-            'method'   => 'PUT',
-            'endpoint' => "users/{$params['userId']}/organization_memberships/{$params['id']}/make_default.json",
-        ]);
+        $this->assertEndpointCalled(
+            function () use ($params) {
+                $this->client->organizationMemberships()->makeDefault($params);
+            },
+            "users/{$params['userId']}/organization_memberships/{$params['id']}/make_default.json",
+            'PUT'
+        );
     }
 
+    /**
+     * Test for make default method using chaining
+     */
     public function testMakeDefaultChained()
     {
-        $this->mockAPIResponses([
-            new Response(200, [], '')
-        ]);
-
         $params = [
             'id'     => 1122,
             'userId' => 2341,
         ];
 
-        $this->client->users($params['userId'])->organizationMemberships($params['id'])->makeDefault();
-
-        $this->assertLastRequestIs([
-            'method'   => 'PUT',
-            'endpoint' => "users/{$params['userId']}/organization_memberships/{$params['id']}/make_default.json",
-        ]);
+        $this->assertEndpointCalled(function () use ($params) {
+            $this->client->users($params['userId'])->organizationMemberships($params['id'])->makeDefault();
+        }, "users/{$params['userId']}/organization_memberships/{$params['id']}/make_default.json", 'PUT');
     }
 }

--- a/tests/Zendesk/API/UnitTests/OrganizationSubscriptionsTest.php
+++ b/tests/Zendesk/API/UnitTests/OrganizationSubscriptionsTest.php
@@ -2,10 +2,14 @@
 
 namespace Zendesk\API\UnitTests;
 
-use GuzzleHttp\Psr7\Response;
-
+/**
+ * Class OrganizationSubscriptionsTest
+ */
 class OrganizationSubscriptionsTest extends BasicTest
 {
+    /**
+     * Test that the resource name is set correctly
+     */
     public function testResourceNameIsCorrect()
     {
         $resourceName = $this->client->organizationSubscriptions()->getResourceName();
@@ -17,40 +21,26 @@ class OrganizationSubscriptionsTest extends BasicTest
         );
     }
 
+    /**
+     * Test find method with chained user resource
+     */
     public function testFindUserOrganizations()
     {
-        $this->mockAPIResponses(
-            [
-                new Response(200, [], '')
-            ]
-        );
-
-        $this->client->users(123)->organizationSubscriptions()->findAll();
-
-        $this->assertLastRequestIs(
-            [
-                'method'   => 'GET',
-                'endpoint' => 'users/123/organization_subscriptions.json',
-            ]
-        );
+        $userId = 82828;
+        $this->assertEndpointCalled(function () use ($userId) {
+            $this->client->users($userId)->organizationSubscriptions()->findAll();
+        }, "users/{$userId}/organization_subscriptions.json");
     }
 
+    /**
+     * Test find method with chained organization resource
+     */
     public function testFindOrganizationSubscriptions()
     {
-        $this->mockAPIResponses(
-            [
-                new Response(200, [], '')
-            ]
-        );
-
-        $this->client->organizations(123)->subscriptions()->findAll();
-
-        $this->assertLastRequestIs(
-            [
-                'method'   => 'GET',
-                'endpoint' => 'organizations/123/subscriptions.json',
-            ]
-        );
+        $organizationId = 9393;
+        $this->assertEndpointCalled(function () use ($organizationId) {
+            $this->client->organizations($organizationId)->subscriptions()->findAll();
+        }, "organizations/{$organizationId}/subscriptions.json");
     }
 
     /**
@@ -58,19 +48,8 @@ class OrganizationSubscriptionsTest extends BasicTest
      */
     public function testFindAllOrganizationSubscriptions()
     {
-        $this->mockAPIResponses(
-            [
-                new Response(200, [], '')
-            ]
-        );
-
-        $this->client->organizationSubscriptions()->findAll();
-
-        $this->assertLastRequestIs(
-            [
-                'method'   => 'GET',
-                'endpoint' => 'organization_subscriptions.json',
-            ]
-        );
+        $this->assertEndpointCalled(function () {
+            $this->client->organizationSubscriptions()->findAll();
+        }, 'organization_subscriptions.json');
     }
 }

--- a/tests/Zendesk/API/UnitTests/OrganizationsTest.php
+++ b/tests/Zendesk/API/UnitTests/OrganizationsTest.php
@@ -2,22 +2,20 @@
 
 namespace Zendesk\API\UnitTests;
 
-use GuzzleHttp\Psr7\Response;
-
+/**
+ * Class OrganizationsTest
+ */
 class OrganizationsTest extends BasicTest
 {
+    /**
+     * test for FindAll with chained user resource.
+     */
     public function testFindUserOrganizations()
     {
-        $this->mockAPIResponses([
-            new Response(200, [], '')
-        ]);
-
-        $this->client->users(123)->organizations()->findAll();
-
-        $this->assertLastRequestIs([
-            'method'   => 'GET',
-            'endpoint' => 'users/123/organizations.json',
-        ]);
+        $userId = 232;
+        $this->assertEndpointCalled(function () use ($userId) {
+            $this->client->users($userId)->organizations()->findAll();
+        }, "users/{$userId}/organizations.json");
     }
 
     /**
@@ -25,60 +23,40 @@ class OrganizationsTest extends BasicTest
      */
     public function testFindAllOrganizations()
     {
-        $this->mockAPIResponses([
-            new Response(200, [], '')
-        ]);
-
-        $this->client->organizations()->findAll();
-
-        $this->assertLastRequestIs([
-            'method'   => 'GET',
-            'endpoint' => 'organizations.json',
-        ]);
+        $this->assertEndpointCalled(function () {
+            $this->client->organizations()->findAll();
+        }, 'organizations.json');
     }
 
+    /**
+     * Test for autocomplete method
+     */
     public function testAutocomplete()
     {
-        $this->mockAPIResponses([
-            new Response(200, [], '')
-        ]);
-
-        $this->client->organizations()->autocomplete('foo');
-
-        $this->assertLastRequestIs([
-            'method'      => 'GET',
-            'endpoint'    => 'organizations/autocomplete.json',
-            'queryParams' => ['name' => 'foo']
-        ]);
+        $this->assertEndpointCalled(function () {
+            $this->client->organizations()->autocomplete('foo');
+        }, 'organizations/autocomplete.json', 'GET', ['queryParams' => ['name' => 'foo']]);
     }
 
+    /**
+     * Test related method
+     */
     public function testRelated()
     {
-        $this->mockAPIResponses([
-            new Response(200, [], '')
-        ]);
-
-        $this->client->organizations()->related(123);
-
-        $this->assertLastRequestIs([
-            'method'      => 'GET',
-            'endpoint'    => 'organizations/123/related.json',
-            'queryParams' => []
-        ]);
+        $resourceId = 123;
+        $this->assertEndpointCalled(function () use ($resourceId) {
+            $this->client->organizations()->related($resourceId);
+        }, "organizations/{$resourceId}/related.json");
     }
 
+    /**
+     * Test for search method
+     */
     public function testSearchByExternalId()
     {
-        $this->mockAPIResponses([
-            new Response(200, [], '')
-        ]);
-
-        $this->client->organizations()->search(123);
-
-        $this->assertLastRequestIs([
-            'method'      => 'GET',
-            'endpoint'    => 'organizations/search.json',
-            'queryParams' => ['external_id' => 123]
-        ]);
+        $externalId = 123;
+        $this->assertEndpointCalled(function () use ($externalId) {
+            $this->client->organizations()->search($externalId);
+        }, 'organizations/search.json', 'GET', ['queryParams' => ['external_id' => 123]]);
     }
 }

--- a/tests/Zendesk/API/UnitTests/RequestCommentsTest.php
+++ b/tests/Zendesk/API/UnitTests/RequestCommentsTest.php
@@ -7,6 +7,9 @@ namespace Zendesk\API\UnitTests;
  */
 class RequestCommentsTest extends BasicTest
 {
+    /**
+     * Test findAll method
+     */
     public function testFindAll()
     {
         $requestId = 3838;
@@ -16,6 +19,9 @@ class RequestCommentsTest extends BasicTest
         }, "requests/{$requestId}/comments.json");
     }
 
+    /**
+     * Test find method
+     */
     public function testFind()
     {
         $resourceId = 3838;

--- a/tests/Zendesk/API/UnitTests/RequestsTest.php
+++ b/tests/Zendesk/API/UnitTests/RequestsTest.php
@@ -7,6 +7,9 @@ namespace Zendesk\API\UnitTests;
  */
 class RequestsTest extends BasicTest
 {
+    /**
+     * test findAll method
+     */
     public function testFindAll()
     {
         $this->assertEndpointCalled(function () {
@@ -14,6 +17,9 @@ class RequestsTest extends BasicTest
         }, 'requests.json');
     }
 
+    /**
+     * Test findAllOpen method
+     */
     public function testFindAllOpen()
     {
         $this->assertEndpointCalled(function () {
@@ -21,6 +27,9 @@ class RequestsTest extends BasicTest
         }, 'requests/open.json');
     }
 
+    /**
+     * Test findAllSolved method
+     */
     public function testFindAllSolved()
     {
         $this->assertEndpointCalled(function () {
@@ -28,6 +37,9 @@ class RequestsTest extends BasicTest
         }, 'requests/solved.json');
     }
 
+    /**
+     * Test findAllCCd method
+     */
     public function testFindAllCCd()
     {
         $this->assertEndpointCalled(function () {
@@ -35,6 +47,9 @@ class RequestsTest extends BasicTest
         }, 'requests/ccd.json');
     }
 
+    /**
+     * Test findAll method with a chained user
+     */
     public function testFindAllChainedUser()
     {
         $userId = 8373;
@@ -44,6 +59,9 @@ class RequestsTest extends BasicTest
         }, "users/{$userId}/requests.json");
     }
 
+    /**
+     * Test findAll method with chained organization
+     */
     public function testFindAllChainedOrganization()
     {
         $organizationId = 8373;
@@ -53,6 +71,9 @@ class RequestsTest extends BasicTest
         }, "organizations/{$organizationId}/requests.json");
     }
 
+    /**
+     * Test search method
+     */
     public function testSearch()
     {
         $queryParams = [
@@ -63,14 +84,5 @@ class RequestsTest extends BasicTest
         $this->assertEndpointCalled(function () use ($queryParams) {
             $this->client->requests()->search($queryParams);
         }, 'requests/search.json', 'GET', ['queryParams' => $queryParams]);
-    }
-
-    public function testFind()
-    {
-        $resourceId = 3838;
-
-        $this->assertEndpointCalled(function () use ($resourceId) {
-            $this->client->requests()->find($resourceId);
-        }, "requests/{$resourceId}.json");
     }
 }

--- a/tests/Zendesk/API/UnitTests/ResourceTest.php
+++ b/tests/Zendesk/API/UnitTests/ResourceTest.php
@@ -3,194 +3,169 @@ namespace Zendesk\API\UnitTests;
 
 use GuzzleHttp\Psr7\Response;
 
+/**
+ * Class ResourceTest
+ */
 class ResourceTest extends BasicTest
 {
     private $dummyResource;
 
+    /**
+     * {@inheritdoc}
+     */
     public function setUp()
     {
         parent::setUp();
         $this->dummyResource = new DummyResource($this->client);
     }
 
+    /**
+     * Test findAll method
+     */
     public function testFindAll()
     {
-        $this->mockAPIResponses([
-            new Response(200, [], '')
-        ]);
-
-        $this->dummyResource->findAll();
-
-        $this->assertLastRequestIs([
-            'method'   => 'GET',
-            'endpoint' => 'dummy_resource.json',
-        ]);
+        $this->assertEndpointCalled(function () {
+            $this->dummyResource->findAll();
+        }, 'dummy_resource.json');
     }
 
+    /**
+     * Test find method
+     */
     public function testFind()
     {
-        $this->mockAPIResponses([
-            new Response(200, [], json_encode(['dummy' => true]))
-        ]);
-
-        $this->dummyResource->find(1);
-
-        $this->assertLastRequestIs([
-            'method'      => 'GET',
-            'endpoint'    => 'dummy_resource/1.json',
-            'queryParams' => []
-        ]);
+        $resourceId = 8282;
+        $this->assertEndpointCalled(function () use ($resourceId) {
+            $this->dummyResource->find($resourceId);
+        }, "dummy_resource/{$resourceId}.json");
     }
 
+    /**
+     * Test we can set the iterator parameters
+     */
     public function testCanSetIteratorParams()
     {
-        $this->mockAPIResponses([
-            new Response(200, [], json_encode(['dummy' => true]))
-        ]);
-
         $iterators = ['per_page' => 1, 'page' => 2, 'sort_order' => 'desc', 'sort_by' => 'date'];
 
-        $this->dummyResource->findAll($iterators);
-
-        $this->assertLastRequestIs([
-            'method'      => 'GET',
-            'endpoint'    => 'dummy_resource.json',
-            'queryParams' => $iterators
-        ]);
+        $this->assertEndpointCalled(function () use ($iterators) {
+            $this->dummyResource->findAll($iterators);
+        }, 'dummy_resource.json', 'GET', ['queryParams' => $iterators]);
     }
 
+    /**
+     * Test create method
+     */
     public function testCreate()
     {
-        $this->mockAPIResponses([
-            new Response(200, [], '')
-        ]);
-
         $postFields = ['foo' => 'test body'];
 
-        $this->dummyResource->create($postFields);
-
-        $this->assertLastRequestIs(
-            [
-                'method'     => 'POST',
-                'endpoint'   => 'dummy_resource.json',
-                'postFields' => ['dummy' => $postFields]
-            ]
+        $this->assertEndpointCalled(
+            function () use ($postFields) {
+                $this->dummyResource->create($postFields);
+            },
+            'dummy_resource.json',
+            'POST',
+            ['postFields' => ['dummy' => $postFields]]
         );
     }
 
+    /**
+     * Test update method
+     */
     public function testUpdate()
     {
-        $this->mockAPIResponses([
-            new Response(200, [], '')
-        ]);
-
+        $resourceId = 39392;
         $postFields = ['foo' => 'test body'];
-        $this->dummyResource->update(1, $postFields);
-
-        $this->assertLastRequestIs(
-            [
-                'method'     => 'PUT',
-                'endpoint'   => 'dummy_resource/1.json',
-                'postFields' => ['dummy' => $postFields],
-            ]
+        $this->assertEndpointCalled(
+            function () use ($resourceId, $postFields) {
+                $this->dummyResource->update($resourceId, $postFields);
+            },
+            "dummy_resource/{$resourceId}.json",
+            'PUT',
+            ['postFields' => ['dummy' => $postFields]]
         );
     }
 
+    /**
+     * Test delete method
+     */
     public function testDelete()
     {
-        $this->mockAPIResponses([
-            new Response(200, [], '')
-        ]);
 
-        $this->dummyResource->delete(1);
-
-        $this->assertLastRequestIs(
-            [
-                'method'   => 'DELETE',
-                'endpoint' => 'dummy_resource/1.json'
-            ]
-        );
+        $resourceId = 292;
+        $this->assertEndpointCalled(function () use ($resourceId) {
+            $this->dummyResource->delete($resourceId);
+        }, "dummy_resource/{$resourceId}.json", 'DELETE');
     }
 
+    /**
+     * Test setting of sideloads
+     */
     public function testSideLoad()
     {
-        $this->mockAPIResponses([
-            new Response(200, [], json_encode(['dummy' => true]))
-        ]);
-
         $sideloads = ['foo', 'bar', 'hello', 'world'];
-        $this->dummyResource->sideload($sideloads);
-        $this->dummyResource->findAll();
 
-        $this->assertLastRequestIs([
-            'method'      => 'GET',
-            'endpoint'    => 'dummy_resource.json',
-            'queryParams' => ['include' => implode(',', $sideloads)]
-        ]);
+        $this->assertEndpointCalled(function () use ($sideloads) {
+            $this->dummyResource->sideload($sideloads);
+            $this->dummyResource->findAll();
+        }, 'dummy_resource.json', 'GET', ['queryParams' => ['include' => implode(',', $sideloads)]]);
     }
 
+    /**
+     * Test createMany method
+     */
     public function testCreateMany()
     {
-        $this->mockAPIResponses([
-            new Response(200, [], '')
-        ]);
-
         $postFields = [['foo' => 'test body'], ['foo2' => 'test body 2'], ['foo3' => 'test body3']];
 
-        $this->dummyResource->createMany($postFields);
-
-        $this->assertLastRequestIs(
-            [
-                'method'     => 'POST',
-                'endpoint'   => 'dummy_resource/create_many.json',
-                'postFields' => [DummyResource::OBJ_NAME_PLURAL => $postFields]
-            ]
+        $this->assertEndpointCalled(
+            function () use ($postFields) {
+                $this->dummyResource->createMany($postFields);
+            },
+            'dummy_resource/create_many.json',
+            'POST',
+            ['postFields' => [DummyResource::OBJ_NAME_PLURAL => $postFields]]
         );
     }
 
+    /**
+     * Test findMany method
+     */
     public function testFindMany()
     {
-        $this->mockAPIResponses([
-            new Response(200, [], json_encode(['dummy' => true]))
-        ]);
-
         $ids = [1, 2, 3, 4, 5];
-        $this->dummyResource->findMany($ids);
-
-        $this->assertLastRequestIs([
-            'method'      => 'GET',
-            'endpoint'    => 'dummy_resource/show_many.json',
-            'queryParams' => ['ids' => implode(',', $ids)]
-        ]);
+        $this->assertEndpointCalled(function () use ($ids) {
+            $this->dummyResource->findMany($ids);
+        }, 'dummy_resource/show_many.json', 'GET', ['queryParams' => ['ids' => implode(',', $ids)]]);
     }
 
+    /**
+     * Test updateMany with the same data
+     */
     public function testUpdateManySameData()
     {
-        $this->mockAPIResponses([
-            new Response(200, [], '')
-        ]);
-
         $ids        = [1, 2, 3, 4, 5];
         $postFields = ['foo' => 'test body'];
 
-        $this->dummyResource->updateMany(array_merge(['ids' => $ids], $postFields));
-
-        $this->assertLastRequestIs(
+        $this->assertEndpointCalled(
+            function () use ($ids, $postFields) {
+                $this->dummyResource->updateMany(array_merge(['ids' => $ids], $postFields));
+            },
+            'dummy_resource/update_many.json',
+            'PUT',
             [
-                'method'      => 'PUT',
-                'endpoint'    => 'dummy_resource/update_many.json',
                 'queryParams' => ['ids' => implode(',', $ids)],
                 'postFields'  => [DummyResource::OBJ_NAME => $postFields],
             ]
         );
+
     }
 
+    /**
+     * Test updateMany with different data
+     */
     public function testUpdateManyDifferentData()
     {
-        $this->mockAPIResponses([
-            new Response(200, [], '')
-        ]);
-
         $postFields = [
             ['id' => 1, 'foo' => 'bar', 'hello' => 'world'],
             ['id' => 2, 'foo' => 'bar', 'hello' => 'world'],
@@ -198,36 +173,37 @@ class ResourceTest extends BasicTest
             ['id' => 4, 'foo' => 'bar', 'hello' => 'world']
         ];
 
-        $this->dummyResource->updateMany($postFields);
-
-        $this->assertLastRequestIs(
-            [
-                'method'     => 'PUT',
-                'endpoint'   => 'dummy_resource/update_many.json',
-                'postFields' => [DummyResource::OBJ_NAME_PLURAL => $postFields],
-            ]
+        $this->assertEndpointCalled(
+            function () use ($postFields) {
+                $this->dummyResource->updateMany($postFields);
+            },
+            'dummy_resource/update_many.json',
+            'PUT',
+            ['postFields' => [DummyResource::OBJ_NAME_PLURAL => $postFields]]
         );
+
     }
 
+    /**
+     * Test delete many
+     */
     public function testDeleteMany()
     {
-        $this->mockAPIResponses([
-            new Response(200, [], '')
-        ]);
-
         $ids = [1, 2, 3, 4, 5];
-        $this->dummyResource->deleteMany($ids);
 
-        $this->assertLastRequestIs(
-            [
-                'method'      => 'DELETE',
-                'endpoint'    => 'dummy_resource/destroy_many.json',
-                'queryParams' => ['ids' => implode(',', $ids)]
-            ]
+        $this->assertEndpointCalled(
+            function () use ($ids) {
+                $this->dummyResource->deleteMany($ids);
+            },
+            'dummy_resource/destroy_many.json',
+            'DELETE',
+            ['queryParams' => ['ids' => implode(',', $ids)]]
         );
     }
 
     /**
+     * Test we can handle server exceptions
+     *
      * @expectedException Zendesk\API\Exceptions\ApiResponseException
      * @expectedExceptionMessage Zendesk may be experiencing internal issues or undergoing scheduled maintenance.
      */
@@ -241,6 +217,8 @@ class ResourceTest extends BasicTest
     }
 
     /**
+     * Test we can handle api exceptions
+     *
      * @expectedException Zendesk\API\Exceptions\ApiResponseException
      * @expectedExceptionMessage Unprocessable Entity
      */

--- a/tests/Zendesk/API/UnitTests/SearchTest.php
+++ b/tests/Zendesk/API/UnitTests/SearchTest.php
@@ -4,26 +4,27 @@ namespace Zendesk\API\UnitTests;
 
 use GuzzleHttp\Psr7\Response;
 
+/**
+ * Class SearchTest
+ */
 class SearchTest extends BasicTest
 {
     /**
+     * Test seach using a querystring
+     *
      * @dataProvider basicQueryStrings
      */
     public function testSearchQueryString($searchString)
     {
-        $this->mockAPIResponses(
-            [
-                new Response(200, [], '')
-            ]
-        );
 
         $queryParams = ['sort_by' => 'updated_at'];
-        $this->client->search()->find($searchString, $queryParams);
-
-        $this->assertLastRequestIs(
+        $this->assertEndpointCalled(
+            function () use ($searchString, $queryParams) {
+                $this->client->search()->find($searchString, $queryParams);
+            },
+            'search.json',
+            'GET',
             [
-                'method'      => 'GET',
-                'endpoint'    => 'search.json',
                 'queryParams' => [
                     'sort_by' => 'updated_at',
                     // replace colons, the colons are a special case in this endpoint so let's do the replacement
@@ -34,6 +35,9 @@ class SearchTest extends BasicTest
         );
     }
 
+    /**
+     * @return array
+     */
     public function basicQueryStrings()
     {
         return [

--- a/tests/Zendesk/API/UnitTests/TagsTest.php
+++ b/tests/Zendesk/API/UnitTests/TagsTest.php
@@ -14,8 +14,6 @@ class TagsTest extends BasicTest
      * topics/{id}/tags.json
      * organizations/{id}/tags.json
      * users/{id}/tags.json
-     *
-     * @todo add more as these classes are built
      */
     public function testGetRoute()
     {

--- a/tests/Zendesk/API/UnitTests/TicketAuditsTest.php
+++ b/tests/Zendesk/API/UnitTests/TicketAuditsTest.php
@@ -2,59 +2,37 @@
 
 namespace Zendesk\API\UnitTests;
 
-use GuzzleHttp\Psr7\Response;
-
 /**
  * Ticket Audits test class
  */
 class TicketAuditsTest extends BasicTest
 {
-    protected $ticket_id = 12345;
+    /**
+     * @var int
+     */
+    protected $ticketId = 12345;
 
+    /**
+     * Test findAll with chained resources
+     */
     public function testFindAllWithChainedParams()
     {
-        $this->mockAPIResponses([
-            new Response(200, [], '')
-        ]);
+        $queryParams = ['per_page' => 1];
 
-        $this->client->tickets($this->ticket_id)->audits()->findAll(['per_page' => 1]);
-
-        $this->assertLastRequestIs(
-            [
-                'method'      => 'GET',
-                'endpoint'    => 'tickets/12345/audits.json',
-                'queryParams' => ['per_page' => 1]
-            ]
-        );
+        $this->assertEndpointCalled(function () use ($queryParams) {
+            $this->client->tickets($this->ticketId)->audits()->findAll($queryParams);
+        }, "tickets/{$this->ticketId}/audits.json", 'GET', ['queryParams' => $queryParams]);
     }
 
+    /**
+     * Test find with chained resources
+     */
     public function testFindWithChainedParams()
     {
-        $audit_id = 1;
+        $auditId = 1;
 
-        $response = [
-            'audit' => [
-                'id' => '1'
-            ]
-        ];
-        $this->mockAPIResponses([
-            new Response(200, [], json_encode($response))
-        ]);
-
-        $audits = $this->client->tickets($this->ticket_id)->audits($audit_id)->find();
-
-        $this->assertLastRequestIs(
-            [
-                'method'   => 'GET',
-                'endpoint' => 'tickets/12345/audits/1.json',
-            ]
-        );
-
-        $this->assertEquals(
-            is_object($audits->audit),
-            true,
-            'Should return an object containing an array called "audit"'
-        );
-        $this->assertEquals($audit_id, $audits->audit->id, 'Returns an incorrect id in audit object');
+        $this->assertEndpointCalled(function () use ($auditId) {
+            $this->client->tickets($this->ticketId)->audits($auditId)->find();
+        }, "tickets/{$this->ticketId}/audits/{$auditId}.json");
     }
 }

--- a/tests/Zendesk/API/UnitTests/TicketCommentsTest.php
+++ b/tests/Zendesk/API/UnitTests/TicketCommentsTest.php
@@ -2,70 +2,33 @@
 
 namespace Zendesk\API\UnitTests;
 
-use GuzzleHttp\Psr7\Response;
-
 /**
  * Ticket Comments test class
  */
 class TicketCommentsTest extends BasicTest
 {
-    protected $ticket_id;
-
-    public function setUp()
-    {
-        $this->testTicket = [
-            'id'       => "12345",
-            'subject'  => 'Ticket comment test',
-            'comment'  => [
-                'body' => 'Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.'
-            ],
-            'priority' => 'normal'
-        ];
-        $this->ticket_id = $this->testTicket['id'];
-
-        parent::setUp();
-    }
-
+    /**
+     * Test findAll method
+     */
     public function testAll()
     {
-        $this->mockAPIResponses([
-            new Response(200, [], json_encode(['comments' => [['id' => 1]]]))
-        ]);
 
-        $comments = $this->client->tickets($this->ticket_id)->comments()->findAll();
+        $ticketId = 1234;
+        $this->assertEndpointCalled(function () use ($ticketId) {
+            $this->client->tickets($ticketId)->comments()->findAll();
+        }, "tickets/{$ticketId}/comments.json");
 
-        $this->assertLastRequestIs(
-            [
-                'method'   => 'GET',
-                'endpoint' => 'tickets/12345/comments.json',
-            ]
-        );
-
-        $this->assertEquals(is_object($comments), true, 'Should return an object');
-        $this->assertEquals(
-            is_array($comments->comments),
-            true,
-            'Should return an object containing an array called "comments"'
-        );
-        $this->assertGreaterThan(0, $comments->comments[0]->id, 'Should return a numeric ID.');
     }
 
-    /*
+    /**
      * Test make private
      */
     public function testMakePrivate()
     {
-        $this->mockAPIResponses([
-            new Response(200, [], '')
-        ]);
-
-        $this->client->tickets(12345)->comments(1)->makePrivate();
-
-        $this->assertLastRequestIs(
-            [
-                'method'   => 'PUT',
-                'endpoint' => 'tickets/12345/comments/1/make_private.json',
-            ]
-        );
+        $ticketId  = 12345;
+        $commentId = 123;
+        $this->assertEndpointCalled(function () use ($ticketId, $commentId) {
+            $this->client->tickets($ticketId)->comments($commentId)->makePrivate();
+        }, "tickets/{$ticketId}/comments/{$commentId}/make_private.json", 'PUT');
     }
 }

--- a/tests/Zendesk/API/UnitTests/TicketFieldsTest.php
+++ b/tests/Zendesk/API/UnitTests/TicketFieldsTest.php
@@ -10,6 +10,9 @@ use Zendesk\API\Resources\TicketFields;
 class TicketFieldsTest extends BasicTest
 {
 
+    /**
+     * Test that the resource name was set correctly
+     */
     public function testResourceNameWasSetCorrectly()
     {
         $ticketFields = new TicketFields($this->client);

--- a/tests/Zendesk/API/UnitTests/TicketsTest.php
+++ b/tests/Zendesk/API/UnitTests/TicketsTest.php
@@ -37,133 +37,106 @@ class TicketsTest extends BasicTest
         parent::setUp();
     }
 
+    /**
+     * Tests if the client can call and build the tickets endpoint with the proper sideloads
+     */
     public function testAllSideLoadedMethod()
     {
-        $this->mockAPIResponses([
-            new Response(200, [], '')
-        ]);
-
-        $this->client->tickets()->sideload(['users', 'groups'])->findAll();
-
-        $this->assertLastRequestIs(
-            [
-                'method'      => 'GET',
-                'endpoint'    => 'tickets.json',
-                'queryParams' => ['include' => 'users,groups'],
-            ]
-        );
+        $this->assertEndpointCalled(function () {
+            $this->client->tickets()->sideload(['users', 'groups'])->findAll();
+        }, 'tickets.json', 'GET', ['queryParams' => ['include' => 'users,groups']]);
 
         $this->assertNull($this->client->getSideload());
     }
 
+    /**
+     * Tests if the client can call and build the tickets endpoint with the proper sideloads
+     */
     public function testAllSideLoadedParameter()
     {
-        $this->mockAPIResponses([
-            new Response(200, [], '')
-        ]);
-
-        $this->client->tickets()->findAll(['sideload' => ['users', 'groups']]);
-
-        $this->assertLastRequestIs(
-            [
-                'method'      => 'GET',
-                'endpoint'    => 'tickets.json',
-                'queryParams' => ['include' => 'users,groups'],
-            ]
-        );
+        $this->assertEndpointCalled(function () {
+            $this->client->tickets()->findAll(['sideload' => ['users', 'groups']]);
+        }, 'tickets.json', 'GET', ['queryParams' => ['include' => 'users,groups']]);
     }
 
+    /**
+     * Tests if the client can call and build the find ticket endpoint
+     */
     public function testFindSingle()
     {
-        $this->mockAPIResponses([
-            new Response(200, [], '')
-        ]);
-
-        $this->client->tickets()->find($this->testTicket['id']);
-
-        $this->assertLastRequestIs(
-            [
-                'method'   => 'GET',
-                'endpoint' => 'tickets/' . $this->testTicket['id'] . '.json',
-            ]
-        );
-
+        $this->assertEndpointCalled(function () {
+            $this->client->tickets()->find($this->testTicket['id']);
+        }, 'tickets/' . $this->testTicket['id'] . '.json');
     }
 
+    /**
+     * Tests if the client can call and build the find ticket endpoint while chaining
+     */
     public function testFindSingleChainPattern()
     {
-        $this->mockAPIResponses([
-            new Response(200, [], '')
-        ]);
-
-        $this->client->tickets($this->testTicket['id'])->find();
-
-        $this->assertLastRequestIs(
-            [
-                'method' => 'GET',
-                'tickets/' . $this->testTicket['id'] . '.json',
-            ]
-        );
+        $this->assertEndpointCalled(function () {
+            $this->client->tickets($this->testTicket['id'])->find();
+        }, 'tickets/' . $this->testTicket['id'] . '.json');
     }
 
+    /**
+     * Tests if the client can call and build the show many tickets endpoint with the correct IDs
+     */
     public function testFindMultiple()
     {
-        $this->mockAPIResponses([
-            new Response(200, [], '')
-        ]);
-
-        $this->client->tickets()->findMany([$this->testTicket['id'], $this->testTicket2['id']]);
-
-        $this->assertLastRequestIs(
+        $this->assertEndpointCalled(
+            function () {
+                $this->client->tickets()->findMany([$this->testTicket['id'], $this->testTicket2['id']]);
+            },
+            'tickets/show_many.json',
+            'GET',
             [
-                'method'      => 'GET',
-                'endpoint'    => 'tickets/show_many.json',
-                'queryParams' => ['ids' => implode(',', [$this->testTicket['id'], $this->testTicket2['id']])],
+                'queryParams' => [
+                    'ids' => implode(',', [$this->testTicket['id'], $this->testTicket2['id']])
+                ]
             ]
         );
     }
 
+    /**
+     * Tests if the client can call and build the show many tickets endpoint with the proper sideloads and correct IDs
+     */
     public function testFindMultipleWithSideload()
     {
-        $this->mockAPIResponses([
-            new Response(200, [], '')
-        ]);
-
-        $this->client->tickets()->findMany(
-            [$this->testTicket['id'], $this->testTicket2['id']],
-            ['sideload' => ['users', 'groups'], 'per_page' => 20],
-            'ids'
-        );
-
-        $this->assertLastRequestIs(
+        $this->assertEndpointCalled(
+            function () {
+                $this->client->tickets()->findMany(
+                    [$this->testTicket['id'], $this->testTicket2['id']],
+                    ['sideload' => ['users', 'groups'], 'per_page' => 20],
+                    'ids'
+                );
+            },
+            'tickets/show_many.json',
+            'GET',
             [
-                'method'      => 'GET',
-                'endpoint'    => 'tickets/show_many.json',
                 'queryParams' => [
                     'ids'      => implode(',', [$this->testTicket['id'], $this->testTicket2['id']]),
                     'per_page' => 20,
                     'include'  => 'users,groups'
-                ],
+                ]
             ]
         );
     }
 
+    /**
+     * Tests if the client can call and build the delete many tickets endpoint with the correct IDs
+     */
     public function testDeleteMultiple()
     {
-        $this->mockAPIResponses([
-            new Response(200, [], '')
-        ]);
-
-        $this->client->tickets()->deleteMany([123, 321]);
-        $this->assertLastRequestIs(
-            [
-                'method'      => 'DELETE',
-                'endpoint'    => 'tickets/destroy_many.json',
-                'queryParams' => ['ids' => implode(',', [123, 321])],
-            ]
-        );
+        $this->assertEndpointCalled(function () {
+            $this->client->tickets()->deleteMany([123, 321]);
+        }, 'tickets/destroy_many.json', 'DELETE', ['queryParams' => ['ids' => implode(',', [123, 321])]]);
     }
 
+    /**
+     * Tests if the client can call and build the create ticket witch attachment endpoint and initiate the file upload
+     * headers and POST data
+     */
     public function testCreateWithAttachment()
     {
         $this->mockAPIResponses([
@@ -205,188 +178,120 @@ class TicketsTest extends BasicTest
         ]);
     }
 
+    /**
+     * Tests if the client can call and build the export tickets endpoint with the proper pagination query
+     */
     public function testExport()
     {
-        $this->mockAPIResponses([
-            new Response(200, [], '')
-        ]);
-
-        $this->client->tickets()->export(['start_time' => '1332034771']);
-
-        $this->assertLastRequestIs(
-            [
-                'method'      => 'GET',
-                'endpoint'    => 'exports/tickets.json',
-                'queryParams' => ['start_time' => '1332034771'],
-            ]
-        );
+        $this->assertEndpointCalled(function () {
+            $this->client->tickets()->export(['start_time' => '1332034771']);
+        }, 'exports/tickets.json', 'GET', ['queryParams' => ['start_time' => '1332034771']]);
     }
 
+    /**
+     * Tests if the client can call and build the update many tickets endpoint with the correct IDS and POST fields
+     */
     public function testUpdateManyWithQueryParams()
     {
         $ticketIds = [$this->testTicket['id'], $this->testTicket2['id']];
 
-        $this->mockAPIResponses([
-            new Response(200, [], '')
-        ]);
-
-        $this->client->tickets()->updateMany(
+        $this->assertEndpointCalled(
+            function () use ($ticketIds) {
+                $this->client->tickets()->updateMany(
+                    [
+                        'ids'    => $ticketIds,
+                        'status' => 'solved'
+                    ]
+                );
+            },
+            'tickets/update_many.json',
+            'PUT',
             [
-                'ids'    => $ticketIds,
-                'status' => 'solved'
-            ]
-        );
-
-        $this->assertLastRequestIs(
-            [
-                'method'      => 'PUT',
-                'endpoint'    => 'tickets/update_many.json',
                 'queryParams' => ['ids' => implode(',', $ticketIds)],
                 'postFields'  => ['ticket' => ['status' => 'solved']]
             ]
         );
     }
 
+    /**
+     * Tests if the client can call and build the update many tickets endpoint with the correct IDS and POST fields
+     */
     public function testUpdateMany()
     {
         $tickets = [$this->testTicket, $this->testTicket2];
 
-        $this->mockAPIResponses([
-            new Response(200, [], '')
-        ]);
-
-        $this->client->tickets()->updateMany($tickets);
-
-        $this->assertLastRequestIs(
-            [
-                'method'     => 'PUT',
-                'endpoint'   => 'tickets/update_many.json',
-                'postFields' => ['tickets' => $tickets]
-            ]
-        );
+        $this->assertEndpointCalled(function () use ($tickets) {
+            $this->client->tickets()->updateMany($tickets);
+        }, 'tickets/update_many.json', 'PUT', ['postFields' => ['tickets' => $tickets]]);
     }
 
+    /**
+     * Tests if the client can call and build the related tickets endpoint with the correct ID
+     */
     public function testRelated()
     {
-        $this->mockAPIResponses([
-            new Response(200, [], json_encode(['topic_id' => 1]))
-        ]);
-
-        $related = $this->client->tickets(12345)->related();
-
-        $this->assertLastRequestIs(
-            [
-                'method'   => 'GET',
-                'endpoint' => 'tickets/12345/related.json',
-            ]
-        );
-
-        // Test if the method returns readable data
-        $this->assertEquals(is_object($related), true, 'Should return an object');
+        $this->assertEndpointCalled(function () {
+            $this->client->tickets(12345)->related();
+        }, 'tickets/12345/related.json');
     }
 
+    /**
+     * Tests if the client can call and build the ticket collaborators endpoint with the correct ID
+     */
     public function testCollaborators()
     {
-        $this->mockAPIResponses([
-            new Response(200, [], json_encode(['topic_id' => 1]))
-        ]);
-
-        $collaborators = $this->client->tickets()->collaborators(['id' => 12345]);
-
-        $this->assertLastRequestIs(
-            [
-                'method'   => 'GET',
-                'endpoint' => 'tickets/12345/collaborators.json',
-            ]
-        );
-
-        $this->assertEquals(is_object($collaborators), true, 'Should return an object');
+        $this->assertEndpointCalled(function () {
+            $this->client->tickets()->collaborators(['id' => 12345]);
+        }, 'tickets/12345/collaborators.json');
     }
 
+    /**
+     * Tests if the client can call and build the tickets incidents endpoint with the correct ID
+     */
     public function testIncidents()
     {
-        $this->mockAPIResponses([
-            new Response(200, [], json_encode(['topic_id' => 1]))
-        ]);
-
-        $incidents = $this->client->tickets()->incidents(['id' => 12345]);
-
-        $this->assertLastRequestIs(
-            [
-                'method'   => 'GET',
-                'endpoint' => 'tickets/12345/incidents.json',
-            ]
-        );
-
-        $this->assertEquals(is_object($incidents), true, 'Should return an object');
+        $this->assertEndpointCalled(function () {
+            $this->client->tickets()->incidents(['id' => 12345]);
+        }, 'tickets/12345/incidents.json');
     }
 
+    /**
+     * Tests if the client can call and build the problem tickets endpoint
+     */
     public function testProblems()
     {
-        $this->mockAPIResponses([
-            new Response(200, [], json_encode(['tickets' => []]))
-        ]);
-
-        $problems = $this->client->tickets()->problems();
-
-        $this->assertLastRequestIs(
-            [
-                'method'   => 'GET',
-                'endpoint' => 'problems.json',
-            ]
-        );
-
-        $this->assertEquals(is_object($problems), true, 'Should return an object');
+        $this->assertEndpointCalled(function () {
+            $this->client->tickets()->problems();
+        }, 'problems.json');
     }
 
+    /**
+     * Tests if the client can call and build the problem autocomplete endpoint
+     */
     public function testProblemAutoComplete()
     {
-        $this->mockAPIResponses([
-            new Response(200, [], json_encode(['tickets' => []]))
-        ]);
-
-        $this->client->tickets()->problemAutoComplete(['text' => 'foo']);
-
-        $this->assertLastRequestIs(
-            [
-                'method'     => 'POST',
-                'endpoint'   => 'problems/autocomplete.json',
-                'postFields' => ['text' => 'foo'],
-            ]
-        );
-
+        $this->assertEndpointCalled(function () {
+            $this->client->tickets()->problemAutoComplete(['text' => 'foo']);
+        }, 'problems/autocomplete.json', 'POST', ['postFields' => ['text' => 'foo']]);
     }
 
+    /**
+     * Tests if the client can call and build the mark ticket as spam endpoint with the correct ID
+     */
     public function testMarkAsSpam()
     {
-        $this->mockAPIResponses([
-            new Response(200, [], '')
-        ]);
-
-        $this->client->tickets(12345)->markAsSpam();
-
-        $this->assertLastRequestIs(
-            [
-                'method'   => 'PUT',
-                'endpoint' => 'tickets/12345/mark_as_spam.json',
-            ]
-        );
+        $this->assertEndpointCalled(function () {
+            $this->client->tickets(12345)->markAsSpam();
+        }, 'tickets/12345/mark_as_spam.json', 'PUT');
     }
 
+    /**
+     * Tests if the client can call and build the mark many tickets as spam endpoint with the correct IDs
+     */
     public function testMarkManyAsSpam()
     {
-        $this->mockAPIResponses([
-            new Response(200, [], '')
-        ]);
-
-        $this->client->tickets()->markAsSpam([12345, 54321]);
-
-        $this->assertLastRequestIs(
-            [
-                'method'      => 'PUT',
-                'endpoint'    => 'tickets/mark_many_as_spam.json',
-                'queryParams' => ['ids' => '12345,54321']
-            ]
-        );
+        $this->assertEndpointCalled(function () {
+            $this->client->tickets()->markAsSpam([12345, 54321]);
+        }, 'tickets/mark_many_as_spam.json', 'PUT', ['queryParams' => ['ids' => '12345,54321']]);
     }
 }

--- a/tests/Zendesk/API/UnitTests/TriggersTest.php
+++ b/tests/Zendesk/API/UnitTests/TriggersTest.php
@@ -2,26 +2,18 @@
 
 namespace Zendesk\API\UnitTests;
 
-use GuzzleHttp\Psr7\Response;
-
 /**
  * Triggers test class
  */
 class TriggersTest extends BasicTest
 {
+    /**
+     * Tests if the client can call and build the active triggers endpoint
+     */
     public function testActive()
     {
-        $this->mockAPIResponses([
-            new Response(200, [], '')
-        ]);
-
-        $this->client->triggers()->findActive();
-
-        $this->assertLastRequestIs(
-            [
-                'method'   => 'GET',
-                'endpoint' => 'triggers/active.json',
-            ]
-        );
+        $this->assertEndpointCalled(function () {
+            $this->client->triggers()->findActive();
+        }, 'triggers/active.json');
     }
 }

--- a/tests/Zendesk/API/UnitTests/UserFieldsTest.php
+++ b/tests/Zendesk/API/UnitTests/UserFieldsTest.php
@@ -2,29 +2,20 @@
 
 namespace Zendesk\API\UnitTests;
 
-use GuzzleHttp\Psr7\Response;
-
 /**
  * UserFields test class
  */
 class UserFieldsTest extends BasicTest
 {
+    /**
+     * Tests if the client can call and build the reorder endpoint
+     */
     public function testReorder()
     {
-        $this->mockAPIResponses([
-            new Response(200, [], '')
-        ]);
-
         $ids = [1, 2, 3];
 
-        $this->client->userFields()->reorder($ids);
-
-        $this->assertLastRequestIs(
-            [
-                'method'     => 'PUT',
-                'endpoint'   => 'user_fields/reorder.json',
-                'postFields' => ['user_field_ids' => $ids],
-            ]
-        );
+        $this->assertEndpointCalled(function () use ($ids) {
+            $this->client->userFields()->reorder($ids);
+        }, 'user_fields/reorder.json', 'PUT', ['postFields' => ['user_field_ids' => $ids]]);
     }
 }

--- a/tests/Zendesk/API/UnitTests/UserIdentitiesTest.php
+++ b/tests/Zendesk/API/UnitTests/UserIdentitiesTest.php
@@ -2,7 +2,6 @@
 
 namespace Zendesk\API\UnitTests;
 
-use GuzzleHttp\Psr7\Response;
 use Zendesk\API\Resources\UserIdentities;
 
 /**
@@ -11,6 +10,9 @@ use Zendesk\API\Resources\UserIdentities;
 class UserIdentitiesTest extends BasicTest
 {
 
+    /**
+     * Tests if the unique routes are called correctly
+     */
     public function testRoutes()
     {
         $userId = 3124;
@@ -62,12 +64,11 @@ class UserIdentitiesTest extends BasicTest
         );
     }
 
+    /**
+     * Tests if the client can POST to the identities end point
+     */
     public function testCreateAsEndUser()
     {
-
-        $this->mockAPIResponses([
-            new Response(200, [], '')
-        ]);
         $userId = 3124;
 
         $postFields = [
@@ -75,70 +76,47 @@ class UserIdentitiesTest extends BasicTest
             'value' => 'thecustomer@domain.com'
         ];
 
-        $this->client->users($userId)->identities()->createAsEndUser($postFields);
-
-        $this->assertLastRequestIs(
-            [
-                'method'     => 'POST',
-                'endpoint'   => "end_users/{$userId}/identities.json",
-                'postFields' => [UserIdentities::OBJ_NAME => $postFields]
-            ]
-        );
+        $this->assertEndpointCalled(function () use ($userId, $postFields) {
+            $this->client->users($userId)->identities()->createAsEndUser($postFields);
+        }, "end_users/{$userId}/identities.json", 'POST', ['postFields' => [UserIdentities::OBJ_NAME => $postFields]]);
     }
 
+    /**
+     * Tests if the client can call and build the verify endpoint
+     */
     public function testVerify()
     {
-        $this->mockAPIResponses([
-            new Response(200, [], '')
-        ]);
         $userId = 3124;
         $id     = 123;
 
-        $this->client->users($userId)->identities($id)->verify();
-
-        $this->assertLastRequestIs(
-            [
-                'method'   => 'PUT',
-                'endpoint' => "users/{$userId}/identities/{$id}/verify.json",
-            ]
-        );
+        $this->assertEndpointCalled(function () use ($userId, $id) {
+            $this->client->users($userId)->identities($id)->verify();
+        }, "users/{$userId}/identities/{$id}/verify.json", 'PUT');
     }
 
+    /**
+     * Tests if the client can call and build the make primary endpoint
+     */
     public function testMakePrimary()
     {
-        $this->mockAPIResponses([
-            new Response(200, [], '')
-        ]);
-
         $userId = 3124;
         $id     = 123;
 
-        $this->client->users($userId)->identities($id)->makePrimary();
-
-        $this->assertLastRequestIs(
-            [
-                'method'   => 'PUT',
-                'endpoint' => "users/$userId/identities/$id/make_primary.json",
-            ]
-        );
+        $this->assertEndpointCalled(function () use ($id, $userId) {
+            $this->client->users($userId)->identities($id)->makePrimary();
+        }, "users/$userId/identities/$id/make_primary.json", 'PUT');
     }
 
+    /**
+     * Tests if the client can call and build the request verification endpoint
+     */
     public function testRequestVerification()
     {
-        $this->mockAPIResponses([
-            new Response(200, [], '')
-        ]);
-
         $userId = 3124;
         $id     = 123;
 
-        $this->client->users($userId)->identities($id)->requestVerification();
-
-        $this->assertLastRequestIs(
-            [
-                'method'   => 'PUT',
-                'endpoint' => "users/{$userId}/identities/{$id}/request_verification.json",
-            ]
-        );
+        $this->assertEndpointCalled(function () use ($id, $userId) {
+            $this->client->users($userId)->identities($id)->requestVerification();
+        }, "users/{$userId}/identities/{$id}/request_verification.json", 'PUT');
     }
 }

--- a/tests/Zendesk/API/UnitTests/UsersTest.php
+++ b/tests/Zendesk/API/UnitTests/UsersTest.php
@@ -2,7 +2,6 @@
 
 namespace Zendesk\API\UnitTests;
 
-use GuzzleHttp\Psr7\Response;
 use Zendesk\API\Resources\Users;
 
 /**
@@ -12,370 +11,69 @@ class UsersTest extends BasicTest
 {
     protected $number;
 
-    public function testCreate()
-    {
-        $testUser = [
-            'id'          => '12345',
-            'name'        => 'Roger Wilco',
-            'email'       => 'roge@example.org',
-            'role'        => 'agent',
-            'verified'    => true,
-            'external_id' => '3000'
-        ];
-
-        $this->mockAPIResponses([
-            new Response(200, [], json_encode(['user' => $testUser]))
-        ]);
-
-        $user = $this->client->users()->create($testUser);
-
-        $this->assertLastRequestIs(
-            [
-                'method'     => 'POST',
-                'endpoint'   => 'users.json',
-                'postFields' => ['user' => $testUser],
-            ]
-        );
-
-        $this->assertEquals(is_object($user), true, 'Should return an object');
-        $this->assertEquals(is_object($user->user), true, 'Should return an object called "user"');
-        $this->assertGreaterThan(0, $user->user->id, 'Should return a numeric id for user');
-    }
-
-    public function testDelete()
-    {
-        $this->mockAPIResponses([
-            new Response(200, [], '')
-        ]);
-
-        $this->client->users(12345)->delete();
-
-        $this->assertLastRequestIs(
-            [
-                'method'   => 'DELETE',
-                'endpoint' => 'users/12345.json',
-            ]
-        );
-    }
-
-    public function testAll()
-    {
-        $response = json_encode(
-            [
-                'users' => [
-                    ['id' => 12345]
-                ]
-            ]
-        );
-
-        $this->mockAPIResponses([
-            new Response(200, [], $response)
-        ]);
-
-        $users = $this->client->users()->findAll();
-
-        $this->assertLastRequestIs(
-            [
-                'method'   => 'GET',
-                'endpoint' => 'users.json',
-            ]
-        );
-
-        $this->assertEquals(is_object($users), true, 'Should return an object');
-        $this->assertEquals(
-            is_array($users->users),
-            true,
-            'Should return an object containing an array called "users"'
-        );
-
-        $this->assertGreaterThan(0, $users->users[0]->id, 'Should return a numeric id for requests[0]');
-    }
-
-    public function testFind()
-    {
-        $this->mockAPIResponses([
-            new Response(200, [], json_encode(['user' => ['id' => 12345]]))
-        ]);
-
-        $user = $this->client->users(12345)->find();
-
-        $this->assertLastRequestIs(
-            [
-                'method'   => 'GET',
-                'endpoint' => 'users/12345.json',
-            ]
-        );
-
-        $this->assertEquals(is_object($user), true, 'Should return an object');
-        $this->assertEquals(is_object($user->user), true, 'Should return an object called "user"');
-        $this->assertGreaterThan(0, $user->user->id, 'Should return a numeric id for user');
-    }
-
-    public function testFindManyUsingIds()
-    {
-        $findIds  = [12345, 80085];
-        $response = [
-            'users' => [
-                ['id' => $findIds[0]],
-                ['id' => $findIds[1]],
-            ]
-        ];
-
-        $this->mockAPIResponses([
-            new Response(200, [], json_encode($response))
-        ]);
-
-        $users = $this->client->users()->findMany(['ids' => $findIds]);
-
-        $this->assertEquals(is_object($users), true, 'Should return an object');
-        $this->assertEquals(is_array($users->users), true, 'Should return an array called "users"');
-        $this->assertEquals(
-            is_object($users->users[0]),
-            true,
-            'Should return an object as first "users" array element'
-        );
-    }
-
+    /**
+     * Tests show_many using external_ids
+     */
     public function testFindManyUsingExternalIds()
     {
-        $findIds  = [12345, 80085];
-        $response = [
-            'users' => [
-                ['id' => $findIds[0]],
-                ['id' => $findIds[1]],
-            ]
-        ];
+        $findIds = [12345, 80085];
 
-        $this->mockAPIResponses([
-            new Response(200, [], json_encode($response))
-        ]);
-
-        $users = $this->client->users()->findMany(['external_ids' => $findIds]);
-
-        $this->assertLastRequestIs(
-            [
-                'method'      => 'GET',
-                'endpoint'    => 'users/show_many.json',
-                'queryParams' => ['external_ids' => implode(',', $findIds)]
-            ]
-        );
-
-        $this->assertEquals(is_object($users), true, 'Should return an object');
-        $this->assertEquals(is_array($users->users), true, 'Should return an array called "users"');
-        $this->assertEquals(
-            is_object($users->users[0]),
-            true,
-            'Should return an object as first "users" array element'
-        );
+        $this->assertEndpointCalled(function () use ($findIds) {
+            $this->client->users()->findMany(['external_ids' => $findIds]);
+        }, 'users/show_many.json', 'GET', ['queryParams' => ['external_ids' => implode(',', $findIds)]]);
     }
 
+    /**
+     * Tests if the related enpoint can be called by the client and is passed the correct ID
+     */
     public function testRelated()
     {
-        $this->mockAPIResponses([
-            new Response(200, [], json_encode(['user_related' => ['requested_tickets' => 1]]))
-        ]);
-
-        $related = $this->client->users(12345)->related();
-
-        $this->assertLastRequestIs(
-            [
-                'method'   => 'GET',
-                'endpoint' => 'users/12345/related.json',
-            ]
-        );
-        $this->assertEquals(is_object($related), true, 'Should return an object');
-        $this->assertEquals(
-            is_object($related->user_related),
-            true,
-            'Should return an object called "user_related"'
-        );
-        $this->assertGreaterThan(
-            0,
-            $related->user_related->requested_tickets,
-            'Should return a numeric requested_tickets for user'
-        );
+        $this->assertEndpointCalled(function () {
+            $this->client->users(12345)->related();
+        }, 'users/12345/related.json');
     }
 
+    /**
+     * Tests if the nerge enpoint can be called by the client and is passed the correct data
+     */
     public function testMerge()
     {
         $postFields = ['id' => 12345];
 
-        $this->mockAPIResponses([
-            new Response(200, [], json_encode(['user' => ['id' => 12345]]))
-        ]);
-
-        $this->client->users('me')->merge($postFields);
-
-        $this->assertLastRequestIs(
-            [
-                'method'     => 'PUT',
-                'endpoint'   => 'users/me/merge.json',
-                'postFields' => [Users::OBJ_NAME => $postFields],
-            ]
-        );
+        $this->assertEndpointCalled(function () use ($postFields) {
+            $this->client->users('me')->merge($postFields);
+        }, 'users/me/merge.json', 'PUT', ['postFields' => [Users::OBJ_NAME => $postFields]]);
     }
 
-    public function testCreateMany()
-    {
-        $postFields = [
-            [
-                'name'     => 'Roger Wilco 3',
-                'email'    => 'roge3@example.org',
-                'verified' => true
-            ],
-            [
-                'name'     => 'Roger Wilco 4',
-                'email'    => 'roge4@example.org',
-                'verified' => true
-            ]
-        ];
-
-        $this->mockAPIResponses([
-            new Response(200, [], json_encode(['job_status' => ['id' => 1]]))
-        ]);
-
-        $jobStatus = $this->client->users()->createMany($postFields);
-
-        $this->assertLastRequestIs(
-            [
-                'method'     => 'POST',
-                'endpoint'   => 'users/create_many.json',
-                'postFields' => [Users::OBJ_NAME_PLURAL => $postFields],
-            ]
-        );
-
-        $this->assertEquals(is_object($jobStatus), true, 'Should return an object');
-        $this->assertEquals(is_object($jobStatus->job_status), true, 'Should return an object called "job_status"');
-        $this->assertGreaterThan(0, $jobStatus->job_status->id, 'Should return a numeric id for users[0]');
-    }
-
-    public function testUpdate()
-    {
-        $postFields = ['name' => 'Joe Soap'];
-
-        $this->mockAPIResponses([
-            new Response(200, [], json_encode([Users::OBJ_NAME => []]))
-        ]);
-
-        $this->client->users(12345)->update(null, $postFields);
-
-        $this->assertLastRequestIs(
-            [
-                'method'     => 'PUT',
-                'endpoint'   => 'users/12345.json',
-                'postFields' => [Users::OBJ_NAME => $postFields],
-            ]
-        );
-    }
-
-    public function testUpdateMany()
-    {
-        $updateIds     = [12345, 80085];
-        $requestParams = [
-            'ids'   => $updateIds,
-            'phone' => '1234567890'
-        ];
-
-        $this->mockAPIResponses([
-            new Response(200, [], json_encode(['job_status' => ['id' => 1]]))
-        ]);
-
-        $jobStatus = $this->client->users()->updateMany($requestParams);
-
-        $this->assertLastRequestIs(
-            [
-                'method'      => 'PUT',
-                'endpoint'    => 'users/update_many.json',
-                'queryParams' => ['ids' => implode(',', $requestParams['ids'])],
-                'postFields'  => [Users::OBJ_NAME => ['phone' => $requestParams['phone']]]
-            ]
-        );
-
-        $this->assertEquals(is_object($jobStatus), true, 'Should return an array');
-        $this->assertEquals(is_object($jobStatus->job_status), true, 'Should return an object called "job_status"');
-        $this->assertGreaterThan(0, $jobStatus->job_status->id, 'Should return a numeric id for users[0]');
-    }
-
-    public function testUpdateManyIndividualUsers()
-    {
-        $requestParams = [
-            [
-                'id'    => 12345,
-                'phone' => '1234567890'
-            ],
-            [
-                'id'    => 80085,
-                'phone' => '0987654321'
-            ]
-        ];
-
-        $this->mockAPIResponses([
-            new Response(200, [], json_encode(['job_status' => ['id' => 1]]))
-        ]);
-
-        $jobStatus = $this->client->users()->updateMany($requestParams);
-
-        $this->assertLastRequestIs(
-            [
-                'method'     => 'PUT',
-                'endpoint'   => 'users/update_many.json',
-                'postFields' => [Users::OBJ_NAME_PLURAL => $requestParams]
-            ]
-        );
-
-        $this->assertEquals(is_object($jobStatus), true, 'Should return an array');
-        $this->assertEquals(is_object($jobStatus->job_status), true, 'Should return an object called "job_status"');
-        $this->assertGreaterThan(0, $jobStatus->job_status->id, 'Should return a numeric id for users[0]');
-    }
-
+    /**
+     * Tests if the suspend enpoint can be called by the client and is passed the correct ID
+     */
     public function testSuspend()
     {
         $userId = 12345;
 
-        $this->mockAPIResponses([
-            new Response(200, [], json_encode(['user' => ['id' => $userId]]))
-        ]);
-
-        $user = $this->client->users($userId)->suspend();
-
-        $this->assertLastRequestIs(
+        $this->assertEndpointCalled(
+            function () use ($userId) {
+                $this->client->users($userId)->suspend();
+            },
+            'users/12345.json',
+            'PUT',
             [
-                'method'     => 'PUT',
-                'endpoint'   => 'users/12345.json',
-                'postFields' => [Users::OBJ_NAME => ['id' => $userId, 'suspended' => true]],
+                'postFields' => [Users::OBJ_NAME => ['id' => $userId, 'suspended' => true]]
             ]
         );
-
-        $this->assertEquals(is_object($user), true, 'Should return an object');
-        $this->assertEquals(is_object($user->user), true, 'Should return an object called "user"');
-        $this->assertGreaterThan(0, $user->user->id, 'Should return a numeric id for request');
     }
 
+    /**
+     * Tests if the search enpoint can be called by the client and is passed the correct query
+     */
     public function testSearch()
     {
         $queryParams = ['query' => 'Roger'];
 
-        $this->mockAPIResponses([
-            new Response(200, [], json_encode(['users' => [['id' => 12345]]]))
-        ]);
-
-        $users = $this->client->users()->search($queryParams);
-
-        $this->assertLastRequestIs(
-            [
-                'method'      => 'GET',
-                'endpoint'    => 'users/search.json',
-                'queryParams' => $queryParams,
-            ]
-        );
-
-        $this->assertEquals(is_object($users), true, 'Should return an object');
-        $this->assertEquals(
-            is_array($users->users),
-            true,
-            'Should return an object containing an array called "users"'
-        );
-        $this->assertGreaterThan(0, $users->users[0]->id, 'Should return a numeric id for user');
+        $this->assertEndpointCalled(function () use ($queryParams) {
+            $this->client->users()->search($queryParams);
+        }, 'users/search.json', 'GET', ['queryParams' => $queryParams]);
     }
 
     /*
@@ -385,114 +83,67 @@ class UsersTest extends BasicTest
     {
         $queryParams = ['name' => 'joh'];
 
-        $this->mockAPIResponses([
-            new Response(200, [], json_encode(['users' => [['id' => 12345]]]))
-        ]);
-
-        $users = $this->client->users()->autocomplete($queryParams);
-
-        $this->assertLastRequestIs(
-            [
-                'method'      => 'POST',
-                'endpoint'    => 'users/autocomplete.json',
-                'queryParams' => $queryParams,
-            ]
-        );
-
-        $this->assertEquals(is_object($users), true, 'Should return an object');
-        $this->assertEquals(
-            is_array($users->users),
-            true,
-            'Should return an object containing an array called "users"'
-        );
-        $this->assertGreaterThan(0, $users->users[0]->id, 'Should return a numeric id for user');
+        $this->assertEndpointCalled(function () use ($queryParams) {
+            $this->client->users()->autocomplete($queryParams);
+        }, 'users/autocomplete.json', 'POST', ['queryParams' => $queryParams]);
     }
 
+    /**
+     * Tests if the client can perform the update profile functionality
+     */
     public function testUpdateProfileImageFromFile()
     {
-        $this->mockAPIResponses([
-            new Response(200, [], '')
-        ]);
-
         $id = 915987427;
 
-        $params = [
-            'file' => getcwd() . '/tests/assets/UK.png'
-        ];
-
-        $this->client->users($id)->updateProfileImageFromFile($params);
-
-        $this->assertLastRequestIs(
-            [
-                'method'   => 'PUT',
-                'endpoint' => "users/{$id}.json",
-                'multipart'
-            ]
-        );
+        $this->assertEndpointCalled(function () use ($id) {
+            $params = [
+                'file' => getcwd() . '/tests/assets/UK.png'
+            ];
+            $this->client->users($id)->updateProfileImageFromFile($params);
+        }, "users/{$id}.json", 'PUT', ['multipart']);
     }
 
+    /**
+     * Tests if the client can perform the update profile image functionality
+     */
     public function testUpdateProfileImageFromUrl()
     {
-        $this->mockAPIResponses([
-            new Response(200, [], '')
-        ]);
-
         $id = 915987427;
 
         $params = [
             'url' => 'http://www.test.com/profile.png'
         ];
 
-        $this->client->users($id)->updateProfileImageFromUrl($params);
-
-        $this->assertLastRequestIs(
-            [
-                'method'     => 'PUT',
-                'endpoint'   => "users/{$id}.json",
-                'postFields' => [Users::OBJ_NAME => ['remote_photo_url' => $params['url']]],
-            ]
-        );
+        $this->assertEndpointCalled(function () use ($id, $params) {
+            $this->client->users($id)->updateProfileImageFromUrl($params);
+        }, "users/{$id}.json", 'PUT', ['postFields' => [Users::OBJ_NAME => ['remote_photo_url' => $params['url']]]]);
     }
 
+    /**
+     * Tests if the client can call the users/me.json endpoint
+     */
     public function testAuthenticatedUser()
     {
-        $this->mockAPIResponses([
-            new Response(200, [], json_encode(['user' => ['id' => 12345]]))
-        ]);
-
-        $user = $this->client->users()->me();
-
-        $this->assertLastRequestIs(
-            [
-                'method'   => 'GET',
-                'endpoint' => 'users/me.json',
-            ]
-        );
-
-        $this->assertEquals(is_object($user), true, 'Should return an object');
-        $this->assertEquals(is_object($user->user), true, 'Should return an object called "user"');
-        $this->assertGreaterThan(0, $user->user->id, 'Should return a numeric id for request');
+        $this->assertEndpointCalled(function () {
+            $this->client->users()->me();
+        }, 'users/me.json');
     }
 
+    /**
+     * Tests if the setPassword function calls the correct endpoint and passes the correct POST data
+     */
     public function testSetPassword()
     {
         $postFields = ['password' => 'aBc12345'];
 
-        $this->mockAPIResponses([
-            new Response(200, [], '')
-        ]);
-
-        $this->client->users(12345)->setPassword($postFields);
-
-        $this->assertLastRequestIs(
-            [
-                'method'     => 'POST',
-                'endpoint'   => 'users/12345/password.json',
-                'postFields' => [Users::OBJ_NAME => $postFields],
-            ]
-        );
+        $this->assertEndpointCalled(function () use ($postFields) {
+            $this->client->users(12345)->setPassword($postFields);
+        }, 'users/12345/password.json', 'POST', ['postFields' => [Users::OBJ_NAME => $postFields]]);
     }
 
+    /**
+     * Tests if the changePassword function calls the correct endpoint and passes the correct PUT data
+     */
     public function testChangePassword()
     {
         $postFields = [
@@ -500,18 +151,10 @@ class UsersTest extends BasicTest
             'password'          => '12345'
         ];
 
-        $this->mockAPIResponses([
-            new Response(200, [], '')
-        ]);
+        $userId = 421450109;
 
-        $this->client->users(421450109)->changePassword($postFields);
-
-        $this->assertLastRequestIs(
-            [
-                'method'     => 'PUT',
-                'endpoint'   => 'users/421450109/password.json',
-                'postFields' => $postFields,
-            ]
-        );
+        $this->assertEndpointCalled(function () use ($postFields, $userId) {
+            $this->client->users($userId)->changePassword($postFields);
+        }, "users/{$userId}/password.json", 'PUT');
     }
 }

--- a/tests/Zendesk/API/UnitTests/ViewsTest.php
+++ b/tests/Zendesk/API/UnitTests/ViewsTest.php
@@ -2,7 +2,6 @@
 
 namespace Zendesk\API\UnitTests;
 
-use GuzzleHttp\Psr7\Response;
 use Zendesk\API\Resources\Views;
 
 /**
@@ -20,25 +19,9 @@ class ViewsTest extends BasicTest
      */
     public function testActive()
     {
-        $this->mockAPIResponses([
-            new Response(200, [], json_encode(['views' => [['id' => $this->id]]]))
-        ]);
-
-        $views = $this->client->views()->findAllActive();
-
-        $this->assertLastRequestIs(
-            [
-                'method'   => 'GET',
-                'endpoint' => 'views/active.json',
-            ]
-        );
-
-        $this->assertEquals(
-            is_array($views->views),
-            true,
-            'Should return an object containing an array called "views"'
-        );
-        $this->assertGreaterThan(0, $views->views[0]->id, 'Should return a numeric id for views[0]');
+        $this->assertEndpointCalled(function () {
+            $this->client->views()->findAllActive();
+        }, 'views/active.json');
     }
 
     /**
@@ -46,25 +29,9 @@ class ViewsTest extends BasicTest
      */
     public function testCompact()
     {
-        $this->mockAPIResponses([
-            new Response(200, [], json_encode(['views' => [['id' => $this->id]]]))
-        ]);
-
-        $views = $this->client->views()->findAllCompact();
-
-        $this->assertLastRequestIs(
-            [
-                'method'   => 'GET',
-                'endpoint' => 'views/compact.json',
-            ]
-        );
-        $this->assertEquals(is_object($views), true, 'Should return an object');
-        $this->assertEquals(
-            is_array($views->views),
-            true,
-            'Should return an object containing an array called "views"'
-        );
-        $this->assertGreaterThan(0, $views->views[0]->id, 'Should return a numeric id for views[0]');
+        $this->assertEndpointCalled(function () {
+            $this->client->views()->findAllCompact();
+        }, 'views/compact.json');
     }
 
     /**
@@ -75,23 +42,10 @@ class ViewsTest extends BasicTest
     public function testExecute()
     {
         $queryParams = ['per_page' => 1];
-        $this->mockAPIResponses([
-            new Response(200, [], json_encode(['view' => ['id' => $this->id]]))
-        ]);
 
-        $view = $this->client->views($this->id)->execute($queryParams);
-
-        $this->assertLastRequestIs(
-            [
-                'method'      => 'GET',
-                'endpoint'    => 'views/' . $this->id . '/execute.json',
-                'queryParams' => $queryParams,
-            ]
-        );
-
-        $this->assertEquals(is_object($view), true, 'Should return an object');
-        $this->assertEquals(is_object($view->view), true, 'Should return an object called "view"');
-        $this->assertGreaterThan(0, $view->view->id, 'Should return a numeric id for view');
+        $this->assertEndpointCalled(function () use ($queryParams) {
+            $this->client->views($this->id)->execute($queryParams);
+        }, "views/{$this->id}/execute.json", 'GET', ['queryParams' => $queryParams]);
     }
 
     /**
@@ -101,22 +55,9 @@ class ViewsTest extends BasicTest
      */
     public function testCount()
     {
-        $this->mockAPIResponses([
-            new Response(200, [], json_encode(['view_count' => ['view_id' => $this->id]]))
-        ]);
-
-        $counts = $this->client->views($this->id)->count();
-
-        $this->assertLastRequestIs(
-            [
-                'method'   => 'GET',
-                'endpoint' => 'views/' . $this->id . '/count.json',
-            ]
-        );
-
-        $this->assertEquals(is_object($counts), true, 'Should return an object');
-        $this->assertEquals(is_object($counts->view_count), true, 'Should return an object called "view_count"');
-        $this->assertGreaterThan(0, $counts->view_count->view_id, 'Should return a numeric view_id for view_count');
+        $this->assertEndpointCalled(function () {
+            $this->client->views($this->id)->count();
+        }, "views/{$this->id}/count.json");
     }
 
     /**
@@ -127,30 +68,10 @@ class ViewsTest extends BasicTest
     public function testCountMany()
     {
         $queryIds = [$this->id, 80085];
-        $this->mockAPIResponses([
-            new Response(200, [], json_encode(['view_counts' => [['view_id' => $this->id]]]))
-        ]);
 
-        $counts = $this->client->views($queryIds)->count();
-
-        $this->assertLastRequestIs(
-            [
-                'method'      => 'GET',
-                'endpoint'    => 'views/count_many.json',
-                'queryParams' => ['ids' => implode(',', $queryIds)]
-            ]
-        );
-
-        $this->assertEquals(
-            is_array($counts->view_counts),
-            true,
-            'Should return an array of objects called "view_counts"'
-        );
-        $this->assertGreaterThan(
-            0,
-            $counts->view_counts[0]->view_id,
-            'Should return a numeric view_id for view_counts[0]'
-        );
+        $this->assertEndpointCalled(function () use ($queryIds) {
+            $this->client->views($queryIds)->count();
+        }, 'views/count_many.json', 'GET', ['queryParams' => ['ids' => implode(',', $queryIds)]]);
     }
 
     /**
@@ -158,21 +79,9 @@ class ViewsTest extends BasicTest
      */
     public function testExport()
     {
-        $this->mockAPIResponses([
-            new Response(200, [], json_encode(['export' => ['view_id' => $this->id]]))
-        ]);
-
-        $export = $this->client->views($this->id)->export();
-
-        $this->assertLastRequestIs(
-            [
-                'method'   => 'GET',
-                'endpoint' => 'views/' . $this->id . '/export.json',
-            ]
-        );
-
-        $this->assertEquals(is_object($export), true, 'Should return an object');
-        $this->assertGreaterThan(0, $export->export->view_id, 'Should return a numeric view_id for export');
+        $this->assertEndpointCalled(function () {
+            $this->client->views($this->id)->export();
+        }, "views/{$this->id}/export.json", 'GET');
     }
 
     /**
@@ -193,23 +102,9 @@ class ViewsTest extends BasicTest
             ]
         ];
 
-        $this->mockAPIResponses([
-            new Response(200, [], json_encode(['rows' => [], 'columns' => []]))
-        ]);
-
-        $preview = $this->client->views()->preview($postFields);
-
-        $this->assertLastRequestIs(
-            [
-                'method'     => 'POST',
-                'endpoint'   => 'views/preview.json',
-                'postFields' => [Views::OBJ_NAME => $postFields]
-            ]
-        );
-
-        $this->assertEquals(is_object($preview), true, 'Should return an object');
-        $this->assertEquals(is_array($preview->rows), true, 'Should return an array of objects called "rows"');
-        $this->assertEquals(is_array($preview->columns), true, 'Should return an array of objects called "columns"');
+        $this->assertEndpointCalled(function () use ($postFields) {
+            $this->client->views()->preview($postFields);
+        }, 'views/preview.json', 'POST', ['postFields' => [Views::OBJ_NAME => $postFields]]);
     }
 
     /**
@@ -230,22 +125,9 @@ class ViewsTest extends BasicTest
             ]
         ];
 
-        $this->mockAPIResponses([
-            new Response(200, [], json_encode(['view_count' => (new \stdClass())]))
-        ]);
-
-        $preview = $this->client->views()->previewCount($postFields);
-
-        $this->assertLastRequestIs(
-            [
-                'method'     => 'POST',
-                'endpoint'   => 'views/preview/count.json',
-                'postFields' => [Views::OBJ_NAME => $postFields],
-            ]
-        );
-
-        $this->assertEquals(is_object($preview), true, 'Should return an object');
-        $this->assertEquals(is_object($preview->view_count), true, 'Should return an object called "view_count"');
+        $this->assertEndpointCalled(function () use ($postFields) {
+            $this->client->views()->previewCount($postFields);
+        }, 'views/preview/count.json', 'POST', ['postFields' => [Views::OBJ_NAME => $postFields]]);
     }
 
     /**
@@ -253,20 +135,8 @@ class ViewsTest extends BasicTest
      */
     public function testGetTickets()
     {
-        $this->mockAPIResponses([
-            new Response(200, [], json_encode(['tickets' => ['id' => $this->id]]))
-        ]);
-
-        $preview = $this->client->views($this->id)->tickets();
-
-        $this->assertLastRequestIs(
-            [
-                'method'   => 'GET',
-                'endpoint' => "views/{$this->id}/tickets.json",
-            ]
-        );
-
-        $this->assertEquals(is_object($preview), true, 'Should return an object');
-        $this->assertEquals(is_object($preview->tickets), true, 'Should return an object called "tickets"');
+        $this->assertEndpointCalled(function () {
+            $this->client->views($this->id)->tickets();
+        }, "views/{$this->id}/tickets.json");
     }
 }


### PR DESCRIPTION
Use a wrapper function to assert the API client functionality. This removes a lot of repetitive test code.

/cc @miogalang @jwswj @mmolina @atroche

### References
 - Jira link: 

### Risks
 - Medium - the tests might not cover all cases