### PR TITLE
Whitelist external_id as an accepted query param

### DIFF
--- a/src/Zendesk/API/Http.php
+++ b/src/Zendesk/API/Http.php
@@ -35,7 +35,7 @@ class Http
         // Next look for special collection iterators
         if (is_array($iterators)) {
             foreach ($iterators as $k => $v) {
-                if (in_array($k, ['per_page', 'page', 'sort_order', 'sort_by'])) {
+                if (in_array($k, ['per_page', 'page', 'sort_order', 'sort_by', 'external_id'])) {
                     $addParams[$k] = $v;
                 }
             }

--- a/tests/Zendesk/API/UnitTests/Core/UsersTest.php
+++ b/tests/Zendesk/API/UnitTests/Core/UsersTest.php
@@ -77,6 +77,17 @@ class UsersTest extends BasicTest
         }, 'users/search.json', 'GET', ['queryParams' => $queryParams]);
     }
 
+    /**
+     * Tests if the search enpoint can be called by the client and is passed the correct external_id
+     */
+    public function testSearchByExternalId()
+    {
+        $queryParams = ['external_id' => 'ext-1'];
+        $this->assertEndpointCalled(function () use ($queryParams) {
+            $this->client->users()->search($queryParams);
+        }, 'users/search.json', 'GET', ['queryParams' => $queryParams]);
+    }
+
     /*
      * Needs an existed User with specified query 'name' keyword to run this function
      */


### PR DESCRIPTION
@miogalang @joseconsador @iandjx @joho 

Quick fix for https://github.com/zendesk/zendesk_api_client_php/issues/195 while we work through the bigger change.