### PR TITLE
Remove the composer version from composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,6 @@
   "name": "zendesk/zendesk_api_client_php",
   "description": "PHP Client for Zendesk REST API. See http://developer.zendesk.com/api-docs",
   "license": "Apache License Version 2.0",
-  "version": "2.0.0-beta2",
   "homepage": "https://github.com/zendesk/zendesk_api_client_php",
   "require": {
     "php": ">=5.5.0",


### PR DESCRIPTION
Packagist will just get the version from the github tag. Currently this takes precedence and thus some of our releases are not appearing.

Fix for https://github.com/zendesk/zendesk_api_client_php/issues/211

/cc @zendesk/butanding @mmolina

### References
* JIRA:

### Risks
* Medium. We might be missing versions in packagist.