### PR TITLE
[MI-258] User search

### DIFF
--- a/samples/oauth.php
+++ b/samples/oauth.php
@@ -37,7 +37,7 @@ if (isset($_POST['action']) && 'redirect' === $_POST['action']) {
         echo "<h1>Success!</h1>";
         echo "<p>Your OAuth token is: " . $response->access_token . "</p>";
         echo "<p>Use this code before any other API call:</p>";
-        echo "<code>&lt;?<br />\$client = new ZendeskAPI(\$subdomain, \$username);<br />\$client->setAuth(\Zendesk\API\Utilities\Auth::OAUTH, '" . $response->access_token . "');<br />?&gt;</code>";
+        echo "<code>&lt;?php<br />\$client = new ZendeskAPI(\$subdomain, \$username);<br />\$client->setAuth(\Zendesk\API\Utilities\Auth::OAUTH, ['token' => " . $response->access_token . "]');<br />?&gt;</code>";
     } catch (\Zendesk\API\Exceptions\ApiResponseException $e) {
         echo "<h1>Error!</h1>";
         echo "<p>We couldn't get an access token for you. Please check your credentials and try again.</p>";

--- a/src/Zendesk/API/Http.php
+++ b/src/Zendesk/API/Http.php
@@ -17,34 +17,6 @@ class Http
     public static $curl;
 
     /**
-     * Prepares an endpoint URL with optional side-loading
-     *
-     * @param array $sideload
-     * @param array $iterators
-     *
-     * @return string
-     */
-    public static function prepareQueryParams(array $sideload = null, array $iterators = null)
-    {
-        $addParams = [];
-        // First look for side-loaded variables
-        if (is_array($sideload)) {
-            $addParams['include'] = implode(',', $sideload);
-        }
-
-        // Next look for special collection iterators
-        if (is_array($iterators)) {
-            foreach ($iterators as $k => $v) {
-                if (in_array($k, ['per_page', 'page', 'sort_order', 'sort_by', 'external_id'])) {
-                    $addParams[$k] = $v;
-                }
-            }
-        }
-
-        return $addParams;
-    }
-
-    /**
      * Use the send method to call every endpoint except for oauth/tokens
      *
      * @param HttpClient $client

--- a/src/Zendesk/API/HttpClient.php
+++ b/src/Zendesk/API/HttpClient.php
@@ -339,10 +339,14 @@ class HttpClient
      *
      * @return array|null
      */
-    public function getSideload(array $params = null)
+    public function getSideload(array $params = [])
     {
-        if ((isset($params['sideload'])) && (is_array($params['sideload']))) {
-            return $params['sideload'];
+        // Allow both for backward compatability
+        $sideloadKeys = array('include', 'sideload');
+
+        if (! empty($sideloads = array_intersect_key($params, array_flip($sideloadKeys)))) {
+            // Merge to a single array
+            return call_user_func_array('array_merge', $sideloads);
         } else {
             return $this->sideload;
         }
@@ -352,7 +356,6 @@ class HttpClient
     {
         $sideloads = $this->getSideload($queryParams);
 
-        // TODO: filter allowed query params
         if (is_array($sideloads)) {
             $queryParams['include'] = implode(',', $sideloads);
             unset($queryParams['sideload']);

--- a/src/Zendesk/API/Resources/Core/AuditLogs.php
+++ b/src/Zendesk/API/Resources/Core/AuditLogs.php
@@ -33,13 +33,8 @@ class AuditLogs extends ResourceAbstract
      */
     public function findAll(array $params = [])
     {
-        $sideloads = $this->client->getSideload($params);
-
-        $extraParams = Http::prepareQueryParams($sideloads, $params);
         $queryParams = array_filter(array_flip($params), [$this, 'filterParams']);
-        $queryParams = array_flip($queryParams);
-
-        $queryParams = array_merge($queryParams, $extraParams);
+        $queryParams = array_merge($params, array_flip($queryParams));
 
         return $this->traitFindAll($queryParams);
     }

--- a/src/Zendesk/API/Resources/Core/Organizations.php
+++ b/src/Zendesk/API/Resources/Core/Organizations.php
@@ -104,12 +104,9 @@ class Organizations extends ResourceAbstract
      */
     public function autocomplete($name, array $params = [])
     {
-        $sideloads = $this->client->getSideload($params);
+        $params['name'] = $name;
 
-        $queryParams         = Http::prepareQueryParams($sideloads, $params);
-        $queryParams['name'] = $name;
-
-        return $this->client->get($this->getRoute(__FUNCTION__), $queryParams);
+        return $this->client->get($this->getRoute(__FUNCTION__), $params);
     }
 
     /**
@@ -138,11 +135,8 @@ class Organizations extends ResourceAbstract
      */
     public function search($external_id, array $params = [])
     {
-        $sideloads = $this->client->getSideload($params);
+        $params['external_id'] = $external_id;
 
-        $queryParams                = Http::prepareQueryParams($sideloads, $params);
-        $queryParams['external_id'] = $external_id;
-
-        return $this->client->get($this->getRoute(__FUNCTION__), $queryParams);
+        return $this->client->get($this->getRoute(__FUNCTION__), $params);
     }
 }

--- a/src/Zendesk/API/Resources/Core/Tickets.php
+++ b/src/Zendesk/API/Resources/Core/Tickets.php
@@ -68,14 +68,10 @@ class Tickets extends ResourceAbstract
      */
     private function sendGetRequest($route, array $params = [])
     {
-        $queryParams = Http::prepareQueryParams(
-            $this->client->getSideload($params),
-            $params
-        );
-        $response    = Http::send(
+        $response = Http::send(
             $this->client,
             $this->getRoute($route, $params),
-            ['queryParams' => $queryParams]
+            ['queryParams' => $params]
         );
 
         return $response;
@@ -126,7 +122,8 @@ class Tickets extends ResourceAbstract
             $endPointBase . (is_array($params['comment_ids']) ? '?' . implode(',', $params['comment_ids']) : ''),
             $this->client->getSideload($params)
         );
-        $response     = Http::send($this->client, $endPoint);
+
+        $response = Http::send($this->client, $endPoint);
 
         return $response;
     }

--- a/src/Zendesk/API/Resources/Core/Users.php
+++ b/src/Zendesk/API/Resources/Core/Users.php
@@ -217,9 +217,7 @@ class Users extends ResourceAbstract
      */
     public function search(array $params)
     {
-        $queryParams = isset($params['query']) ? ['query' => $params['query']] : [];
-
-        return $this->client->get($this->getRoute(__FUNCTION__), array_merge($params, $queryParams));
+        return $this->client->get($this->getRoute(__FUNCTION__), $params);
     }
 
     /**

--- a/src/Zendesk/API/Resources/Core/Users.php
+++ b/src/Zendesk/API/Resources/Core/Users.php
@@ -149,11 +149,10 @@ class Users extends ResourceAbstract
             throw new MissingParametersException(__METHOD__, ['id']);
         }
 
-        $queryParams = Http::prepareQueryParams($this->client->getSideload($params), $params);
-        $response    = Http::send(
+        $response = Http::send(
             $this->client,
             $this->getRoute(__FUNCTION__, ['id' => $params['id']]),
-            ['queryParams' => $queryParams]
+            ['queryParams' => $params]
         );
 
         return $response;
@@ -219,9 +218,8 @@ class Users extends ResourceAbstract
     public function search(array $params)
     {
         $queryParams = isset($params['query']) ? ['query' => $params['query']] : [];
-        $extraParams = Http::prepareQueryParams($this->client->getSideload($params), $params);
 
-        return $this->client->get($this->getRoute(__FUNCTION__), array_merge($extraParams, $queryParams));
+        return $this->client->get($this->getRoute(__FUNCTION__), array_merge($params, $queryParams));
     }
 
     /**

--- a/src/Zendesk/API/Resources/Core/Users.php
+++ b/src/Zendesk/API/Resources/Core/Users.php
@@ -209,7 +209,7 @@ class Users extends ResourceAbstract
     /**
      * Search for users
      *
-     * @param array $params
+     * @param array $params Accepts `external_id` & `query`
      *
      * @throws ResponseException
      * @throws \Exception

--- a/src/Zendesk/API/Resources/Core/Views.php
+++ b/src/Zendesk/API/Resources/Core/Views.php
@@ -15,7 +15,6 @@ class Views extends ResourceAbstract
 {
     use Defaults {
         findAll as traitFindall;
-        find as traitFind;
     }
 
     /**
@@ -61,24 +60,6 @@ class Views extends ResourceAbstract
     }
 
     /**
-     * Show a specific view
-     *
-     * @param int   $id
-     * @param array $queryParams
-     *
-     * @return mixed
-     */
-    public function find($id = null, array $queryParams = [])
-    {
-        $queryParams = Http::prepareQueryParams(
-            $this->client->getSideload($queryParams),
-            $queryParams
-        );
-
-        return $this->traitFind($id, $queryParams);
-    }
-
-    /**
      * Execute a specific view
      *
      * @param array $params
@@ -91,21 +72,18 @@ class Views extends ResourceAbstract
      */
     public function execute(array $params = [])
     {
-        $params = $this->addChainedParametersToParams(
-            $params,
-            ['id' => get_class($this)]
-        );
+        if (! isset($params['id'])) {
+            $id = $this->getChainedParameter(get_class($this));
+        } else {
+            $id = $params['id'];
+            unset($params['id']);
+        }
 
-        if (! $this->hasKeys($params, ['id'])) {
+        if (is_null($id)) {
             throw new MissingParametersException(__METHOD__, ['id']);
         }
 
-        $queryParams = Http::prepareQueryParams(
-            $this->client->getSideload($params),
-            $params
-        );
-
-        return $this->client->get($this->getRoute(__FUNCTION__, ['id' => $params['id']]), $queryParams);
+        return $this->client->get($this->getRoute(__FUNCTION__, ['id' => $id]), $params);
     }
 
     /**
@@ -121,21 +99,18 @@ class Views extends ResourceAbstract
      */
     public function tickets(array $params = [])
     {
-        $params = $this->addChainedParametersToParams(
-            $params,
-            ['id' => get_class($this)]
-        );
+        if (! isset($params['id'])) {
+            $id = $this->getChainedParameter(get_class($this));
+        } else {
+            $id = $params['id'];
+            unset($params['id']);
+        }
 
-        if (! $this->hasKeys($params, ['id'])) {
+        if (is_null($id)) {
             throw new MissingParametersException(__METHOD__, ['id']);
         }
 
-        $queryParams = Http::prepareQueryParams(
-            $this->client->getSideload($params),
-            $params
-        );
-
-        return $this->client->get($this->getRoute(__FUNCTION__, ['id' => $params['id']]), $queryParams);
+        return $this->client->get($this->getRoute(__FUNCTION__, ['id' => $id]), $params);
     }
 
     /**
@@ -169,12 +144,7 @@ class Views extends ResourceAbstract
             $routeParams = ['id' => $params['id']];
         }
 
-        $extraParams = Http::prepareQueryParams(
-            $this->client->getSideload($params),
-            $params
-        );
-
-        return $this->client->get($this->getRoute(__FUNCTION__, $routeParams), array_merge($extraParams, $queryParams));
+        return $this->client->get($this->getRoute(__FUNCTION__, $routeParams), array_merge($params, $queryParams));
     }
 
     /**
@@ -190,20 +160,18 @@ class Views extends ResourceAbstract
      */
     public function export(array $params = [])
     {
-        $params = $this->addChainedParametersToParams(
-            $params,
-            ['id' => get_class($this)]
-        );
-        if (! $this->hasKeys($params, ['id'])) {
+        if (! isset($params['id'])) {
+            $id = $this->getChainedParameter(get_class($this));
+        } else {
+            $id = $params['id'];
+            unset($params['id']);
+        }
+
+        if (is_null($id)) {
             throw new MissingParametersException(__METHOD__, ['id']);
         }
 
-        $queryParams = Http::prepareQueryParams(
-            $this->client->getSideload($params),
-            $params
-        );
-
-        return $this->client->get($this->getRoute(__FUNCTION__, ['id' => $params['id']]), $queryParams);
+        return $this->client->get($this->getRoute(__FUNCTION__, ['id' => $id]), $params);
     }
 
     /**

--- a/src/Zendesk/API/Resources/Core/Views.php
+++ b/src/Zendesk/API/Resources/Core/Views.php
@@ -191,8 +191,8 @@ class Views extends ResourceAbstract
 
     /**
      * Get the ticket ID from the chained parameters or a params array
-     * 
-     * @param  array  &$params 
+     *
+     * @param  array  &$params
      * @return int
      */
     private function getIdFromParams(array &$params)

--- a/src/Zendesk/API/Resources/Core/Views.php
+++ b/src/Zendesk/API/Resources/Core/Views.php
@@ -72,12 +72,7 @@ class Views extends ResourceAbstract
      */
     public function execute(array $params = [])
     {
-        if (! isset($params['id'])) {
-            $id = $this->getChainedParameter(get_class($this));
-        } else {
-            $id = $params['id'];
-            unset($params['id']);
-        }
+        $id = $this->getIdFromParams($params);
 
         if (is_null($id)) {
             throw new MissingParametersException(__METHOD__, ['id']);
@@ -99,12 +94,7 @@ class Views extends ResourceAbstract
      */
     public function tickets(array $params = [])
     {
-        if (! isset($params['id'])) {
-            $id = $this->getChainedParameter(get_class($this));
-        } else {
-            $id = $params['id'];
-            unset($params['id']);
-        }
+        $id = $this->getIdFromParams($params);
 
         if (is_null($id)) {
             throw new MissingParametersException(__METHOD__, ['id']);
@@ -160,12 +150,7 @@ class Views extends ResourceAbstract
      */
     public function export(array $params = [])
     {
-        if (! isset($params['id'])) {
-            $id = $this->getChainedParameter(get_class($this));
-        } else {
-            $id = $params['id'];
-            unset($params['id']);
-        }
+        $id = $this->getIdFromParams($params);
 
         if (is_null($id)) {
             throw new MissingParametersException(__METHOD__, ['id']);
@@ -202,5 +187,23 @@ class Views extends ResourceAbstract
     public function previewCount(array $params)
     {
         return $this->client->post($this->getRoute(__FUNCTION__), [$this->objectName => $params]);
+    }
+
+    /**
+     * Get the ticket ID from the chained parameters or a params array
+     * 
+     * @param  array  &$params 
+     * @return int
+     */
+    private function getIdFromParams(array &$params)
+    {
+        if (! isset($params['id'])) {
+            $id = $this->getChainedParameter(get_class($this));
+        } else {
+            $id = $params['id'];
+            unset($params['id']);
+        }
+
+        return $id;
     }
 }

--- a/tests/Zendesk/API/LiveTests/SearchTest.php
+++ b/tests/Zendesk/API/LiveTests/SearchTest.php
@@ -4,10 +4,17 @@ namespace Zendesk\API\LiveTests;
 
 class SearchTest extends BasicTest
 {
+    /**
+     * @throws \Zendesk\API\Exceptions\MissingParametersException
+     */
     public function testSearchQueryString()
     {
         $response = $this->client->search()->find('type:ticket status:open', ['sort_by' => 'updated_at']);
 
         $this->assertTrue(isset($response->results), 'Should contain a property called `results`');
+        $this->assertTrue(
+            is_array($response->results) && count($response->results) > 0,
+            'Should contain a non-empty `results` array.'
+        );
     }
 }

--- a/tests/Zendesk/API/LiveTests/TicketsTest.php
+++ b/tests/Zendesk/API/LiveTests/TicketsTest.php
@@ -181,7 +181,6 @@ class TicketsTest extends BasicTest
             'followup_source_ids',
             'from_archive',
             'incidents',
-            'twitter'
         ];
         foreach ($properties as $property) {
             $this->assertTrue(

--- a/tests/Zendesk/API/LiveTests/UsersTest.php
+++ b/tests/Zendesk/API/LiveTests/UsersTest.php
@@ -2,6 +2,7 @@
 namespace Zendesk\API\LiveTests;
 
 use Faker\Factory;
+use Zendesk\API\Exceptions\ApiResponseException;
 
 /**
  * Users test class
@@ -143,9 +144,15 @@ class UsersTest extends BasicTest
     {
         $postFields = ['password' => 'aBc12345'];
 
-        $this->client->users($user->id)->setPassword($postFields);
-        $this->assertEquals(200, $this->client->getDebug()->lastResponseCode);
-        $this->assertNull($this->client->getDebug()->lastResponseError);
+        try {
+            $this->client->users($user->id)->setPassword($postFields);
+            $this->assertEquals(200, $this->client->getDebug()->lastResponseCode);
+            $this->assertNull($this->client->getDebug()->lastResponseError);
+        } catch (ApiResponseException $e) {
+            if ($e->getCode() === 403) {
+                $this->markTestSkipped('Skipping test, `Allow admins to set passwords` must be enabled in Security.');
+            }
+        }
 
         return $user;
     }

--- a/tests/Zendesk/API/LiveTests/UsersTest.php
+++ b/tests/Zendesk/API/LiveTests/UsersTest.php
@@ -15,9 +15,10 @@ class UsersTest extends BasicTest
     {
         $faker      = Factory::create();
         $userFields = [
-            'name'     => $faker->name,
-            'email'    => $faker->safeEmail,
-            'verified' => true,
+            'name'        => $faker->name,
+            'email'       => $faker->safeEmail,
+            'verified'    => true,
+            'external_id' => $faker->uuid,
         ];
         $response   = $this->client->users()->create($userFields);
         $this->assertTrue(property_exists($response, 'user'));
@@ -60,6 +61,20 @@ class UsersTest extends BasicTest
     public function testSearch($user)
     {
         $response = $this->client->users()->search(['query' => $user->name]);
+        $this->assertTrue(property_exists($response, 'users'));
+        $this->assertNotNull($foundUser = $response->users[0]);
+        $this->assertEquals($user->email, $foundUser->email);
+        $this->assertEquals($user->name, $foundUser->name);
+    }
+
+    /**
+     * Tests search for a user
+     *
+     * @depends testCreate
+     */
+    public function testSearchByExternalId($user)
+    {
+        $response = $this->client->users()->search(['external_id' => $user->external_id]);
         $this->assertTrue(property_exists($response, 'users'));
         $this->assertNotNull($foundUser = $response->users[0]);
         $this->assertEquals($user->email, $foundUser->email);

--- a/tests/Zendesk/API/UnitTests/Core/AuditLogsTest.php
+++ b/tests/Zendesk/API/UnitTests/Core/AuditLogsTest.php
@@ -17,17 +17,13 @@ class AuditLogsTest extends BasicTest
         $queryParams = [
             'filter["source_type"]' => 'rule',
             'filter["valid"]'       => 'somerule',
-            'invalid'               => 'invalidrule',
+            'per_page'              => 1,
         ];
 
         // We expect invalid parameters are removed.
         // We also expect url encoded keys and values
         $expectedQueryParams = [];
         foreach ($queryParams as $key => $value) {
-            if ($key == 'invalid') {
-                continue;
-            }
-
             $expectedQueryParams = array_merge($expectedQueryParams, [urlencode($key) => urlencode($value)]);
         }
 

--- a/tests/Zendesk/API/UnitTests/Core/AuditLogsTest.php
+++ b/tests/Zendesk/API/UnitTests/Core/AuditLogsTest.php
@@ -17,7 +17,6 @@ class AuditLogsTest extends BasicTest
         $queryParams = [
             'filter["source_type"]' => 'rule',
             'filter["valid"]'       => 'somerule',
-            'per_page'              => 1,
         ];
 
         // We expect invalid parameters are removed.

--- a/tests/Zendesk/API/UnitTests/Core/ResourceTest.php
+++ b/tests/Zendesk/API/UnitTests/Core/ResourceTest.php
@@ -54,6 +54,23 @@ class ResourceTest extends BasicTest
     }
 
     /**
+     * This tests if passing `include`, or `sideload` is converted to a single `include` query parameter, also tests if other params can be set
+     */
+    public function testCanSetAdditionalParams()
+    {
+        $params = ['include' => ['users', 'groups'], 'sideload' => ['test', 'this'], 'external_id' => 12345];
+
+        $this->assertEndpointCalled(function () use ($params) {
+            $this->dummyResource->findAll($params);
+        }, 'dummy_resource.json', 'GET', [
+            'queryParams' => [
+                'include' => 'users,groups,test,this',
+                'external_id' => 12345
+            ]
+        ]);
+    }
+
+    /**
      * Test create method
      */
     public function testCreate()

--- a/tests/Zendesk/API/UnitTests/Core/ResourceTest.php
+++ b/tests/Zendesk/API/UnitTests/Core/ResourceTest.php
@@ -58,7 +58,11 @@ class ResourceTest extends BasicTest
      */
     public function testCanSetAdditionalParams()
     {
-        $params = ['include' => ['users', 'groups'], 'sideload' => ['test', 'this'], 'external_id' => 12345];
+        $params = [
+            'include' => ['users', 'groups'],
+            'sideload' => ['test', 'this'],
+            'external_id' => 12345
+        ];
 
         $this->assertEndpointCalled(function () use ($params) {
             $this->dummyResource->findAll($params);

--- a/tests/Zendesk/API/UnitTests/Core/UsersTest.php
+++ b/tests/Zendesk/API/UnitTests/Core/UsersTest.php
@@ -88,18 +88,6 @@ class UsersTest extends BasicTest
         }, 'users/search.json', 'GET', ['queryParams' => $queryParams]);
     }
 
-    /**
-     * Tests if the search enpoint can be called by the client and is passed the correct external_id
-     */
-    public function testSearchByExternalId()
-    {
-        $queryParams = ['external_id' => 'ext-1'];
-
-        $this->assertEndpointCalled(function () use ($queryParams) {
-            $this->client->users()->search($queryParams);
-        }, 'users/search.json', 'GET', ['queryParams' => $queryParams]);
-    }
-
     /*
      * Needs an existed User with specified query 'name' keyword to run this function
      */

--- a/tests/Zendesk/API/UnitTests/Core/UsersTest.php
+++ b/tests/Zendesk/API/UnitTests/Core/UsersTest.php
@@ -141,7 +141,7 @@ class UsersTest extends BasicTest
         }, 'users/me.json');
     }
 
-    /**
+    /*
      * Tests if the setPassword function calls the correct endpoint and passes the correct POST data
      */
     public function testSetPassword()

--- a/tests/Zendesk/API/UnitTests/Core/UsersTest.php
+++ b/tests/Zendesk/API/UnitTests/Core/UsersTest.php
@@ -68,7 +68,7 @@ class UsersTest extends BasicTest
     /**
      * Tests if the search enpoint can be called by the client and is passed the correct query
      */
-    public function testSearch()
+    public function testSearchByQuery()
     {
         $queryParams = ['query' => 'Roger'];
 
@@ -83,6 +83,18 @@ class UsersTest extends BasicTest
     public function testSearchByExternalId()
     {
         $queryParams = ['external_id' => 'ext-1'];
+        $this->assertEndpointCalled(function () use ($queryParams) {
+            $this->client->users()->search($queryParams);
+        }, 'users/search.json', 'GET', ['queryParams' => $queryParams]);
+    }
+
+    /**
+     * Tests if the search enpoint can be called by the client and is passed the correct external_id
+     */
+    public function testSearchByExternalId()
+    {
+        $queryParams = ['external_id' => 'ext-1'];
+
         $this->assertEndpointCalled(function () use ($queryParams) {
             $this->client->users()->search($queryParams);
         }, 'users/search.json', 'GET', ['queryParams' => $queryParams]);

--- a/tests/Zendesk/API/UnitTests/Core/ViewsTest.php
+++ b/tests/Zendesk/API/UnitTests/Core/ViewsTest.php
@@ -81,8 +81,8 @@ class ViewsTest extends BasicTest
     public function testExport()
     {
         $this->assertEndpointCalled(function () {
-            $this->client->views($this->id)->export();
-        }, "views/{$this->id}/export.json", 'GET');
+            $this->client->views()->export(['id' => $this->id]);
+        }, "views/{$this->id}/export.json", 'GET', ['queryParams' => []]);
     }
 
     /**


### PR DESCRIPTION
Removes the HttpClient::prepareQueryParams() method which filters the allowed query parameters (iterators usually) for most requests. 

/cc @miogalang @jwswj @mmolina @iandjx 

### References
 - Jira link: https://zendesk.atlassian.net/browse/MI-258
 - Github Issue: #195 

### Risks
 - High: Query parameters may not be set / ANY query parameter may be set. Could break calls to the API.