### PR TITLE
[MI-331] Add option to set additional headers to the client

### DIFF
--- a/src/Zendesk/API/Http.php
+++ b/src/Zendesk/API/Http.php
@@ -47,11 +47,11 @@ class Http
             $options
         );
 
-        $headers = [
+        $headers = array_merge([
             'Accept'       => 'application/json',
             'Content-Type' => $options['contentType'],
             'User-Agent'   => $client->getUserAgent()
-        ];
+        ], $client->getHeaders());
 
         $request = new Request(
             $options['method'],

--- a/src/Zendesk/API/HttpClient.php
+++ b/src/Zendesk/API/HttpClient.php
@@ -100,6 +100,11 @@ class HttpClient
     use InstantiatorTrait;
 
     /**
+     * @var array $headers
+     */
+    private $headers = [];
+
+    /**
      * @var Auth
      */
     protected $auth;
@@ -263,6 +268,31 @@ class HttpClient
         $this->auth = new Auth($strategy, $options);
     }
 
+    /**
+     * @return array
+     */
+    public function getHeaders()
+    {
+        return $this->headers;
+    }
+
+    /**
+     * @param array $headers
+     *
+     * @return HttpClient
+     */
+    public function setHeader($key, $value)
+    {
+        $this->headers[$key] = $value;
+
+        return $this;
+    }
+
+    /**
+     * Return the user agent string
+     *
+     * @return string
+     */
     public function getUserAgent()
     {
         return 'ZendeskAPI PHP ' . self::VERSION;

--- a/tests/Zendesk/API/UnitTests/Core/ResourceTest.php
+++ b/tests/Zendesk/API/UnitTests/Core/ResourceTest.php
@@ -311,4 +311,23 @@ class ResourceTest extends BasicTest
 
         $this->assertRegExp('/ZendeskAPI PHP/', $request->getHeaderLine('User-Agent'));
     }
+
+    /**
+     * Tests if extra headers are set
+     */
+    public function testAdditionalHeaders()
+    {
+        $this->client->setHeader('X-CUSTOM-HEADER', 'foo');
+
+        $this->mockApiResponses([
+            new Response(200, [], '')
+        ]);
+
+        $this->dummyResource->findAll();
+
+        $transaction = $this->mockedTransactionsContainer[0];
+        $request     = $transaction['request'];
+
+        $this->assertEquals('foo', $request->getHeaderLine('X-CUSTOM-HEADER'));
+    }
 }


### PR DESCRIPTION
Add option to set additional headers to the client. Initial use-case for this is to keep track of requests made per integration.

/cc @zendesk/mintegrations @mmolina @miketineo

### References
 - Jira link: https://zendesk.atlassian.net/browse/MI-331

### Risks
 - Medium: default headers could be overwritten and unexpected responses/requests could be sent.