### PR TITLE
Use the domain defined in client when getting the urls for domain

### DIFF
--- a/src/Zendesk/API/Utilities/OAuth.php
+++ b/src/Zendesk/API/Utilities/OAuth.php
@@ -19,9 +19,9 @@ class OAuth
      * @return array
      * @throws ApiResponseException
      */
-    public static function getAccessToken(Client $client, $subdomain, array $params)
+    public static function getAccessToken(Client $client, $subdomain, array $params, $domain = 'zendesk.com')
     {
-        $authUrl  = 'https://' . $subdomain . '.zendesk.com/oauth/tokens';
+        $authUrl  = "https://$subdomain.$domain/oauth/tokens";
 
         // Fetch access_token
         $params = array_merge([
@@ -52,7 +52,7 @@ class OAuth
      *
      * @return string
      */
-    public static function getAuthUrl($subdomain, array $options)
+    public static function getAuthUrl($subdomain, array $options, $domain = 'zendesk.com')
     {
         $queryParams = [
             'response_type' => 'code',
@@ -64,7 +64,7 @@ class OAuth
 
         $options = array_merge($queryParams, $options);
 
-        $oAuthUrl = "https://$subdomain.zendesk.com/oauth/authorizations/new?";
+        $oAuthUrl = "https://$subdomain.$domain/oauth/authorizations/new?";
         // Build query and remove empty values
         $oAuthUrl .= http_build_query(array_filter($options));
 

--- a/tests/Zendesk/API/UnitTests/Utilities/OAuthTest.php
+++ b/tests/Zendesk/API/UnitTests/Utilities/OAuthTest.php
@@ -49,4 +49,19 @@ class OAuthTest extends BasicTest
             ],
         ]);
     }
+
+    /**
+     * Tests if the OAuth::getAuthUrl function returns a correct URL.
+     */
+    public function testConfigurableDomain()
+    {
+        $params = [
+            'client_id'    => 'test_client',
+            'state'        => 'St8fulbar',
+        ];
+
+        $expected = 'https://z3ntestsub.testDomain.com/oauth/authorizations/new?response_type=code&client_id=test_client&state=St8fulbar&scope=read+write';
+
+        $this->assertEquals($expected, OAuth::getAuthUrl('z3ntestsub', $params, 'testDomain.com'));
+    }
 }


### PR DESCRIPTION
/cc @zendesk/mintegrations @miketineo @mmolina

### Description

Fixes a problem where the defined domain is not used when generating authentication links.

### References
* JIRA: 

### Risks
* Medium. We might generate wrong auth links.