### PR TITLE
ApiResponseException::getErrorDetails now returns an array, like spec…

### DIFF
--- a/src/Zendesk/API/Exceptions/ApiResponseException.php
+++ b/src/Zendesk/API/Exceptions/ApiResponseException.php
@@ -58,6 +58,6 @@ class ApiResponseException extends \Exception
      */
     public function getErrorDetails()
     {
-        return $this->errorDetails;
+        return json_decode($this->errorDetails, true);
     }
 }


### PR DESCRIPTION
…ified in the PHPDoc annotation

I guess this is a pretty big BC break, so it's smarter to just change annotation for this major/minor version.