### PR TITLE
[MI-753] Fix update of app installations to allow setting of "enabled"

### DIFF
--- a/src/Zendesk/API/Resources/Core/AppInstallations.php
+++ b/src/Zendesk/API/Resources/Core/AppInstallations.php
@@ -43,6 +43,7 @@ class AppInstallations extends ResourceAbstract
     {
         $this->setRoutes([
             'create' => $this->resourceName . '.json',
+            'update' => $this->resourceName . '/{id}.json',
             'jobStatuses' => $this->resourceName . '/job_statuses/{job_id}.json',
             'requirements' => $this->resourceName . '/{id}/requirements.json',
         ]);
@@ -111,7 +112,15 @@ class AppInstallations extends ResourceAbstract
      */
     public function update($id = null, array $updateResourceFields = [], $routeKey = __FUNCTION__)
     {
-        $this->objectName = 'settings';
-        return $this->traitUpdate($id, $updateResourceFields, $routeKey);
+        if (empty($id)) {
+            $id = $this->getChainedParameter(__CLASS__);
+        }
+
+        $route = $this->getRoute($routeKey, ['id' => $id]);
+
+        return $this->client->put(
+            $route,
+            $updateResourceFields
+        );
     }
 }

--- a/tests/Zendesk/API/UnitTests/Core/AppInstallationsTest.php
+++ b/tests/Zendesk/API/UnitTests/Core/AppInstallationsTest.php
@@ -85,14 +85,17 @@ class AppInstallationsTest extends BasicTest
     {
         $faker = Factory::create();
         $params = [
-            $faker->word => $faker->boolean(),
-            $faker->word => $faker->randomNumber(),
+            'enabled' => $faker->boolean(),
+            'settings' => [
+                $faker->word => $faker->boolean(),
+                $faker->word => $faker->randomNumber(),
+            ]
         ];
 
         $id = $faker->randomNumber();
 
         $this->assertEndpointCalled(function () use ($id, $params) {
             $this->client->appInstallations()->update($id, $params);
-        }, "apps/installations/{$id}.json", 'PUT', ['postFields' => ['settings' => $params]]);
+        }, "apps/installations/{$id}.json", 'PUT', ['postFields' => $params]);
     }
 }


### PR DESCRIPTION
/cc @zendesk/mintegrations @miketineo @mmolina

### Description

Fix update of app installations to allow setting of "enabled"
see: https://developer.zendesk.com/rest_api/docs/core/apps#update-an-app-installation

### References
* JIRA: https://zendesk.atlassian.net/browse/MI-753

### Risks
* Medium. Users might not be able to call the update app installation endpoint