### PR TITLE
[MI-320] Add support for ticket merging.

### DIFF
--- a/src/Zendesk/API/Resources/Core/Tickets.php
+++ b/src/Zendesk/API/Resources/Core/Tickets.php
@@ -93,6 +93,7 @@ class Tickets extends ResourceAbstract
             'deleteMany'          => 'tickets/destroy_many.json',
             'collaborators'       => 'tickets/{id}/collaborators.json',
             'incidents'           => 'tickets/{id}/incidents.json',
+            'merge'               => 'tickets/{id}/merge.json',
             'problems'            => 'problems.json',
             'export'              => 'exports/tickets.json',
             'problemAutoComplete' => 'problems/autocomplete.json'
@@ -378,7 +379,7 @@ class Tickets extends ResourceAbstract
         $response = Http::send(
             $this->client,
             $this->getRoute('export'),
-            ["queryParams" => $queryParams]
+            ['queryParams' => $queryParams]
         );
 
         return $response;
@@ -405,5 +406,35 @@ class Tickets extends ResourceAbstract
         $this->lastAttachments[] = $upload->upload->token;
 
         return $this;
+    }
+
+    /**
+     * @param array $params
+     *
+     * @throws MissingParametersException
+     * @throws ResponseException
+     * @return Tickets
+     */
+    public function merge(array $params = [])
+    {
+        $params = $this->addChainedParametersToParams($params, ['id' => get_class($this)]);
+
+        if (! $this->hasKeys($params, ['id', 'ids'])) {
+            throw new MissingParametersException(__METHOD__, ['id', 'ids']);
+        }
+
+        $route = $this->getRoute(__FUNCTION__, ['id' => $params['id']]);
+        unset($params['id']);
+
+        $response = Http::send(
+            $this->client,
+            $route,
+            [
+                'method'     => 'POST',
+                'postFields' => $params,
+            ]
+        );
+
+        return $response;
     }
 }

--- a/tests/Zendesk/API/UnitTests/Core/TicketsTest.php
+++ b/tests/Zendesk/API/UnitTests/Core/TicketsTest.php
@@ -295,4 +295,20 @@ class TicketsTest extends BasicTest
             $this->client->tickets()->markAsSpam([12345, 54321]);
         }, 'tickets/mark_many_as_spam.json', 'PUT', ['queryParams' => ['ids' => '12345,54321']]);
     }
+
+    /**
+     * Tests if the client can call the merge endpoint.
+     */
+    public function testMerge()
+    {
+        $params   = [
+            'ids'            => [123, 234],
+            'target_comment' => 'Closing in favor of #345',
+            'source_comment' => 'Combining with #123, #234',
+        ];
+        $ticketId = 345;
+        $this->assertEndpointCalled(function () use ($ticketId, $params) {
+            $this->client->tickets($ticketId)->merge($params);
+        }, "tickets/{$ticketId}/merge.json", 'POST', $params);
+    }
 }


### PR DESCRIPTION
Add support for merging tickets endpoint
https://developer.zendesk.com/rest_api/docs/core/tickets#merge-tickets-into-target-ticket

Solves ticket: https://support.zendesk.com/agent/tickets/1253489

/cc @jwswj @joseconsador @iandjx @pdeuter @mmolina @ggrossman 

### References
* JIRA: https://zendesk.atlassian.net/browse/MI-320

### Risks
* Medium. We might not be able to merge tickets using the API.