### PR TITLE
Add php7 into the build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,10 @@ language: php
 php:
   - 5.6
   - 5.5
-  # - 5.4
-  # - hhvm
+  - 7.0
+matrix:
+  allow_failures:
+    - php: 7.0
 install:
   - travis_retry composer self-update && composer install
 script:


### PR DESCRIPTION
Add PHP7 into the build matrix, allowing it to fail for now.

@miogalang @joseconsador 

### Risks
- None