### PR TITLE
Change the exception message format

### DIFF
--- a/src/Zendesk/API/Exceptions/ApiResponseException.php
+++ b/src/Zendesk/API/Exceptions/ApiResponseException.php
@@ -19,18 +19,18 @@ class ApiResponseException extends \Exception
     public function __construct(RequestException $e)
     {
         $response = $e->getResponse();
-        $message  = $response->getReasonPhrase();
+        $message  = $response->getReasonPhrase()
+            . " [status code] " . $response->getStatusCode();
 
         $level = floor($response->getStatusCode() / 100);
         // Check if business-level error message
         // https://developer.zendesk.com/rest_api/docs/core/introduction#requests
-        if ($response->getHeaderLine('Content-Type') == 'application/json; charset=UTF-8') {
-            $responseBody = json_decode($response->getBody()->getContents());
-
-            $this->errorDetails = $responseBody->details;
-            $message            = $responseBody->description . "\n" . 'Errors: ' . print_r($this->errorDetails, true);
+        if ($level == '4') {
+            $responseBody = $response->getBody()->getContents();
+            $this->errorDetails = $responseBody;
+            $message .= ' [details] ' . $this->errorDetails;
         } elseif ($level == '5') {
-            $message = 'Zendesk may be experiencing internal issues or undergoing scheduled maintenance.';
+            $message .= ' [details] Zendesk may be experiencing internal issues or undergoing scheduled maintenance.';
         }
 
         parent::__construct($message, $response->getStatusCode());


### PR DESCRIPTION
I was struggling to debug some errors earlier today because the messages being returned weren't useful:
```
Fatal error: Uncaught exception 'Zendesk\API\Exceptions\ApiResponseException' with message '
Errors: ' in /Users/jsmale/Code/other/testphpapi/vendor/zendesk/zendesk_api_client_php/src/Zendesk/API/Http.php:116
Stack trace:
#0 /Users/jsmale/Code/other/testphpapi/vendor/zendesk/zendesk_api_client_php/src/Zendesk/API/HttpClient.php(408): Zendesk\API\Http::send(Object(Zendesk\API\HttpClient), 'tickets/155.jso...', Array)
#1 /Users/jsmale/Code/other/testphpapi/vendor/zendesk/zendesk_api_client_php/src/Zendesk/API/Traits/Resource/Update.php(40): Zendesk\API\HttpClient->put('tickets/155.jso...', Array)
#2 /Users/jsmale/Code/other/testphpapi/vendor/zendesk/zendesk_api_client_php/src/Zendesk/API/Resources/Core/Tickets.php(201): Zendesk\API\Resources\Core\Tickets->traitUpdate(155, Array)
#3 /Users/jsmale/Code/other/testphpapi/index.php(48): Zendesk\API\Resources\Core\Tickets->update(155, Array)
#4 {main}
  thrown in /Users/jsmale/Code/other/testphpapi/vendor/zendesk/zendesk_api_client_php/src/Zendesk/API/Http.php on line 116
```

Without our client interfering with Guzzle's exception it was much easier to understand:
```
Fatal error: Uncaught exception 'Zendesk\API\Exceptions\ApiResponseException' with message 'exception 'GuzzleHttp\Exception\ClientException' with message 'Client error: 401' in /Users/jsmale/Code/other/testphpapi/vendor/guzzlehttp/guzzle/src/Middleware.php:69
Stack trace:
#0 /Users/jsmale/Code/other/testphpapi/vendor/guzzlehttp/promises/src/Promise.php(199): GuzzleHttp\Middleware::GuzzleHttp\{closure}(Object(GuzzleHttp\Psr7\Response))
#1 /Users/jsmale/Code/other/testphpapi/vendor/guzzlehttp/promises/src/Promise.php(152): GuzzleHttp\Promise\Promise::callHandler(1, Object(GuzzleHttp\Psr7\Response), Array)
#2 /Users/jsmale/Code/other/testphpapi/vendor/guzzlehttp/promises/src/TaskQueue.php(60): GuzzleHttp\Promise\Promise::GuzzleHttp\Promise\{closure}()
#3 /Users/jsmale/Code/other/testphpapi/vendor/guzzlehttp/guzzle/src/Handler/CurlMultiHandler.php(96): GuzzleHttp\Promise\TaskQueue->run()
#4 /Users/jsmale/Code/other/testphpapi/vendor/guzzlehttp/guzzle/src/Handler/CurlMultiHandler.php(123): GuzzleHttp\Handler\CurlMultiHandler-> in /Users/jsmale/Code/other/testphpapi/vendor/zendesk/zendesk_api_client_php/src/Zendesk/API/Http.php on line 116
```

But just using the default Guzzle exception message misses out on displaying all the goodness that our API does return to help with debugging. This PR will now throw an error like:
```
Fatal error: Uncaught exception 'Zendesk\API\Exceptions\ApiResponseException' with message 'Unauthorized [status code] 401 [details] {"error":"Couldn't authenticate you"}' in /Users/jsmale/Code/other/testphpapi/vendor/zendesk/zendesk_api_client_php/src/Zendesk/API/Http.php:116
Stack trace:
#0 /Users/jsmale/Code/other/testphpapi/vendor/zendesk/zendesk_api_client_php/src/Zendesk/API/HttpClient.php(408): Zendesk\API\Http::send(Object(Zendesk\API\HttpClient), 'tickets/155.jso...', Array)
#1 /Users/jsmale/Code/other/testphpapi/vendor/zendesk/zendesk_api_client_php/src/Zendesk/API/Traits/Resource/Update.php(40): Zendesk\API\HttpClient->put('tickets/155.jso...', Array)
#2 /Users/jsmale/Code/other/testphpapi/vendor/zendesk/zendesk_api_client_php/src/Zendesk/API/Resources/Core/Tickets.php(201): Zendesk\API\Resources\Core\Tickets->traitUpdate(155, Array)
#3 /Users/jsmale/Code/other/testphpapi/index.php(48): Zendesk\API\Resources\Core\Tickets->update(155, Array)
#4 {main}
  thrown in /Users/jsmale/Code/other/testphpapi/vendor/zendesk/zendesk_api_client_php/src/Zendesk/API/Http.php on line 116
```

I decided not parse the JSON response and render it over multiple lines as sometimes a string is returned for 4XX responses. I'm not sure if that's the best decision, but I was put off by print_r showing the object type `stdClass Object`.

@miogalang @joseconsador thoughts?