### PR TITLE
[MI-179] Add PHP version support to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,9 @@
 
 This client **only** supports Zendesk's API v2.  Please see our [API documentation](http://developer.zendesk.com) for more information.
 
+## Requrements
+* PHP (at least 5.5)
+
 ## Installation
 
 The Zendesk PHP API client can be installed using [Composer](https://packagist.org/packages/zendesk/zendesk_api_client_php).

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 This client **only** supports Zendesk's API v2.  Please see our [API documentation](http://developer.zendesk.com) for more information.
 
 ## Requrements
-* PHP (at least 5.5)
+* PHP 5.5+
 
 ## Installation
 


### PR DESCRIPTION
Add PHP version support to the README.
PHP5.5+ is a requirement for Guzzle 6.

/cc @miogalang @jwswj @mmolina @atroche

### References
 - Jira link: https://zendesk.atlassian.net/browse/MI-179

### Risks
 - None