### PR TITLE
[ZD#1945658] Fix typo in error message

### DIFF
--- a/src/Zendesk/API/Resources/Core/TicketComments.php
+++ b/src/Zendesk/API/Resources/Core/TicketComments.php
@@ -98,6 +98,6 @@ class TicketComments extends ResourceAbstract
     public function find($id = null, array $queryQueryParams = [])
     {
         throw new CustomException('Method ' . __METHOD__
-                                  . ' does not exist. Try $client->ticket(ticket_id)->comments()->findAll() instead.');
+                                  . ' does not exist. Try $client->tickets(ticket_id)->comments()->findAll() instead.');
     }
 }


### PR DESCRIPTION
/cc @zendesk/sustaining @zendesk/mintegrations

### Description
Fixes a typo in an error message

### References

* ZD ticket: https://support.zendesk.com/agent/tickets/1879279

### Risks

*  None: no functional change