### PR TITLE
Added the possibility to load tickets for a specific organization

### DIFF
--- a/src/Zendesk/API/Resources/Core/OrganizationTickets.php
+++ b/src/Zendesk/API/Resources/Core/OrganizationTickets.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace Zendesk\API\Resources\Core;
+
+use Zendesk\API\Exceptions\CustomException;
+use Zendesk\API\Exceptions\MissingParametersException;
+use Zendesk\API\Resources\ResourceAbstract;
+use Zendesk\API\Traits\Resource\FindAll;
+
+/**
+ * The OrganizationTickets class exposes tickets methods for organizations
+ */
+class OrganizationTickets extends ResourceAbstract
+{
+    use FindAll {
+        findAll as traitFindAll;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected $objectName = 'ticket';
+    /**
+     * {@inheritdoc}
+     */
+    protected $objectNamePlural = 'tickets';
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function setUpRoutes()
+    {
+        $this->setRoutes(
+            [
+                'findAll'     => 'organizations/{organization_id}/tickets.json',
+            ]
+        );
+    }
+
+    /**
+     * Returns all tickets for a particular organization
+     *
+     * @param array $queryParams
+     *
+     * @throws MissingParametersException
+     * @throws \Exception
+     *
+     * @return mixed
+     */
+    public function findAll(array $queryParams = [])
+    {
+        $queryParams = $this->addChainedParametersToParams($queryParams, ['organization_id' => Organizations::class]);
+
+        if (! $this->hasKeys($queryParams, ['organization_id'])) {
+            throw new MissingParametersException(__METHOD__, ['organization_id']);
+        }
+
+        return $this->traitFindAll($queryParams);
+    }
+
+    /*
+     * Syntactic sugar methods:
+     * Handy aliases:
+     */
+
+    /**
+     * @param array $params
+     *
+     * @return mixed|void
+     * @throws CustomException
+     */
+    public function find($id = null, array $queryQueryParams = [])
+    {
+        throw new CustomException('Method ' . __METHOD__
+            . ' does not exist. Try $client->ticket()->find(ticket_id) instead.');
+    }
+}

--- a/src/Zendesk/API/Resources/Core/Organizations.php
+++ b/src/Zendesk/API/Resources/Core/Organizations.php
@@ -17,6 +17,7 @@ use Zendesk\API\Traits\Utility\InstantiatorTrait;
  * @method OrganizationMemberships organizationMemberships()
  * @method OrganizationSubscriptions organizationSubscriptions()
  * @method Requests requests()
+ * @method OrganizationTickets tickets()
  */
 class Organizations extends ResourceAbstract
 {

--- a/src/Zendesk/API/Resources/Core/Organizations.php
+++ b/src/Zendesk/API/Resources/Core/Organizations.php
@@ -38,6 +38,7 @@ class Organizations extends ResourceAbstract
             'memberships'   => OrganizationMemberships::class,
             'subscriptions' => OrganizationSubscriptions::class,
             'requests'      => Requests::class,
+            'tickets'       => OrganizationTickets::class,
         ];
     }
 

--- a/tests/Zendesk/API/UnitTests/Core/OrganizationTicketsTest.php
+++ b/tests/Zendesk/API/UnitTests/Core/OrganizationTicketsTest.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Zendesk\API\UnitTests\Core;
+
+use Zendesk\API\UnitTests\BasicTest;
+
+/**
+ * Organization Tickets test class
+ */
+class OrganizationTicketsTest extends BasicTest
+{
+    /**
+     * Test findAll method
+     */
+    public function testAll()
+    {
+
+        $organizationId = 1234;
+        $this->assertEndpointCalled(function () use ($organizationId) {
+            $this->client->organizations($organizationId)->tickets()->findAll();
+        }, "organizations/{$organizationId}/tickets.json");
+
+    }
+}


### PR DESCRIPTION
You can now load the tickets for a specific organization, based on the existing API-end-point. (https://developer.zendesk.com/rest_api/docs/core/tickets#listing-tickets)