### PR TITLE
use example.com for sample codes

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ require 'vendor/autoload.php';
 use Zendesk\API\HttpClient as ZendeskAPI;
 
 $subdomain = "subdomain";
-$username  = "email@company.com";
+$username  = "email@example.com"; // replace this with your registered email
 $token     = "6wiIBWbGkBMo1mRDMuVwkw1EPsNkeUj95PIz2akv"; // replace this with your token
 
 $client = new ZendeskAPI($subdomain, $username);

--- a/samples/getTickets.php
+++ b/samples/getTickets.php
@@ -7,7 +7,7 @@ use Zendesk\API\HttpClient as ZendeskAPI;
  * Replace the following with your own.
  */
 $subdomain = "subdomain";
-$username  = "email@company.com";
+$username  = "email@example.com";
 $token     = "6wiIBWbGkBMo1mRDMuVwkw1EPsNkeUj95PIz2akv";
 
 $client = new ZendeskAPI($subdomain, $username);


### PR DESCRIPTION
company.com exists in reality.
https://whois.icann.org/en/lookup?name=company.com

we should use example.com instead.
http://www.rfc-editor.org/rfc/rfc2606.txt