### PR TITLE
[MI-575] Add unit tests and cleanup create and update many

### DIFF
--- a/src/Zendesk/API/Resources/Core/DynamicContentItemVariants.php
+++ b/src/Zendesk/API/Resources/Core/DynamicContentItemVariants.php
@@ -9,7 +9,6 @@ use Zendesk\API\Traits\Resource\Delete;
 use Zendesk\API\Traits\Resource\Find;
 use Zendesk\API\Traits\Resource\FindAll;
 use Zendesk\API\Traits\Resource\UpdateMany;
-use Zendesk\API\Traits\Resource\CreateOrUpdateMany;
 
 /**
  * Class DynamicContentItemVariants
@@ -23,7 +22,7 @@ class DynamicContentItemVariants extends ResourceAbstract
 
     use CreateMany;
     use UpdateMany;
-    use CreateOrUpdateMany;
+
     /**
      * {@inheritdoc}
      */
@@ -46,7 +45,6 @@ class DynamicContentItemVariants extends ResourceAbstract
                 'delete'     => 'dynamic_content/items/{item_id}/variants.json',
                 'createMany' => 'dynamic_content/items/{item_id}/variants/create_many.json',
                 'updateMany' => 'dynamic_content/items/{item_id}/variants/update_many.json',
-                'createOrUpdateMany' => 'dynamic_content/items/{item_id}/variants/create_or_update_many.json',
             ]
         );
     }

--- a/src/Zendesk/API/Resources/Core/Organizations.php
+++ b/src/Zendesk/API/Resources/Core/Organizations.php
@@ -2,14 +2,12 @@
 
 namespace Zendesk\API\Resources\Core;
 
-use Zendesk\API\Http;
 use Zendesk\API\Resources\ResourceAbstract;
 use Zendesk\API\Traits\Resource\CreateMany;
 use Zendesk\API\Traits\Resource\Defaults;
 use Zendesk\API\Traits\Resource\DeleteMany;
 use Zendesk\API\Traits\Resource\FindMany;
 use Zendesk\API\Traits\Resource\UpdateMany;
-use Zendesk\API\Traits\Resource\CreateOrUpdateMany;
 use Zendesk\API\Traits\Utility\InstantiatorTrait;
 
 /**
@@ -30,7 +28,6 @@ class Organizations extends ResourceAbstract
     use DeleteMany;
     use FindMany;
     use UpdateMany;
-    use CreateOrUpdateMany;
 
     /**
      * {@inheritdoc}

--- a/src/Zendesk/API/Resources/Core/Tickets.php
+++ b/src/Zendesk/API/Resources/Core/Tickets.php
@@ -10,7 +10,6 @@ use Zendesk\API\Traits\Resource\Defaults;
 use Zendesk\API\Traits\Resource\DeleteMany;
 use Zendesk\API\Traits\Resource\FindMany;
 use Zendesk\API\Traits\Resource\UpdateMany;
-use Zendesk\API\Traits\Resource\CreateOrUpdateMany;
 use Zendesk\API\Traits\Utility\InstantiatorTrait;
 
 /**

--- a/src/Zendesk/API/Traits/Resource/CreateOrUpdateMany.php
+++ b/src/Zendesk/API/Traits/Resource/CreateOrUpdateMany.php
@@ -47,7 +47,7 @@ trait CreateOrUpdateMany
             [
                 'queryParams' => $queryParams,
                 'postFields'  => [$resourceUpdateName => $params],
-                'method'      => 'PUT'
+                'method'      => 'POST'
             ]
         );
 

--- a/src/Zendesk/API/Traits/Resource/CreateOrUpdateMany.php
+++ b/src/Zendesk/API/Traits/Resource/CreateOrUpdateMany.php
@@ -3,7 +3,6 @@
 namespace Zendesk\API\Traits\Resource;
 
 use Zendesk\API\Exceptions\RouteException;
-use Zendesk\API\Http;
 
 /**
  * Allows resources to call a bulk createOrUpdate endpoint.
@@ -15,11 +14,10 @@ trait CreateOrUpdateMany
      * Update group of resources
      *
      * @param array  $params
-     * @param string $key Could be `id`, `external_id` or `email`
      *
      * @return mixed
      */
-    public function createOrUpdateMany(array $params, $key = 'ids')
+    public function createOrUpdateMany(array $params)
     {
         try {
             $route = $this->getRoute(__FUNCTION__);
@@ -32,26 +30,11 @@ trait CreateOrUpdateMany
             $this->setRoute('createOrUpdateMany', $route);
         }
 
-        $resourceUpdateName = $this->objectNamePlural;
-        $queryParams        = [];
-        if (isset($params[$key]) && is_array($params[$key])) {
-            $queryParams[$key] = implode(',', $params[$key]);
-            unset($params[$key]);
 
-            $resourceUpdateName = $this->objectName;
-        }
-
-        $response = Http::send(
-            $this->client,
+        $response = $this->client->post(
             $route,
-            [
-                'queryParams' => $queryParams,
-                'postFields'  => [$resourceUpdateName => $params],
-                'method'      => 'POST'
-            ]
+            [$this->objectNamePlural => $params]
         );
-
-        $this->client->setSideload(null);
 
         return $response;
     }

--- a/tests/Zendesk/API/LiveTests/TicketsTest.php
+++ b/tests/Zendesk/API/LiveTests/TicketsTest.php
@@ -228,7 +228,7 @@ class TicketsTest extends BasicTest
     public function testDelete($ticket)
     {
         $this->client->tickets($ticket->id)->delete();
-        $this->assertEquals(200, $this->client->getDebug()->lastResponseCode);
+        $this->assertEquals(204, $this->client->getDebug()->lastResponseCode);
         $this->assertNull($this->client->getDebug()->lastResponseError);
     }
 

--- a/tests/Zendesk/API/LiveTests/UsersTest.php
+++ b/tests/Zendesk/API/LiveTests/UsersTest.php
@@ -111,23 +111,24 @@ class UsersTest extends BasicTest
     }
 
     /**
-     * Tests create or update user
+     * Tests create or update many users
      *
-     * @depends testCreateorUpdate
+     * @depends testCreate
      */
     public function testCreateOrUpdateMany($user)
     {
         $faker      = Factory::create();
         $userFields = [
             [
-                'id'   => $user->id,
+                'email'   => $user->email,
                 'name' => $faker->name,
             ]
         ];
 
-        $response = $this->client->users()->createOrUpdateMany(['users' => $userFields]);
+        $response = $this->client->users()->createOrUpdateMany($userFields);
 
-        $this->assertEquals($userFields['name'], $response->user->name);
+        // Test the job was queued
+        $this->assertEquals('queued', $response->job_status->status);
     }
 
     /**

--- a/tests/Zendesk/API/LiveTests/UsersTest.php
+++ b/tests/Zendesk/API/LiveTests/UsersTest.php
@@ -120,8 +120,8 @@ class UsersTest extends BasicTest
         $faker      = Factory::create();
         $userFields = [
             [
-                'email'   => $user->email,
-                'name' => $faker->name,
+                'email' => $user->email,
+                'name'  => $faker->name,
             ]
         ];
 

--- a/tests/Zendesk/API/LiveTests/UsersTest.php
+++ b/tests/Zendesk/API/LiveTests/UsersTest.php
@@ -111,19 +111,21 @@ class UsersTest extends BasicTest
     }
 
     /**
-     * Tests update
+     * Tests create or update user
      *
      * @depends testCreateorUpdate
      */
-    public function testCreateOrUpdate($user)
+    public function testCreateOrUpdateMany($user)
     {
         $faker      = Factory::create();
         $userFields = [
-            'id'   => $user->id,
-            'name' => $faker->name,
+            [
+                'id'   => $user->id,
+                'name' => $faker->name,
+            ]
         ];
 
-        $response = $this->client->users()->createOrUpdate($user->id, $userFields);
+        $response = $this->client->users()->createOrUpdateMany(['users' => $userFields]);
 
         $this->assertEquals($userFields['name'], $response->user->name);
     }

--- a/tests/Zendesk/API/UnitTests/Core/ResourceTest.php
+++ b/tests/Zendesk/API/UnitTests/Core/ResourceTest.php
@@ -330,4 +330,28 @@ class ResourceTest extends BasicTest
 
         $this->assertEquals('foo', $request->getHeaderLine('X-CUSTOM-HEADER'));
     }
+
+    /**
+     * Tests the ability to create or update many
+     */
+    public function testCreateOrUpdateMany()
+    {
+        $postFields = [
+            'resources' =>
+                [
+                    ['foo' => 'test body'],
+                    ['foo2' => 'test body 2'],
+                    ['foo3' => 'test body3']
+                ]
+        ];
+
+        $this->assertEndpointCalled(
+            function () use ($postFields) {
+                $this->dummyResource->createOrUpdateMany($postFields);
+            },
+            'dummy_resource/create_or_update_many.json',
+            'POST',
+            ['postFields' => ['dummies' => $postFields]]
+        );
+    }
 }


### PR DESCRIPTION
/cc @zendesk/mintegrations @miketineo @mmolina

### Description

Remove create and update many to classes which don't have it.
Fix method to POST as the docs say (https://developer.zendesk.com/rest_api/docs/core/users#create-or-update-many-users)
Add unit test
Update live test for new delete response

### References
* JIRA: https://zendesk.atlassian.net/browse/MI-575

### Risks
* Low. Client might not be able to call the create or update many endpoint