### PR TITLE
Satisfaction rating - invalid endpoint

### DIFF
--- a/src/Zendesk/API/Resources/Core/Requests.php
+++ b/src/Zendesk/API/Resources/Core/Requests.php
@@ -68,30 +68,36 @@ class Requests extends ResourceAbstract
      * Find all open requests
      *
      * @param array $params
+     *
+     * @return mixed
      */
     public function findAllOpen(array $params = [])
     {
-        $this->findAll($params, __FUNCTION__);
+        return $this->findAll($params, __FUNCTION__);
     }
 
     /**
      * Find all open requests
      *
      * @param array $params
+     *
+     * @return mixed
      */
     public function findAllSolved(array $params = [])
     {
-        $this->findAll($params, __FUNCTION__);
+        return $this->findAll($params, __FUNCTION__);
     }
 
     /**
      * Find all open requests
      *
      * @param array $params
+     *
+     * @return mixed
      */
     public function findAllCCd(array $params = [])
     {
-        $this->findAll($params, __FUNCTION__);
+        return $this->findAll($params, __FUNCTION__);
     }
 
     /**

--- a/src/Zendesk/API/Resources/Core/SatisfactionRatings.php
+++ b/src/Zendesk/API/Resources/Core/SatisfactionRatings.php
@@ -3,6 +3,7 @@
 namespace Zendesk\API\Resources\Core;
 
 use Zendesk\API\Resources\ResourceAbstract;
+use Zendesk\API\Exceptions\MissingParametersException;
 use Zendesk\API\Traits\Resource\Create;
 use Zendesk\API\Traits\Resource\Find;
 use Zendesk\API\Traits\Resource\FindAll;
@@ -13,7 +14,42 @@ use Zendesk\API\Traits\Resource\FindAll;
  */
 class SatisfactionRatings extends ResourceAbstract
 {
-    use Create;
+    use Create {
+        create as traitCreate;
+    }
     use Find;
     use FindAll;
+
+    /**
+     * Declares routes to be used by this resource.
+     */
+    protected function setUpRoutes()
+    {
+        parent::setUpRoutes();
+
+        $this->setRoutes([
+            'create' => 'tickets/{ticket_id}/satisfaction_rating.json'
+        ]);
+    }
+
+    /**
+     * Returns all comments for a particular ticket
+     *
+     * @param array $queryParams
+     *
+     * @throws MissingParametersException
+     * @throws \Exception
+     *
+     * @return mixed
+     */
+    public function create(array $queryParams = [])
+    {
+        $queryParams = $this->addChainedParametersToParams($queryParams, ['ticket_id' => Tickets::class]);
+
+        if (! $this->hasKeys($queryParams, ['ticket_id'])) {
+            throw new MissingParametersException(__METHOD__, ['ticket_id']);
+        }
+
+        return $this->traitCreate($queryParams);
+    }
 }


### PR DESCRIPTION
When you create a satisfaction rating, with:

```
$client->satisfactionRatings()->create([
			'score' => 'Good',
			'comment' => 'Awesome support!',
			'ticket_id' => 33,
		]);
```

You reiceive an "InvalidEnpoint", because the request is done to https://{subdomain}.zendesk.com/api/v2/satisfaction_ratings.json instead of https://{subdomain}.zendesk.com/api/v2/tickets/{ticket_id}/satisfaction_rating.json as explained [here](https://developer.zendesk.com/rest_api/docs/core/satisfaction_ratings#create-a-satisfaction-rating).

This file change fixes the issue for me.