### PR TITLE
Please pass the params array to the parent function call

### DIFF
--- a/src/Zendesk/API/Resources/Core/Users.php
+++ b/src/Zendesk/API/Resources/Core/Users.php
@@ -102,7 +102,7 @@ class Users extends ResourceAbstract
             $this->endpoint = 'users.json';
         }
 
-        return $this->traitFindAll();
+        return $this->traitFindAll($params);
     }
 
     /**


### PR DESCRIPTION
https://github.com/zendesk/zendesk_api_client_php/issues/208 describes the issue at hand. The $params don't get passed through successfully.

/cc @zendesk/quokka

### References
 - Jira link: 

### Risks
 - None