### PR TITLE
[MI-150] Add the push notifications devices resource

### DIFF
--- a/src/Zendesk/API/HttpClient.php
+++ b/src/Zendesk/API/HttpClient.php
@@ -30,6 +30,7 @@ use Zendesk\API\Resources\Core\OrganizationFields;
 use Zendesk\API\Resources\Core\OrganizationMemberships;
 use Zendesk\API\Resources\Core\Organizations;
 use Zendesk\API\Resources\Core\OrganizationSubscriptions;
+use Zendesk\API\Resources\Core\PushNotificationDevices;
 use Zendesk\API\Resources\Core\Requests;
 use Zendesk\API\Resources\Core\SatisfactionRatings;
 use Zendesk\API\Resources\Core\Search;

--- a/src/Zendesk/API/HttpClient.php
+++ b/src/Zendesk/API/HttpClient.php
@@ -68,6 +68,7 @@ use Zendesk\API\Utilities\Auth;
  * @method OAuthClients oauthClients()
  * @method OrganizationFields organizationFields()
  * @method Organizations organizations()
+ * @method PushNotificationDevices pushNotificationDevices()
  * @method Requests requests()
  * @method Search search()
  * @method Sessions sessions()
@@ -130,7 +131,7 @@ class HttpClient
      */
     protected $debug;
     /**
-     * @var \Guzzlehttp\Client
+     * @var \GuzzleHttp\Client
      */
     public $guzzle;
     /**
@@ -203,6 +204,7 @@ class HttpClient
             'organizationMemberships'   => OrganizationMemberships::class,
             'organizations'             => Organizations::class,
             'organizationSubscriptions' => OrganizationSubscriptions::class,
+            'pushNotificationDevices'   => PushNotificationDevices::class,
             'requests'                  => Requests::class,
             'satisfactionRatings'       => SatisfactionRatings::class,
             'sharingAgreements'         => SharingAgreements::class,

--- a/src/Zendesk/API/Resources/Core/PushNotificationDevices.php
+++ b/src/Zendesk/API/Resources/Core/PushNotificationDevices.php
@@ -1,8 +1,9 @@
 <?php
 
-namespace Zendesk\API\Resources;
+namespace Zendesk\API\Resources\Core;
 
 use Zendesk\API\Exceptions\MissingParametersException;
+use Zendesk\API\Resources\ResourceAbstract;
 
 /**
  * The Push Notification Devices class exposes methods seen at

--- a/src/Zendesk/API/Resources/PushNotificationDevices.php
+++ b/src/Zendesk/API/Resources/PushNotificationDevices.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Zendesk\API\Resources;
+
+use Zendesk\API\Exceptions\MissingParametersException;
+
+/**
+ * The Push Notification Devices class exposes methods seen at
+ * https://developer.zendesk.com/rest_api/docs/core/push_notification_devices
+ */
+class PushNotificationDevices extends ResourceAbstract
+{
+    const OBJ_NAME_PLURAL = 'push_notification_devices';
+
+    /**
+     * Declares routes to be used by this resource.
+     */
+    protected function setUpRoutes()
+    {
+        parent::setUpRoutes();
+
+        $this->setRoute('deleteMany', 'push_notification_devices/destroy_many.json');
+    }
+
+    /**
+     * Unregisters the mobile devices that are receiving push notifications.
+     * Specify the devices as an array of mobile device tokens.
+     *
+     * @param array $params
+     *
+     * @return mixed
+     * @throws MissingParametersException
+     * @throws \Zendesk\API\Exceptions\RouteException
+     */
+    public function deleteMany(array $params = [])
+    {
+        if (! isset($params['tokens']) || ! is_array($params['tokens'])) {
+            throw new MissingParametersException(__METHOD__, ['tokens']);
+
+        }
+        $postData = [self::OBJ_NAME_PLURAL => $params['tokens']];
+
+        return $this->client->post($this->getRoute(__FUNCTION__), $postData);
+    }
+}

--- a/tests/Zendesk/API/UnitTests/PushNotificationDevicesTest.php
+++ b/tests/Zendesk/API/UnitTests/PushNotificationDevicesTest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Zendesk\API\UnitTests;
+
+use Zendesk\API\Resources\PushNotificationDevices;
+
+/**
+ * PushNotificationDevices test class
+ */
+class PushNotificationDevicesTest extends BasicTest
+{
+    /**
+     * Test the deleteMany method
+     */
+    public function testDeleteMany()
+    {
+        $postFields = ['tokens' => ['token1', 'token2']];
+        $this->assertEndpointCalled(
+            function () use ($postFields) {
+                $this->client->pushNotificationDevices()->deleteMany($postFields);
+            },
+            'push_notification_devices/destroy_many.json',
+            'POST',
+            [
+                'postFields' => [PushNotificationDevices::OBJ_NAME_PLURAL => $postFields['tokens']]
+            ]
+        );
+    }
+}

--- a/tests/Zendesk/API/UnitTests/PushNotificationDevicesTest.php
+++ b/tests/Zendesk/API/UnitTests/PushNotificationDevicesTest.php
@@ -2,7 +2,7 @@
 
 namespace Zendesk\API\UnitTests;
 
-use Zendesk\API\Resources\PushNotificationDevices;
+use Zendesk\API\Resources\Core\PushNotificationDevices;
 
 /**
  * PushNotificationDevices test class


### PR DESCRIPTION
Allow the client to use the push notification devices resource

/cc @jwswj @joseconsador @mmolina @atroche

### References
* JIRA: https://zendesk.atlassian.net/browse/MI-150

### Risks
* Low. We might not be able to call push notification devices endpoints using the client