### PR TITLE
[MI-177] Rename the subresource of OrganizationMemberships in the Organization

### DIFF
--- a/src/Zendesk/API/Resources/Core/Organizations.php
+++ b/src/Zendesk/API/Resources/Core/Organizations.php
@@ -35,9 +35,9 @@ class Organizations extends ResourceAbstract
     public static function getValidSubResources()
     {
         return [
-            'organizationMemberships' => OrganizationMemberships::class,
-            'subscriptions'           => OrganizationSubscriptions::class,
-            'requests'                => Requests::class,
+            'memberships'   => OrganizationMemberships::class,
+            'subscriptions' => OrganizationSubscriptions::class,
+            'requests'      => Requests::class,
         ];
     }
 

--- a/tests/Zendesk/API/UnitTests/Core/OrganizationMembershipsTest.php
+++ b/tests/Zendesk/API/UnitTests/Core/OrganizationMembershipsTest.php
@@ -77,7 +77,7 @@ class OrganizationMembershipsTest extends BasicTest
     {
         $resourceId = 123;
         $this->assertEndpointCalled(function () use ($resourceId) {
-            $this->client->organizations($resourceId)->organizationMemberships()->findAll();
+            $this->client->organizations($resourceId)->memberships()->findAll();
         }, "organizations/{$resourceId}/organization_memberships.json");
     }
 


### PR DESCRIPTION
Rename the subresource of OrganizationMemberships in the Organization class.
The call will now look like this
`$client->organizations(1)->memberships()->findAll();`

/cc @jwswj @joseconsador @mmolina @atroche

### References
* JIRA: https://zendesk.atlassian.net/browse/MI-177

### Risks
* Low. We might not be able to call the organization membership correctly.