### PR TITLE
Fixed returning type declaration

### DIFF
--- a/src/Zendesk/API/Http.php
+++ b/src/Zendesk/API/Http.php
@@ -28,7 +28,7 @@ class Http
      *                             string $method "GET", "POST", etc. Default is GET.
      *                             string $contentType Default is "application/json"
      *
-     * @return array The response body, parsed from JSON into an associative array
+     * @return mixed The response body, parsed from JSON into an object. Also returns bool or null if something went wrong
      * @throws ApiResponseException
      * @throws AuthException
      */


### PR DESCRIPTION
json_decode() returns an object if second argument is not being set to true.