### PR TITLE
[MI-146] Add the app install locations resource

### DIFF
--- a/src/Zendesk/API/Resources/Core/AppInstallationLocations.php
+++ b/src/Zendesk/API/Resources/Core/AppInstallationLocations.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Zendesk\API\Resources\Core;
+
+use Zendesk\API\Resources\ResourceAbstract;
+use Zendesk\API\Traits\Resource\Find;
+use Zendesk\API\Traits\Resource\FindAll;
+
+/**
+ * Class AppInstallationLocations
+ * https://developer.zendesk.com/rest_api/docs/core/app_location_installations
+ */
+class AppInstallationLocations extends ResourceAbstract
+{
+    use FindAll;
+    use Find;
+
+    /**
+     * {@inheritdoc}
+     */
+    protected $resourceName = 'apps/location_installations';
+
+    /**
+     *
+     */
+    protected function setUpRoutes()
+    {
+        parent::setUpRoutes();
+
+        $this->setRoute('reorder', "{$this->resourceName}/reorder.json");
+    }
+
+    /**
+     * Creates or updates the relevant Location Installation record with the installation order specified
+     *
+     * @param array $params
+     *
+     * @return array
+     * @throws \Zendesk\API\Exceptions\RouteException
+     */
+    public function reorder(array $params)
+    {
+        return $this->client->post($this->getRoute(__FUNCTION__), $params);
+    }
+}

--- a/src/Zendesk/API/Resources/Core/Apps.php
+++ b/src/Zendesk/API/Resources/Core/Apps.php
@@ -7,14 +7,19 @@ use Zendesk\API\Resources\ResourceAbstract;
 use Zendesk\API\Traits\Resource\Delete;
 use Zendesk\API\Traits\Resource\Find;
 use Zendesk\API\Traits\Resource\MultipartUpload;
+use Zendesk\API\Traits\Utility\InstantiatorTrait;
 
 /**
  * The Apps class exposes app management methods
+ *
+ * @method AppInstallationLocations installationLocations()
  */
 class Apps extends ResourceAbstract
 {
     const OBJ_NAME = 'app';
     const OBJ_NAME_PLURAL = 'apps';
+
+    use InstantiatorTrait;
 
     use Find;
     use Delete;
@@ -52,6 +57,16 @@ class Apps extends ResourceAbstract
     public function getUploadRequestMethod()
     {
         return 'POST';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function getValidSubResources()
+    {
+        return [
+            'installationLocations' => AppInstallationLocations::class,
+        ];
     }
 
     /**

--- a/tests/Zendesk/API/UnitTests/AppInstallationLocationsTest.php
+++ b/tests/Zendesk/API/UnitTests/AppInstallationLocationsTest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Zendesk\API\UnitTests;
+
+/**
+ * Class AppInstallationLocationsTest
+ */
+class AppInstallationLocationsTest extends BasicTest
+{
+
+    /**
+     * Test get incremental export for tickets
+     */
+    public function testTraits()
+    {
+        $this->assertTrue(method_exists($this->client->apps()->installationLocations(), 'find'));
+        $this->assertTrue(method_exists($this->client->apps()->installationLocations(), 'findAll'));
+    }
+
+    /**
+     * Test the reorder method
+     *
+     */
+    public function testReorder()
+    {
+        $postFields = [
+            'installations' => [82, 56],
+            'location_name' => 'nav_bar'
+        ];
+
+        $this->assertEndpointCalled(function () use ($postFields) {
+            $this->client->apps()->installationLocations()->reorder($postFields);
+        }, 'apps/location_installations/reorder.json', 'POST', ['postFields' => $postFields]);
+    }
+}


### PR DESCRIPTION
Add app installation locations resource

This is dependent on https://github.com/zendesk/zendesk_api_client_php/pull/144

/cc @jwswj @joseconsador @mmolina @atroche

### References
* JIRA: https://zendesk.atlassian.net/browse/MI-146

### Risks
* Low. We might not be able to call the app installation endpoints using the client