### PR TITLE
Use guzzle's exception message

### DIFF
--- a/src/Zendesk/API/Http.php
+++ b/src/Zendesk/API/Http.php
@@ -85,8 +85,8 @@ class Http
             list ($request, $requestOptions) = $client->getAuth()->prepareRequest($request, $requestOptions);
             $response = $client->guzzle->send($request, $requestOptions);
         } catch (RequestException $e) {
-            $exception = RequestException::create($e->getRequest(), $e->getResponse());
-            throw new ApiResponseException($exception);
+            $requestException = RequestException::create($e->getRequest(), $e->getResponse());
+            throw new ApiResponseException($requestException);
         } finally {
             $client->setDebug(
                 $request->getHeaders(),

--- a/src/Zendesk/API/Http.php
+++ b/src/Zendesk/API/Http.php
@@ -85,7 +85,8 @@ class Http
             list ($request, $requestOptions) = $client->getAuth()->prepareRequest($request, $requestOptions);
             $response = $client->guzzle->send($request, $requestOptions);
         } catch (RequestException $e) {
-            throw new ApiResponseException($e);
+            $exception = RequestException::create($e->getRequest(), $e->getResponse());
+            throw new ApiResponseException($exception);
         } finally {
             $client->setDebug(
                 $request->getHeaders(),

--- a/tests/Zendesk/API/LiveTests/TicketsTest.php
+++ b/tests/Zendesk/API/LiveTests/TicketsTest.php
@@ -272,4 +272,15 @@ class TicketsTest extends BasicTest
 
         return $response->ticket;
     }
+
+    /**
+     * Test we can handle api exceptions, by finding a non-existing ticket
+     *
+     * @expectedException Zendesk\API\Exceptions\ApiResponseException
+     * @expectedExceptionMessage Not Found
+     */
+    public function testHandlesApiException()
+    {
+        $this->client->tickets()->find(99999999);
+    }
 }

--- a/tests/Zendesk/API/UnitTests/Core/ResourceTest.php
+++ b/tests/Zendesk/API/UnitTests/Core/ResourceTest.php
@@ -1,6 +1,8 @@
 <?php
 namespace Zendesk\API\UnitTests\Core;
 
+use GuzzleHttp\Exception\RequestException;
+use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
 use Zendesk\API\UnitTests\BasicTest;
 
@@ -54,13 +56,14 @@ class ResourceTest extends BasicTest
     }
 
     /**
-     * This tests if passing `include`, or `sideload` is converted to a single `include` query parameter, also tests if other params can be set
+     * This tests if passing `include`, or `sideload` is converted to a single `include` query parameter, also tests if
+     * other params can be set
      */
     public function testCanSetAdditionalParams()
     {
         $params = [
-            'include' => ['users', 'groups'],
-            'sideload' => ['test', 'this'],
+            'include'     => ['users', 'groups'],
+            'sideload'    => ['test', 'this'],
             'external_id' => 12345
         ];
 
@@ -68,7 +71,7 @@ class ResourceTest extends BasicTest
             $this->dummyResource->findAll($params);
         }, 'dummy_resource.json', 'GET', [
             'queryParams' => [
-                'include' => 'users,groups,test,this',
+                'include'     => 'users,groups,test,this',
                 'external_id' => 12345
             ]
         ]);
@@ -273,6 +276,21 @@ class ResourceTest extends BasicTest
         $this->mockApiResponses(
             new Response(422, [], '')
         );
+
+        $this->dummyResource->create(['foo' => 'bar']);
+    }
+
+    /**
+     * Test we can handle api exceptions when no response is returned from the API
+     *
+     * @expectedException Zendesk\API\Exceptions\ApiResponseException
+     * @expectedExceptionMessage Error completing request
+     */
+    public function testHandlesEmptyResponse()
+    {
+        // Create an exception object which is thrown when a response couldn't be retrieved
+        $unsuccessfulResponse = RequestException::create(new Request('GET', 'foo'), null);
+        $this->mockApiResponses($unsuccessfulResponse);
 
         $this->dummyResource->create(['foo' => 'bar']);
     }


### PR DESCRIPTION
Fixes the fatal error from #201 .
The response object from the ResponseException is NULL, which causes this error.
Instead of getting the fatal error, an exception in the following format will be received instead.

```
Zendesk\API\Exceptions\ApiResponseException: Error completing request [url] http://foo.com [http method] GET
```

Uses Guzzle's RequestException::create() method to generate the exceptions, below is a sample of a ClientException.

```
Zendesk\API\Exceptions\ApiResponseException: Client error response [url] https://z3njosemanila.zendesk.com/api/v2/tickets/99999999.json [http method] GET [status code] 404 [reason phrase] Not Found [details] {"error":"RecordNotFound","description":"Not found"}
```

Added a test for handling situations where the server returns no response or the connection is closed.

/cc @miogalang @jwswj @iandjx @pdeuter 

### References
 - Jira link: 

### Risks
 - Medium: Exceptions and cases not covered in ApiResponseException::__construct() may not be caught.