### PR TITLE
[MI-133] Add Monitored Twitter Handles

### DIFF
--- a/src/Zendesk/API/HttpClient.php
+++ b/src/Zendesk/API/HttpClient.php
@@ -36,6 +36,7 @@ use Zendesk\API\Resources\Targets;
 use Zendesk\API\Resources\TicketImports;
 use Zendesk\API\Resources\Tickets;
 use Zendesk\API\Resources\Triggers;
+use Zendesk\API\Resources\TwitterHandles;
 use Zendesk\API\Resources\UserFields;
 use Zendesk\API\Resources\Users;
 use Zendesk\API\Resources\Views;
@@ -63,6 +64,7 @@ use Zendesk\API\Utilities\Auth;
  * @method Targets targets()
  * @method Tickets ticket()
  * @method TicketImports ticketImports()
+ * @method TwitterHandles twitterHandles()
  * @method Triggers triggers()
  * @method UserFields userFields()
  * @method Users users()
@@ -189,6 +191,7 @@ class HttpClient
             'tickets'                   => Tickets::class,
             'ticketImports'             => TicketImports::class,
             'triggers'                  => Triggers::class,
+            'twitterHandles'            => TwitterHandles::class,
             'userFields'                => UserFields::class,
             'users'                     => Users::class,
             'views'                     => Views::class,

--- a/src/Zendesk/API/Resources/TwitterHandles.php
+++ b/src/Zendesk/API/Resources/TwitterHandles.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Zendesk\API\Resources;
+
+use Zendesk\API\Traits\Resource\Find;
+use Zendesk\API\Traits\Resource\FindAll;
+
+class TwitterHandles extends ResourceAbstract
+{
+    const OBJ_NAME = 'monitored_twitter_handle';
+    const OBJ_NAME_PLURAL = 'monitored_twitter_handles';
+
+    use Find;
+    use FindAll;
+
+    protected $resourceName = 'channels/twitter/monitored_twitter_handles';
+}

--- a/tests/Zendesk/API/UnitTests/TwitterHandlesTest.php
+++ b/tests/Zendesk/API/UnitTests/TwitterHandlesTest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Zendesk\API\UnitTests;
+
+class TwitterHandlesTest extends BasicTest
+{
+    /**
+     * Tests if the find and findAll method calls the correct endpoints
+     */
+    public function testRoutes()
+    {
+        $this->assertEndpointCalled(function () {
+            $this->client->twitterHandles()->findAll();
+        }, 'channels/twitter/monitored_twitter_handles.json');
+
+        $this->assertEndpointCalled(function () {
+            $this->client->twitterHandles()->find(1);
+        }, 'channels/twitter/monitored_twitter_handles/1.json');
+    }
+
+    /**
+     * Test that only find and findAll are present
+     */
+    public function testMethods()
+    {
+        $this->assertFalse(method_exists($this->client->twitterHandles(), 'create'));
+        $this->assertFalse(method_exists($this->client->twitterHandles(), 'delete'));
+        $this->assertFalse(method_exists($this->client->twitterHandles(), 'update'));
+    }
+}


### PR DESCRIPTION
Add twitter handles resource and test

/cc @miogalang @jwswj @mmolina @atroche

### References
 - Jira link: https://zendesk.atlassian.net/browse/MI-123

### Risks
 - Low. We might not be able to use the Monitored Twitter Handles resources