### PR TITLE
Use stdClass for return types of several methods of core resources classes.

### DIFF
--- a/src/Zendesk/API/Http.php
+++ b/src/Zendesk/API/Http.php
@@ -28,7 +28,7 @@ class Http
      *                             string $method "GET", "POST", etc. Default is GET.
      *                             string $contentType Default is "application/json"
      *
-     * @return mixed The response body, parsed from JSON into an object. Also returns bool or null if something went wrong
+     * @return \stdClass | null The response body, parsed from JSON into an object. Also returns null if something went wrong
      * @throws ApiResponseException
      * @throws AuthException
      */

--- a/src/Zendesk/API/HttpClient.php
+++ b/src/Zendesk/API/HttpClient.php
@@ -394,7 +394,7 @@ class HttpClient
      * @param       $endpoint
      * @param array $queryParams
      *
-     * @return mixed
+     * @return \stdClass | null
      * @throws Exceptions\ApiResponseException
      */
     public function get($endpoint, $queryParams = [])
@@ -421,7 +421,7 @@ class HttpClient
      * @param       $endpoint
      * @param array $postData
      *
-     * @return mixed
+     * @return \stdClass | null
      * @throws Exceptions\ApiResponseException
      */
     public function post($endpoint, $postData = [])
@@ -444,7 +444,7 @@ class HttpClient
      * @param       $endpoint
      * @param array $putData
      *
-     * @return mixed
+     * @return \stdClass | null
      * @throws Exceptions\ApiResponseException
      */
     public function put($endpoint, $putData = [])
@@ -463,7 +463,7 @@ class HttpClient
      *
      * @param $endpoint
      *
-     * @return mixed
+     * @return null
      * @throws Exceptions\ApiResponseException
      */
     public function delete($endpoint)

--- a/src/Zendesk/API/Resources/Core/AppInstallationLocations.php
+++ b/src/Zendesk/API/Resources/Core/AppInstallationLocations.php
@@ -35,7 +35,7 @@ class AppInstallationLocations extends ResourceAbstract
      *
      * @param array $params
      *
-     * @return mixed
+     * @return \stdClass | null
      * @throws \Zendesk\API\Exceptions\RouteException
      */
     public function reorder(array $params)

--- a/src/Zendesk/API/Resources/Core/AppInstallations.php
+++ b/src/Zendesk/API/Resources/Core/AppInstallations.php
@@ -53,7 +53,7 @@ class AppInstallations extends ResourceAbstract
      *
      * @param $jobId
      *
-     * @return mixed
+     * @return \stdClass | null
      */
     public function jobStatuses($jobId)
     {
@@ -66,7 +66,7 @@ class AppInstallations extends ResourceAbstract
      * @param null $appInstallationId
      * @param array $params
      *
-     * @return mixed
+     * @return \stdClass | null
      * @throws \Zendesk\API\Exceptions\MissingParametersException
      */
     public function requirements($appInstallationId = null, array $params = [])
@@ -80,7 +80,7 @@ class AppInstallations extends ResourceAbstract
      * @param array $params
      *
      * @throws \Exception
-     * @return mixed
+     * @return \stdClass | null
      */
     public function create(array $params, $routeKey = __FUNCTION__)
     {
@@ -107,7 +107,7 @@ class AppInstallations extends ResourceAbstract
      * @param null $id
      * @param array $updateResourceFields
      * @param string $routeKey
-     * @return mixed
+     * @return \stdClass | null
      */
     public function update($id = null, array $updateResourceFields = [], $routeKey = __FUNCTION__)
     {

--- a/src/Zendesk/API/Resources/Core/Apps.php
+++ b/src/Zendesk/API/Resources/Core/Apps.php
@@ -74,7 +74,7 @@ class Apps extends ResourceAbstract
      *
      * @throws \Exception
      *
-     * @return mixed
+     * @return \stdClass | null
      */
     public function create(array $params)
     {
@@ -89,7 +89,7 @@ class Apps extends ResourceAbstract
      *
      * @param array $params
      *
-     * @return mixed
+     * @return \stdClass | null
      * @throws MissingParametersException
      * @throws \Zendesk\API\Exceptions\RouteException
      */
@@ -114,7 +114,7 @@ class Apps extends ResourceAbstract
      * @param null  $id
      * @param array $params
      *
-     * @return mixed
+     * @return \stdClass | null
      * @throws MissingParametersException
      * @throws \Zendesk\API\Exceptions\RouteException
      */
@@ -143,7 +143,7 @@ class Apps extends ResourceAbstract
      *
      * @param array $params
      *
-     * @return mixed
+     * @return \stdClass | null
      */
     public function findAllOwned(array $params = [])
     {
@@ -156,7 +156,7 @@ class Apps extends ResourceAbstract
      *
      * @param array $params
      *
-     * @return mixed
+     * @return \stdClass | null
      */
     public function notify(array $params)
     {
@@ -170,7 +170,7 @@ class Apps extends ResourceAbstract
      *
      * @param array $params
      *
-     * @return mixed
+     * @return \stdClass | null
      */
     public function install(array $params)
     {

--- a/src/Zendesk/API/Resources/Core/Attachments.php
+++ b/src/Zendesk/API/Resources/Core/Attachments.php
@@ -43,7 +43,7 @@ class Attachments extends ResourceAbstract
      * @throws CustomException
      * @throws MissingParametersException
      * @throws \Exception
-     * @return mixed
+     * @return \stdClass | null
      */
     public function upload(array $params)
     {

--- a/src/Zendesk/API/Resources/Core/Autocomplete.php
+++ b/src/Zendesk/API/Resources/Core/Autocomplete.php
@@ -23,7 +23,7 @@ class Autocomplete extends ResourceAbstract
      * @param array $params
      *
      * @throws \Exception
-     * @return mixed
+     * @return \stdClass | null
      */
     public function tags(array $params)
     {

--- a/src/Zendesk/API/Resources/Core/Automations.php
+++ b/src/Zendesk/API/Resources/Core/Automations.php
@@ -28,7 +28,7 @@ class Automations extends ResourceAbstract
      * @param array $params
      *
      * @throws \Exception
-     * @return mixed
+     * @return \stdClass | null
      */
     public function findActive(array $params = [])
     {

--- a/src/Zendesk/API/Resources/Core/Brands.php
+++ b/src/Zendesk/API/Resources/Core/Brands.php
@@ -33,7 +33,7 @@ class Brands extends ResourceAbstract
      *
      * @param array $params
      *
-     * @return mixed
+     * @return \stdClass | null
      * @throws \Zendesk\API\Exceptions\RouteException
      */
     public function checkHostMapping(array $params = [])
@@ -62,7 +62,7 @@ class Brands extends ResourceAbstract
      *
      * @param array $params
      *
-     * @return mixed
+     * @return \stdClass | null
      */
     public function updateImage(array $params = [])
     {

--- a/src/Zendesk/API/Resources/Core/GroupMemberships.php
+++ b/src/Zendesk/API/Resources/Core/GroupMemberships.php
@@ -108,7 +108,7 @@ class GroupMemberships extends ResourceAbstract
      *
      * @param array $params
      *
-     * @return mixed
+     * @return \stdClass | null
      * @throws MissingParametersException
      */
     public function makeDefault($params = [])

--- a/src/Zendesk/API/Resources/Core/Groups.php
+++ b/src/Zendesk/API/Resources/Core/Groups.php
@@ -73,7 +73,7 @@ class Groups extends ResourceAbstract
     /**
      * Show assignable groups
      *
-     * @return mixed
+     * @return \stdClass | null
      */
     public function assignable()
     {

--- a/src/Zendesk/API/Resources/Core/Incremental.php
+++ b/src/Zendesk/API/Resources/Core/Incremental.php
@@ -28,7 +28,7 @@ class Incremental extends ResourceAbstract
      *
      * @param array $params
      *
-     * @return mixed
+     * @return \stdClass | null
      * @throws \Zendesk\API\Exceptions\RouteException
      */
     public function tickets(array $params)
@@ -41,7 +41,7 @@ class Incremental extends ResourceAbstract
      *
      * @param array $params
      *
-     * @return mixed
+     * @return \stdClass | null
      * @throws \Zendesk\API\Exceptions\RouteException
      */
     public function ticketEvents(array $params)
@@ -54,7 +54,7 @@ class Incremental extends ResourceAbstract
      *
      * @param array $params
      *
-     * @return mixed
+     * @return \stdClass | null
      * @throws \Zendesk\API\Exceptions\RouteException
      */
     public function organizations(array $params)
@@ -67,7 +67,7 @@ class Incremental extends ResourceAbstract
      *
      * @param array $params
      *
-     * @return mixed
+     * @return \stdClass | null
      * @throws \Zendesk\API\Exceptions\RouteException
      */
     public function users(array $params)

--- a/src/Zendesk/API/Resources/Core/Locales.php
+++ b/src/Zendesk/API/Resources/Core/Locales.php
@@ -34,7 +34,7 @@ class Locales extends ResourceAbstract
      *
      * @throws \Exception
      *
-     * @return mixed
+     * @return \stdClass | null
      */
     public function findAllPublic(array $params = [])
     {
@@ -48,7 +48,7 @@ class Locales extends ResourceAbstract
      *
      * @throws \Exception
      *
-     * @return mixed
+     * @return \stdClass | null
      */
     public function findAllAgent(array $params = [])
     {
@@ -63,7 +63,7 @@ class Locales extends ResourceAbstract
      *
      * @throws \Exception
      *
-     * @return mixed
+     * @return \stdClass | null
      */
     public function findCurrent(array $params = [])
     {
@@ -77,7 +77,7 @@ class Locales extends ResourceAbstract
      *
      * @throws \Exception
      *
-     * @return mixed
+     * @return \stdClass | null
      */
     public function findBest(array $params = [])
     {

--- a/src/Zendesk/API/Resources/Core/Macros.php
+++ b/src/Zendesk/API/Resources/Core/Macros.php
@@ -33,7 +33,7 @@ class Macros extends ResourceAbstract
      * @param array $params
      *
      * @throws \Exception
-     * @return mixed
+     * @return \stdClass | null
      */
     public function findAllActive(array $params = [])
     {
@@ -71,7 +71,7 @@ class Macros extends ResourceAbstract
      * @param $id
      * @param $ticketId
      *
-     * @return mixed
+     * @return \stdClass | null
      * @throws MissingParametersException
      * @throws \Exception
      * @throws \Zendesk\API\Exceptions\ResponseException

--- a/src/Zendesk/API/Resources/Core/OAuthTokens.php
+++ b/src/Zendesk/API/Resources/Core/OAuthTokens.php
@@ -51,7 +51,7 @@ class OAuthTokens extends ResourceAbstract
     /**
      * Shows the current token
      *
-     * @return mixed
+     * @return \stdClass | null
      * @throws \Zendesk\API\Exceptions\RouteException
      */
     public function current()

--- a/src/Zendesk/API/Resources/Core/OrganizationFields.php
+++ b/src/Zendesk/API/Resources/Core/OrganizationFields.php
@@ -32,7 +32,7 @@ class OrganizationFields extends ResourceAbstract
      * @throws MissingParametersException
      * @throws \Exception
      *
-     * @return mixed
+     * @return \stdClass | null
      */
     public function reorder(array $params)
     {

--- a/src/Zendesk/API/Resources/Core/OrganizationMemberships.php
+++ b/src/Zendesk/API/Resources/Core/OrganizationMemberships.php
@@ -84,7 +84,7 @@ class OrganizationMemberships extends ResourceAbstract
      *
      * @param array $params
      *
-     * @return mixed
+     * @return \stdClass | null
      * @throws MissingParametersException
      */
     public function makeDefault($params = [])

--- a/src/Zendesk/API/Resources/Core/OrganizationTickets.php
+++ b/src/Zendesk/API/Resources/Core/OrganizationTickets.php
@@ -45,7 +45,7 @@ class OrganizationTickets extends ResourceAbstract
      * @throws MissingParametersException
      * @throws \Exception
      *
-     * @return mixed
+     * @return \stdClass | null
      */
     public function findAll(array $queryParams = [])
     {

--- a/src/Zendesk/API/Resources/Core/Organizations.php
+++ b/src/Zendesk/API/Resources/Core/Organizations.php
@@ -99,7 +99,7 @@ class Organizations extends ResourceAbstract
      * @param       $name
      * @param array $params
      *
-     * @return mixed
+     * @return \stdClass | null
      * @throws \Zendesk\API\Exceptions\ApiResponseException
      * @throws \Zendesk\API\Exceptions\AuthException
      */
@@ -115,7 +115,7 @@ class Organizations extends ResourceAbstract
      *
      * @param $id Organization ID
      *
-     * @return mixed
+     * @return \stdClass | null
      * @throws \Zendesk\API\Exceptions\ApiResponseException
      * @throws \Zendesk\API\Exceptions\AuthException
      */
@@ -130,7 +130,7 @@ class Organizations extends ResourceAbstract
      * @param       $external_id
      * @param array $params
      *
-     * @return mixed
+     * @return \stdClass | null
      * @throws \Zendesk\API\Exceptions\ApiResponseException
      * @throws \Zendesk\API\Exceptions\AuthException
      */

--- a/src/Zendesk/API/Resources/Core/PushNotificationDevices.php
+++ b/src/Zendesk/API/Resources/Core/PushNotificationDevices.php
@@ -27,7 +27,7 @@ class PushNotificationDevices extends ResourceAbstract
      *
      * @param array $params
      *
-     * @return mixed
+     * @return null
      * @throws MissingParametersException
      * @throws \Zendesk\API\Exceptions\RouteException
      */

--- a/src/Zendesk/API/Resources/Core/RequestComments.php
+++ b/src/Zendesk/API/Resources/Core/RequestComments.php
@@ -40,7 +40,7 @@ class RequestComments extends ResourceAbstract
      * @param       $id
      * @param array $queryParams
      *
-     * @return mixed
+     * @return \stdClass | null
      * @throws MissingParametersException
      * @throws \Exception
      */

--- a/src/Zendesk/API/Resources/Core/Requests.php
+++ b/src/Zendesk/API/Resources/Core/Requests.php
@@ -69,7 +69,7 @@ class Requests extends ResourceAbstract
      *
      * @param array $params
      *
-     * @return mixed
+     * @return \stdClass | null
      */
     public function findAllOpen(array $params = [])
     {
@@ -81,7 +81,7 @@ class Requests extends ResourceAbstract
      *
      * @param array $params
      *
-     * @return mixed
+     * @return \stdClass | null
      */
     public function findAllSolved(array $params = [])
     {
@@ -93,7 +93,7 @@ class Requests extends ResourceAbstract
      *
      * @param array $params
      *
-     * @return mixed
+     * @return \stdClass | null
      */
     public function findAllCCd(array $params = [])
     {
@@ -105,7 +105,7 @@ class Requests extends ResourceAbstract
      *
      * @param array $queryParams
      *
-     * @return mixed
+     * @return \stdClass | null
      */
     public function search(array $queryParams)
     {

--- a/src/Zendesk/API/Resources/Core/SatisfactionRatings.php
+++ b/src/Zendesk/API/Resources/Core/SatisfactionRatings.php
@@ -41,7 +41,7 @@ class SatisfactionRatings extends ResourceAbstract
      * @throws MissingParametersException
      * @throws \Exception
      *
-     * @return mixed
+     * @return \stdClass | null
      */
     public function create(array $queryParams = [])
     {

--- a/src/Zendesk/API/Resources/Core/Search.php
+++ b/src/Zendesk/API/Resources/Core/Search.php
@@ -32,7 +32,7 @@ class Search extends ResourceAbstract
      * @param null  $query
      * @param array $queryParams
      *
-     * @return mixed
+     * @return \stdClass | null
      * @throws MissingParametersException
      * @throws \Zendesk\API\Exceptions\RouteException
      */
@@ -55,7 +55,7 @@ class Search extends ResourceAbstract
      * @param       $query
      * @param array $queryParams
      *
-     * @return mixed
+     * @return \stdClass | null
      * @throws \Zendesk\API\Exceptions\RouteException
      */
     public function anonymous($query, $queryParams = [])

--- a/src/Zendesk/API/Resources/Core/Sessions.php
+++ b/src/Zendesk/API/Resources/Core/Sessions.php
@@ -70,7 +70,7 @@ class Sessions extends ResourceAbstract
      *
      * @param null $userId
      *
-     * @return mixed
+     * @return null
      * @throws CustomException
      * @throws MissingParametersException
      * @throws RouteException
@@ -98,7 +98,7 @@ class Sessions extends ResourceAbstract
     /**
      * Deletes the current session.
      *
-     * @return mixed
+     * @return null
      * @throws CustomException
      * @throws RouteException
      */
@@ -110,7 +110,7 @@ class Sessions extends ResourceAbstract
     /**
      * Shows the currently authenticated session
      *
-     * @return mixed
+     * @return \stdClass | null
      * @throws RouteException
      */
     public function current()

--- a/src/Zendesk/API/Resources/Core/SlaPolicies.php
+++ b/src/Zendesk/API/Resources/Core/SlaPolicies.php
@@ -43,7 +43,7 @@ class SlaPolicies extends ResourceAbstract
      * @param null  $id
      * @param array $updateResourceFields
      *
-     * @return mixed
+     * @return \stdClass | null
      */
     public function replace($id = null, $updateResourceFields = [])
     {
@@ -55,7 +55,7 @@ class SlaPolicies extends ResourceAbstract
      *
      * @parama array  $ids
      *
-     * @return mixed
+     * @return \stdClass | null
      */
     public function reorder($ids = [])
     {
@@ -67,7 +67,7 @@ class SlaPolicies extends ResourceAbstract
      *
      * @parama array  $ids
      *
-     * @return mixed
+     * @return \stdClass | null
      */
     public function definitions(array $params = [])
     {

--- a/src/Zendesk/API/Resources/Core/SupportAddresses.php
+++ b/src/Zendesk/API/Resources/Core/SupportAddresses.php
@@ -26,7 +26,7 @@ class SupportAddresses extends ResourceAbstract
      * @param null  $recipientAddressId
      * @param array $updateFields
      *
-     * @return mixed
+     * @return \stdClass | null
      */
     public function verify($recipientAddressId = null, array $updateFields = [])
     {

--- a/src/Zendesk/API/Resources/Core/SuspendedTickets.php
+++ b/src/Zendesk/API/Resources/Core/SuspendedTickets.php
@@ -38,7 +38,7 @@ class SuspendedTickets extends ResourceAbstract
      *
      * @param $id
      *
-     * @return mixed
+     * @return \stdClass | null
      * @throws MissingParametersException
      */
     public function recover($id = null)
@@ -59,7 +59,7 @@ class SuspendedTickets extends ResourceAbstract
      *
      * @param array $ids
      *
-     * @return mixed
+     * @return \stdClass | null
      * @throws MissingParametersException
      * @throws \Zendesk\API\Exceptions\ApiResponseException
      * @throws \Zendesk\API\Exceptions\RouteException

--- a/src/Zendesk/API/Resources/Core/TicketAudits.php
+++ b/src/Zendesk/API/Resources/Core/TicketAudits.php
@@ -44,7 +44,7 @@ class TicketAudits extends ResourceAbstract
      *
      * @param array $params
      *
-     * @return mixed
+     * @return \stdClass | null
      * @throws MissingParametersException
      */
     public function findAll(array $params = [])
@@ -68,7 +68,7 @@ class TicketAudits extends ResourceAbstract
      * @throws MissingParametersException
      * @throws \Exception
      *
-     * @return mixed
+     * @return \stdClass | null
      */
     public function find($id = null, array $params = [])
     {

--- a/src/Zendesk/API/Resources/Core/TicketComments.php
+++ b/src/Zendesk/API/Resources/Core/TicketComments.php
@@ -46,7 +46,7 @@ class TicketComments extends ResourceAbstract
      * @throws MissingParametersException
      * @throws \Exception
      *
-     * @return mixed
+     * @return \stdClass | null
      */
     public function findAll(array $queryParams = [])
     {
@@ -67,7 +67,7 @@ class TicketComments extends ResourceAbstract
      * @throws MissingParametersException
      * @throws \Exception
      *
-     * @return mixed
+     * @return \stdClass | null
      */
     public function makePrivate(array $params = [])
     {

--- a/src/Zendesk/API/Resources/Core/TicketForms.php
+++ b/src/Zendesk/API/Resources/Core/TicketForms.php
@@ -41,7 +41,7 @@ class TicketForms extends ResourceAbstract
      * @throws MissingParametersException
      * @throws ResponseException
      * @throws MissingParametersException
-     * @return mixed
+     * @return \stdClass | null
      */
     public function cloneForm($id = null)
     {
@@ -64,7 +64,7 @@ class TicketForms extends ResourceAbstract
      *
      * @throws ResponseException
      * @throws \Exception
-     * @return mixed
+     * @return \stdClass | null
      */
     public function reorder(array $ticketFormIds)
     {

--- a/src/Zendesk/API/Resources/Core/Tickets.php
+++ b/src/Zendesk/API/Resources/Core/Tickets.php
@@ -63,7 +63,7 @@ class Tickets extends ResourceAbstract
      * @param       $route
      * @param array $params
      *
-     * @return mixed
+     * @return \stdClass | null
      * @throws ResponseException
      * @throws \Exception
      */
@@ -110,7 +110,7 @@ class Tickets extends ResourceAbstract
      * @throws ResponseException
      * @throws \Exception
      *
-     * @return mixed
+     * @return \stdClass | null
      */
     public function findTwicket(array $params = [])
     {
@@ -137,7 +137,7 @@ class Tickets extends ResourceAbstract
      *
      * @throws ResponseException
      * @throws \Exception
-     * @return mixed
+     * @return \stdClass | null
      */
     public function create(array $params)
     {
@@ -157,7 +157,7 @@ class Tickets extends ResourceAbstract
      * @throws MissingParametersException
      * @throws ResponseException
      * @throws \Exception
-     * @return mixed
+     * @return \stdClass | null
      */
     public function createFromTweet(array $params)
     {
@@ -188,7 +188,7 @@ class Tickets extends ResourceAbstract
      * @throws MissingParametersException
      * @throws ResponseException
      * @throws \Exception
-     * @return mixed
+     * @return \stdClass | null
      */
     public function update($id = null, array $updateResourceFields = [])
     {
@@ -208,7 +208,7 @@ class Tickets extends ResourceAbstract
      * @throws MissingParametersException
      * @throws ResponseException
      * @throws \Exception
-     * @return mixed
+     * @return \stdClass | null
      */
     public function updateMany(array $params)
     {
@@ -227,7 +227,7 @@ class Tickets extends ResourceAbstract
      *
      * @throws ResponseException
      * @throws \Exception
-     * @return mixed
+     * @return \stdClass | null
      */
     public function markAsSpam($id = null)
     {
@@ -261,7 +261,7 @@ class Tickets extends ResourceAbstract
      * @throws MissingParametersException
      * @throws ResponseException
      * @throws \Exception
-     * @return mixed
+     * @return \stdClass | null
      */
     public function related(array $params = [])
     {
@@ -282,7 +282,7 @@ class Tickets extends ResourceAbstract
      * @throws MissingParametersException
      * @throws ResponseException
      * @throws \Exception
-     * @return mixed
+     * @return \stdClass | null
      */
     public function collaborators(array $params = [])
     {
@@ -303,7 +303,7 @@ class Tickets extends ResourceAbstract
      * @throws MissingParametersException
      * @throws ResponseException
      * @throws \Exception
-     * @return mixed
+     * @return \stdClass | null
      */
     public function incidents(array $params = [])
     {
@@ -324,7 +324,7 @@ class Tickets extends ResourceAbstract
      * @throws MissingParametersException
      * @throws ResponseException
      * @throws \Exception
-     * @return mixed
+     * @return \stdClass | null
      */
     public function problems(array $params = [])
     {
@@ -339,7 +339,7 @@ class Tickets extends ResourceAbstract
      * @throws MissingParametersException
      * @throws ResponseException
      * @throws \Exception
-     * @return mixed
+     * @return \stdClass | null
      */
     public function problemAutoComplete(array $params)
     {
@@ -367,7 +367,7 @@ class Tickets extends ResourceAbstract
      * @throws MissingParametersException
      * @throws ResponseException
      * @throws \Exception
-     * @return mixed
+     * @return \stdClass | null
      */
     public function export(array $params)
     {
@@ -414,7 +414,7 @@ class Tickets extends ResourceAbstract
      *
      * @throws MissingParametersException
      * @throws ResponseException
-     * @return Tickets
+     * @return \stdClass | null
      */
     public function merge(array $params = [])
     {

--- a/src/Zendesk/API/Resources/Core/Triggers.php
+++ b/src/Zendesk/API/Resources/Core/Triggers.php
@@ -24,7 +24,7 @@ class Triggers extends ResourceAbstract
      *
      * @param array $params
      *
-     * @return mixed
+     * @return \stdClass | null
      * @throws \Zendesk\API\Exceptions\RouteException
      */
     public function findActive($params = [])

--- a/src/Zendesk/API/Resources/Core/UserFields.php
+++ b/src/Zendesk/API/Resources/Core/UserFields.php
@@ -26,7 +26,7 @@ class UserFields extends ResourceAbstract
      *
      * @param array $params
      *
-     * @return mixed
+     * @return \stdClass | null
      */
     public function reorder(array $params)
     {

--- a/src/Zendesk/API/Resources/Core/UserIdentities.php
+++ b/src/Zendesk/API/Resources/Core/UserIdentities.php
@@ -162,7 +162,7 @@ class UserIdentities extends ResourceAbstract
      * @param string $callingMethod
      * @param array  $params
      *
-     * @return mixed
+     * @return \stdClass | null
      * @throws MissingParametersException
      * @throws \Exception
      * @throws \Zendesk\API\Exceptions\ApiResponseException

--- a/src/Zendesk/API/Resources/Core/Users.php
+++ b/src/Zendesk/API/Resources/Core/Users.php
@@ -94,7 +94,7 @@ class Users extends ResourceAbstract
      *
      * @throws ResponseException
      * @throws \Exception
-     * @return mixed
+     * @return \stdClass | null
      */
     public function findAll(array $params = [])
     {
@@ -116,7 +116,7 @@ class Users extends ResourceAbstract
      *
      * @throws ResponseException
      * @throws \Exception
-     * @return mixed
+     * @return \stdClass | null
      */
     public function findMany(array $params = [])
     {
@@ -143,7 +143,7 @@ class Users extends ResourceAbstract
      * @throws MissingParametersException
      * @throws ResponseException
      * @throws \Exception
-     * @return mixed
+     * @return \stdClass | null
      */
     public function related(array $params = [])
     {
@@ -170,7 +170,7 @@ class Users extends ResourceAbstract
      * @throws MissingParametersException
      * @throws ResponseException
      * @throws \Exception
-     * @return mixed
+     * @return \stdClass | null
      */
     public function merge(array $params = [])
     {
@@ -197,7 +197,7 @@ class Users extends ResourceAbstract
      *
      * @throws MissingParametersException
      * @throws ResponseException
-     * @return mixed
+     * @return \stdClass | null
      */
     public function suspend(array $params = [])
     {
@@ -217,7 +217,7 @@ class Users extends ResourceAbstract
      *
      * @throws ResponseException
      * @throws \Exception
-     * @return mixed
+     * @return \stdClass | null
      */
     public function search(array $params)
     {
@@ -231,7 +231,7 @@ class Users extends ResourceAbstract
      *
      * @throws ResponseException
      * @throws \Exception
-     * @return mixed
+     * @return \stdClass | null
      */
     public function autocomplete(array $params)
     {
@@ -273,7 +273,7 @@ class Users extends ResourceAbstract
      * @throws MissingParametersException
      * @throws ResponseException
      * @throws \Exception
-     * @return mixed
+     * @return \stdClass | null
      */
     public function updateProfileImageFromFile(array $params)
     {
@@ -291,7 +291,7 @@ class Users extends ResourceAbstract
      * @throws MissingParametersException
      * @throws ResponseException
      * @throws \Exception
-     * @return mixed
+     * @return \stdClass | null
      */
     public function updateProfileImageFromUrl(array $params)
     {
@@ -321,7 +321,7 @@ class Users extends ResourceAbstract
      *
      * @throws MissingParametersException
      * @throws ResponseException
-     * @return mixed
+     * @return \stdClass | null
      */
     public function me(array $params = [])
     {
@@ -338,7 +338,7 @@ class Users extends ResourceAbstract
      * @throws MissingParametersException
      * @throws ResponseException
      * @throws \Exception
-     * @return mixed
+     * @return null
      */
     public function setPassword(array $params)
     {
@@ -360,7 +360,7 @@ class Users extends ResourceAbstract
      * @throws MissingParametersException
      * @throws ResponseException
      * @throws \Exception
-     * @return mixed
+     * @return null
      */
     public function changePassword(array $params)
     {
@@ -381,7 +381,7 @@ class Users extends ResourceAbstract
      * @param array $params
      *
      * @throws \Exception
-     * @return mixed
+     * @return \stdClass | null
      */
     public function createOrUpdate(array $params, $routeKey = __FUNCTION__)
     {

--- a/src/Zendesk/API/Resources/Core/Views.php
+++ b/src/Zendesk/API/Resources/Core/Views.php
@@ -40,7 +40,7 @@ class Views extends ResourceAbstract
      *
      * @param array $params
      *
-     * @return mixed
+     * @return \stdClass | null
      */
     public function findAllActive(array $params = [])
     {
@@ -52,7 +52,7 @@ class Views extends ResourceAbstract
      *
      * @param array $params
      *
-     * @return mixed
+     * @return \stdClass | null
      */
     public function findAllCompact(array $params = [])
     {
@@ -68,7 +68,7 @@ class Views extends ResourceAbstract
      * @throws ResponseException
      * @throws \Exception
      *
-     * @return mixed
+     * @return \stdClass | null
      */
     public function execute(array $params = [])
     {
@@ -90,7 +90,7 @@ class Views extends ResourceAbstract
      * @throws ResponseException
      * @throws \Exception
      *
-     * @return mixed
+     * @return \stdClass | null
      */
     public function tickets(array $params = [])
     {
@@ -112,7 +112,7 @@ class Views extends ResourceAbstract
      * @throws ResponseException
      * @throws \Exception
      *
-     * @return mixed
+     * @return \stdClass | null
      */
     public function count(array $params = [])
     {
@@ -146,7 +146,7 @@ class Views extends ResourceAbstract
      * @throws ResponseException
      * @throws \Exception
      *
-     * @return mixed
+     * @return \stdClass | null
      */
     public function export(array $params = [])
     {
@@ -167,7 +167,7 @@ class Views extends ResourceAbstract
      * @throws ResponseException
      * @throws \Exception
      *
-     * @return mixed
+     * @return \stdClass | null
      */
     public function preview(array $params)
     {
@@ -182,7 +182,7 @@ class Views extends ResourceAbstract
      * @throws ResponseException
      * @throws \Exception
      *
-     * @return mixed
+     * @return \stdClass | null
      */
     public function previewCount(array $params)
     {

--- a/src/Zendesk/API/Traits/Resource/Create.php
+++ b/src/Zendesk/API/Traits/Resource/Create.php
@@ -12,7 +12,7 @@ trait Create
      * @param array $params
      *
      * @throws \Exception
-     * @return mixed
+     * @return \stdClass | null
      */
     public function create(array $params, $routeKey = __FUNCTION__)
     {

--- a/src/Zendesk/API/Traits/Resource/CreateMany.php
+++ b/src/Zendesk/API/Traits/Resource/CreateMany.php
@@ -18,7 +18,7 @@ trait CreateMany
      * @throws ResponseException
      * @throws \Exception
      *
-     * @return mixed
+     * @return \stdClass | null
      */
     public function createMany(array $params)
     {

--- a/src/Zendesk/API/Traits/Resource/CreateOrUpdateMany.php
+++ b/src/Zendesk/API/Traits/Resource/CreateOrUpdateMany.php
@@ -15,7 +15,7 @@ trait CreateOrUpdateMany
      *
      * @param array  $params
      *
-     * @return mixed
+     * @return \stdClass | null
      */
     public function createOrUpdateMany(array $params)
     {

--- a/src/Zendesk/API/Traits/Resource/DeleteMany.php
+++ b/src/Zendesk/API/Traits/Resource/DeleteMany.php
@@ -17,7 +17,7 @@ trait DeleteMany
      * @param array  $ids Array of IDs to delete
      * @param string $key Could be `id` or `external_id`
      *
-     * @return mixed
+     * @return null
      *
      */
     public function deleteMany(array $ids = [], $key = 'ids')

--- a/src/Zendesk/API/Traits/Resource/Find.php
+++ b/src/Zendesk/API/Traits/Resource/Find.php
@@ -13,7 +13,7 @@ trait Find
      * @param       $id
      * @param array $queryParams
      *
-     * @return mixed
+     * @return \stdClass | null
      * @throws MissingParametersException
      * @throws \Exception
      */

--- a/src/Zendesk/API/Traits/Resource/FindAll.php
+++ b/src/Zendesk/API/Traits/Resource/FindAll.php
@@ -13,7 +13,7 @@ trait FindAll
      *
      * @param string $routeKey
      *
-     * @return mixed
+     * @return \stdClass | null
      */
     public function findAll(array $params = [], $routeKey = __FUNCTION__)
     {

--- a/src/Zendesk/API/Traits/Resource/FindMany.php
+++ b/src/Zendesk/API/Traits/Resource/FindMany.php
@@ -17,7 +17,7 @@ trait FindMany
      * @param array  $extraParams Extra query parameters such as sideloads and iterators
      * @param string $key         Could be `id` or `external_id`
      *
-     * @return mixed
+     * @return \stdClass | null
      *
      */
     public function findMany(array $ids = [], $extraParams = [], $key = 'ids')

--- a/src/Zendesk/API/Traits/Resource/MultipartUpload.php
+++ b/src/Zendesk/API/Traits/Resource/MultipartUpload.php
@@ -34,7 +34,7 @@ trait MultipartUpload
      *
      * @throws \Exception
      *
-     * @return mixed
+     * @return \stdClass | null
      */
     public function upload(array $params, $routeKey = __FUNCTION__)
     {

--- a/src/Zendesk/API/Traits/Resource/Update.php
+++ b/src/Zendesk/API/Traits/Resource/Update.php
@@ -14,7 +14,7 @@ trait Update
      *
      * @throws MissingParametersException
      * @throws \Exception
-     * @return mixed
+     * @return \stdClass | null
      */
     public function update($id = null, array $updateResourceFields = [], $routeKey = __FUNCTION__)
     {

--- a/src/Zendesk/API/Traits/Resource/UpdateMany.php
+++ b/src/Zendesk/API/Traits/Resource/UpdateMany.php
@@ -17,7 +17,7 @@ trait UpdateMany
      * @param array  $params
      * @param string $key Could be `id` or `external_id`
      *
-     * @return mixed
+     * @return \stdClass | null
      */
     public function updateMany(array $params, $key = 'ids')
     {


### PR DESCRIPTION
/cc @zendesk/mintegrations

### Description

Use `stdClass | null` for return types of several GET, POST, PUT methods of core resources classes 

Use `null` for return types of DELETE methods.

### Risks
* [low] PHPdoc return types may be incorrect.