### PR TITLE
Fix Audit Logs filtering for correct filter parameter specification

### DIFF
--- a/src/Zendesk/API/Resources/Core/AuditLogs.php
+++ b/src/Zendesk/API/Resources/Core/AuditLogs.php
@@ -44,6 +44,6 @@ class AuditLogs extends ResourceAbstract
      */
     private function filterParams($param)
     {
-        return preg_match("/^filter[\"[a-zA-Z_]*\"]/", $param);
+        return preg_match("/^filter[[a-zA-Z_]*]/", $param);
     }
 }

--- a/src/Zendesk/API/Resources/Core/AuditLogs.php
+++ b/src/Zendesk/API/Resources/Core/AuditLogs.php
@@ -44,6 +44,6 @@ class AuditLogs extends ResourceAbstract
      */
     private function filterParams($param)
     {
-        return preg_match("/^filter[[a-zA-Z_]*]/", $param);
+        return preg_match("/^filter[[a-zA-Z_]*](\\[\\]?)/", $param);
     }
 }

--- a/src/Zendesk/API/Resources/Core/AuditLogs.php
+++ b/src/Zendesk/API/Resources/Core/AuditLogs.php
@@ -44,6 +44,6 @@ class AuditLogs extends ResourceAbstract
      */
     private function filterParams($param)
     {
-        return preg_match("/^filter[[a-zA-Z_]*](\\[\\]?)/", $param);
+        return preg_match("/^sort_by|sort_order|filter[[a-zA-Z_]*](\\[\\]?)/", $param);
     }
 }

--- a/tests/Zendesk/API/UnitTests/Core/AuditLogsTest.php
+++ b/tests/Zendesk/API/UnitTests/Core/AuditLogsTest.php
@@ -15,6 +15,8 @@ class AuditLogsTest extends BasicTest
     public function testFindAll()
     {
         $queryParams = [
+            'sort_by'              => 'actor_id',
+            'sort_order'           => 'desc',
             'filter[source_type]'  => 'rule',
             'filter[valid]'        => 'somerule',
             'filter[created_at][]' => '2016-01-01T00:00:00Z'

--- a/tests/Zendesk/API/UnitTests/Core/AuditLogsTest.php
+++ b/tests/Zendesk/API/UnitTests/Core/AuditLogsTest.php
@@ -26,7 +26,7 @@ class AuditLogsTest extends BasicTest
         // We also expect url encoded keys and values
         $expectedQueryParams = [];
         foreach ($queryParams as $key => $value) {
-            $expectedQueryParams = array_merge($expectedQueryParams, [urlencode($key) => /*urlencode*/($value)]);
+            $expectedQueryParams = array_merge($expectedQueryParams, [urlencode($key) => $value]);
         }
 
         $this->assertEndpointCalled(

--- a/tests/Zendesk/API/UnitTests/Core/AuditLogsTest.php
+++ b/tests/Zendesk/API/UnitTests/Core/AuditLogsTest.php
@@ -15,8 +15,8 @@ class AuditLogsTest extends BasicTest
     public function testFindAll()
     {
         $queryParams = [
-            'filter["source_type"]' => 'rule',
-            'filter["valid"]'       => 'somerule',
+            'filter[source_type]' => 'rule',
+            'filter[valid]'       => 'somerule',
         ];
 
         // We expect invalid parameters are removed.

--- a/tests/Zendesk/API/UnitTests/Core/AuditLogsTest.php
+++ b/tests/Zendesk/API/UnitTests/Core/AuditLogsTest.php
@@ -15,15 +15,16 @@ class AuditLogsTest extends BasicTest
     public function testFindAll()
     {
         $queryParams = [
-            'filter[source_type]' => 'rule',
-            'filter[valid]'       => 'somerule',
+            'filter[source_type]'  => 'rule',
+            'filter[valid]'        => 'somerule',
+            'filter[created_at][]' => '2016-01-01T00:00:00Z'
         ];
 
         // We expect invalid parameters are removed.
         // We also expect url encoded keys and values
         $expectedQueryParams = [];
         foreach ($queryParams as $key => $value) {
-            $expectedQueryParams = array_merge($expectedQueryParams, [urlencode($key) => urlencode($value)]);
+            $expectedQueryParams = array_merge($expectedQueryParams, [urlencode($key) => /*urlencode*/($value)]);
         }
 
         $this->assertEndpointCalled(


### PR DESCRIPTION
The documentation for Audit Logs (https://developer.zendesk.com/rest_api/docs/core/audit_logs) incorrectly used to state that filter parameters looked like this:

```
?filter["source_type"]=user
?filter["source_type"]=rule
?filter["created_at"]=2013-01-01%2000:00:00,2013-01-01%2023:59:59
```

Based on that information, the PHP code was enforcing this format with the double-quotes present.

However, the API doesn't actually work like that!

What actually works looks like this:

```
By source type:
?filter[source_type]=user
?filter[source_type]=rule

By exact source:
?filter[source_type]=user&filter[source_id]=123

By actor:
?filter[actor_id]=123

By IP address:
?filter[ip_address]=127.0.0.1

By time of creation:
?filter[created_at][]=2013-01-01T00:00:00Z&filter[created_at][]=2013-01-01T23:59:59Z

Control sort order (default is `sort_by=created_at`, `sort_order=desc`):
?sort_by=actor_id&sort_order=asc
```
