### PR TITLE
Outputs message from exception and updated README

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,12 +23,13 @@ The Zendesk PHP API client can be installed using [Composer](https://packagist.o
 
 ### Composer
 
-Inside of `composer.json` specify the following:
+To install run `composer require zendesk/zendesk_api_client_php` or
+inside of `composer.json` specify the following:
 
 ``` json
 {
   "require": {
-    "zendesk/zendesk_api_client_php": "dev-master"
+    "zendesk/zendesk_api_client_php": "^2.1"
   }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -23,16 +23,7 @@ The Zendesk PHP API client can be installed using [Composer](https://packagist.o
 
 ### Composer
 
-To install run `composer require zendesk/zendesk_api_client_php` or
-inside of `composer.json` specify the following:
-
-``` json
-{
-  "require": {
-    "zendesk/zendesk_api_client_php": "^2.1"
-  }
-}
-```
+To install run `composer require zendesk/zendesk_api_client_php`
 
 ### Upgrading from V1 to V2
 If you are upgrading from [v1](https://github.com/zendesk/zendesk_api_client_php/tree/v1) of the client, we've written an [upgrade guide](https://github.com/zendesk/zendesk_api_client_php/wiki/Upgrading-from-v1-to-v2) to highlight some of the key differences.

--- a/samples/tickets/createTicket.php
+++ b/samples/tickets/createTicket.php
@@ -37,5 +37,4 @@ try {
     echo "</pre>";
 } catch (\Zendesk\API\Exceptions\ApiResponseException $e) {
     echo $e->getMessage().'</br>';
-    echo 'Please check your credentials. Make sure to change the $subdomain, $username, and $token variables in this file.';
 }

--- a/samples/tickets/createTicket.php
+++ b/samples/tickets/createTicket.php
@@ -36,5 +36,6 @@ try {
     print_r($newTicket);
     echo "</pre>";
 } catch (\Zendesk\API\Exceptions\ApiResponseException $e) {
+    echo $e->getMessage().'</br>';
     echo 'Please check your credentials. Make sure to change the $subdomain, $username, and $token variables in this file.';
 }

--- a/samples/tickets/createTicketWithAttachment.php
+++ b/samples/tickets/createTicketWithAttachment.php
@@ -45,5 +45,6 @@ try {
     print_r($newTicket);
     echo "</pre>";
 } catch (\Zendesk\API\Exceptions\ApiResponseException $e) {
+    echo $e->getMessage().'</br>';
     echo 'Please check your credentials. Make sure to change the $subdomain, $username, and $token variables in this file.';
 }

--- a/samples/tickets/createTicketWithAttachment.php
+++ b/samples/tickets/createTicketWithAttachment.php
@@ -46,5 +46,4 @@ try {
     echo "</pre>";
 } catch (\Zendesk\API\Exceptions\ApiResponseException $e) {
     echo $e->getMessage().'</br>';
-    echo 'Please check your credentials. Make sure to change the $subdomain, $username, and $token variables in this file.';
 }

--- a/samples/tickets/deleteTicket.php
+++ b/samples/tickets/deleteTicket.php
@@ -21,5 +21,4 @@ try {
     echo "Ticket ($id) has been removed";
 } catch (\Zendesk\API\Exceptions\ApiResponseException $e) {
     echo $e->getMessage().'</br>';
-    echo 'Please check your credentials. Make sure to change the $subdomain, $username, and $token variables in this file.';
 }

--- a/samples/tickets/deleteTicket.php
+++ b/samples/tickets/deleteTicket.php
@@ -20,5 +20,6 @@ try {
     $deleteTicket = $client->tickets()->delete($id);
     echo "Ticket ($id) has been removed";
 } catch (\Zendesk\API\Exceptions\ApiResponseException $e) {
+    echo $e->getMessage().'</br>';
     echo 'Please check your credentials. Make sure to change the $subdomain, $username, and $token variables in this file.';
 }

--- a/samples/tickets/getTicketComments.php
+++ b/samples/tickets/getTicketComments.php
@@ -25,5 +25,4 @@ try {
     echo "</pre>";
 } catch (\Zendesk\API\Exceptions\ApiResponseException $e) {
     echo $e->getMessage().'</br>';
-    echo 'Please check your credentials. Make sure to change the $subdomain, $username, and $token variables in this file.';
 }

--- a/samples/tickets/getTicketComments.php
+++ b/samples/tickets/getTicketComments.php
@@ -24,5 +24,6 @@ try {
     print_r($tickets);
     echo "</pre>";
 } catch (\Zendesk\API\Exceptions\ApiResponseException $e) {
+    echo $e->getMessage().'</br>';
     echo 'Please check your credentials. Make sure to change the $subdomain, $username, and $token variables in this file.';
 }

--- a/samples/tickets/getTickets.php
+++ b/samples/tickets/getTickets.php
@@ -24,5 +24,4 @@ try {
     echo "</pre>";
 } catch (\Zendesk\API\Exceptions\ApiResponseException $e) {
     echo $e->getMessage().'</br>';
-    echo 'Please check your credentials. Make sure to change the $subdomain, $username, and $token variables in this file.';
 }

--- a/samples/tickets/getTickets.php
+++ b/samples/tickets/getTickets.php
@@ -23,5 +23,6 @@ try {
     print_r($tickets);
     echo "</pre>";
 } catch (\Zendesk\API\Exceptions\ApiResponseException $e) {
+    echo $e->getMessage().'</br>';
     echo 'Please check your credentials. Make sure to change the $subdomain, $username, and $token variables in this file.';
 }

--- a/samples/tickets/qcreateTicket.php
+++ b/samples/tickets/qcreateTicket.php
@@ -31,5 +31,6 @@ try {
     print_r($newTicket);
     echo "</pre>";
 } catch (\Zendesk\API\Exceptions\ApiResponseException $e) {
+    echo $e->getMessage().'</br>';
     echo 'Please check your credentials. Make sure to change the $subdomain, $username, and $token variables in this file.';
 }

--- a/samples/tickets/qcreateTicket.php
+++ b/samples/tickets/qcreateTicket.php
@@ -32,5 +32,4 @@ try {
     echo "</pre>";
 } catch (\Zendesk\API\Exceptions\ApiResponseException $e) {
     echo $e->getMessage().'</br>';
-    echo 'Please check your credentials. Make sure to change the $subdomain, $username, and $token variables in this file.';
 }

--- a/samples/tickets/searchTickets.php
+++ b/samples/tickets/searchTickets.php
@@ -34,5 +34,4 @@ try {
     }
 } catch (\Zendesk\API\Exceptions\ApiResponseException $e) {
     echo $e->getMessage().'</br>';
-    echo 'Please check your credentials. Make sure to change the $subdomain, $username, and $token variables in this file.';
 }

--- a/samples/tickets/searchTickets.php
+++ b/samples/tickets/searchTickets.php
@@ -33,5 +33,6 @@ try {
         }
     }
 } catch (\Zendesk\API\Exceptions\ApiResponseException $e) {
+    echo $e->getMessage().'</br>';
     echo 'Please check your credentials. Make sure to change the $subdomain, $username, and $token variables in this file.';
 }

--- a/samples/tickets/updateTicket.php
+++ b/samples/tickets/updateTicket.php
@@ -29,5 +29,4 @@ try {
     echo "</pre>";
 } catch (\Zendesk\API\Exceptions\ApiResponseException $e) {
     echo $e->getMessage().'</br>';
-    echo 'Please check your credentials. Make sure to change the $subdomain, $username, and $token variables in this file.';
 }

--- a/samples/tickets/updateTicket.php
+++ b/samples/tickets/updateTicket.php
@@ -28,5 +28,6 @@ try {
     print_r($updateTicket);
     echo "</pre>";
 } catch (\Zendesk\API\Exceptions\ApiResponseException $e) {
+    echo $e->getMessage().'</br>';
     echo 'Please check your credentials. Make sure to change the $subdomain, $username, and $token variables in this file.';
 }

--- a/samples/tickets/viewTicket.php
+++ b/samples/tickets/viewTicket.php
@@ -26,5 +26,4 @@ try {
     echo "</pre>";
 } catch (\Zendesk\API\Exceptions\ApiResponseException $e) {
     echo $e->getMessage().'</br>';
-    echo 'Please check your credentials. Make sure to change the $subdomain, $username, and $token variables in this file.';
 }

--- a/samples/tickets/viewTicket.php
+++ b/samples/tickets/viewTicket.php
@@ -25,5 +25,6 @@ try {
     print_r($tickets->ticket);
     echo "</pre>";
 } catch (\Zendesk\API\Exceptions\ApiResponseException $e) {
+    echo $e->getMessage().'</br>';
     echo 'Please check your credentials. Make sure to change the $subdomain, $username, and $token variables in this file.';
 }


### PR DESCRIPTION
/cc @zendesk/mintegrations

### Description

There has been a lot of complaints of error requests in examples. Was not able to replicate the problem as it may be a development setup issue. This outputs the actual message from the thrown exception to help users debug the issue. Also updated readme on how to install using composer.

### References
* Composer installation problem https://github.com/zendesk/zendesk_api_client_php/issues/279
* Error request completion https://github.com/zendesk/zendesk_api_client_php/issues/289, https://github.com/zendesk/zendesk_api_client_php/issues/264, and https://github.com/zendesk/zendesk_api_client_php/issues/248

### Risks
* none