### PR TITLE
[MI-480] Update CSAT rating creation to be chainable with ticket.

### DIFF
--- a/src/Zendesk/API/Resources/Core/SatisfactionRatings.php
+++ b/src/Zendesk/API/Resources/Core/SatisfactionRatings.php
@@ -33,7 +33,8 @@ class SatisfactionRatings extends ResourceAbstract
     }
 
     /**
-     * Returns all comments for a particular ticket
+     * Creates a Satisfaction Rating
+     * https://developer.zendesk.com/rest_api/docs/core/satisfaction_ratings#create-a-satisfaction-rating
      *
      * @param array $queryParams
      *

--- a/src/Zendesk/API/Resources/Core/Tickets.php
+++ b/src/Zendesk/API/Resources/Core/Tickets.php
@@ -47,12 +47,13 @@ class Tickets extends ResourceAbstract
     public static function getValidSubResources()
     {
         return [
-            'comments'    => TicketComments::class,
-            'forms'       => TicketForms::class,
-            'tags'        => Tags::class,
-            'audits'      => TicketAudits::class,
-            'attachments' => Attachments::class,
-            'metrics'     => TicketMetrics::class,
+            'comments'            => TicketComments::class,
+            'forms'               => TicketForms::class,
+            'tags'                => Tags::class,
+            'audits'              => TicketAudits::class,
+            'attachments'         => Attachments::class,
+            'metrics'             => TicketMetrics::class,
+            'satisfactionRatings' => SatisfactionRatings::class,
         ];
     }
 

--- a/tests/Zendesk/API/UnitTests/Core/SatisfactionRatingsTest.php
+++ b/tests/Zendesk/API/UnitTests/Core/SatisfactionRatingsTest.php
@@ -18,4 +18,41 @@ class SatisfactionRatingsTest extends BasicTest
         $this->assertTrue(method_exists($this->client->satisfactionRatings(), 'find'));
         $this->assertTrue(method_exists($this->client->satisfactionRatings(), 'findAll'));
     }
+
+    /**
+     * Test the create method.
+     */
+    public function testCreate()
+    {
+        $postParams = [
+            'score' => 'good',
+            'comment' => 'Awesome Support!',
+        ];
+
+        $ticketId = 123;
+
+        $this->assertEndpointCalled(
+            function () use ($ticketId, $postParams) {
+                $this->client->tickets($ticketId)->satisfactionRatings()->create($postParams);
+            },
+            "tickets/{$ticketId}/satisfaction_rating.json",
+            'POST'
+        );
+    }
+
+    /**
+     * Test the create method requires a ticket id
+     *
+     * @expectedException Zendesk\API\Exceptions\MissingParametersException
+     * @expectedExceptionMessage Missing parameters: 'ticket_id' must be supplied for Zendesk\API\Resources\Core\SatisfactionRatings::create
+     */
+    public function testCreateNeedsTicketId()
+    {
+        $postParams = [
+            'score' => 'good',
+            'comment' => 'Awesome Support!',
+        ];
+
+        $this->client->satisfactionRatings()->create($postParams);
+    }
 }


### PR DESCRIPTION
Add tests for Satisfaction Rating creation
Update the Docblock
Allow it to be chained from the ticket resource

/cc @zendesk/mintegrations @mmolina @miketineo

### References
 - Jira link: https://zendesk.atlassian.net/browse/MI-480

### Risks
 - Medium. We might not be able to create satisfactions ratings using the client