### PR TITLE
Added functionality to showMacro when given a macro ID

### DIFF
--- a/src/Zendesk/API/Resources/Core/Macros.php
+++ b/src/Zendesk/API/Resources/Core/Macros.php
@@ -21,7 +21,7 @@ class Macros extends ResourceAbstract
         parent::setUpRoutes();
 
         $this->setRoutes([
-            'showMacro'     => 'macros/{id}.json',
+            'find'     => 'macros/{id}.json',
             'findAllActive' => 'macros/active.json',
             'apply'         => 'macros/{id}/apply.json',
             'applyToTicket' => 'tickets/{ticketId}/macros/{id}/apply.json',

--- a/src/Zendesk/API/Resources/Core/Macros.php
+++ b/src/Zendesk/API/Resources/Core/Macros.php
@@ -42,7 +42,7 @@ class Macros extends ResourceAbstract
     }
 
     /**
-     * Returns the full macro object
+     * Returns a full macro object
      *
      * @param $id
      *
@@ -51,7 +51,7 @@ class Macros extends ResourceAbstract
      * @throws \Exception
      * @throws \Zendesk\API\Exceptions\ResponseException
      */
-    public function showMacro($id)
+    public function find($id)
     {
         if (empty($id)) {
             $id = $this->getChainedParameter(get_class($this));

--- a/src/Zendesk/API/Resources/Core/Macros.php
+++ b/src/Zendesk/API/Resources/Core/Macros.php
@@ -21,6 +21,7 @@ class Macros extends ResourceAbstract
         parent::setUpRoutes();
 
         $this->setRoutes([
+            'showMacro'     => 'macros/{id}.json',
             'findAllActive' => 'macros/active.json',
             'apply'         => 'macros/{id}/apply.json',
             'applyToTicket' => 'tickets/{ticketId}/macros/{id}/apply.json',
@@ -38,6 +39,31 @@ class Macros extends ResourceAbstract
     public function findAllActive(array $params = [])
     {
         return $this->client->get($this->getRoute(__FUNCTION__), $params);
+    }
+
+    /**
+     * Returns the full macro object
+     *
+     * @param $id
+     *
+     * @return mixed
+     * @throws MissingParametersException
+     * @throws \Exception
+     * @throws \Zendesk\API\Exceptions\ResponseException
+     */
+    public function showMacro($id)
+    {
+        if (empty($id)) {
+            $id = $this->getChainedParameter(get_class($this));
+        }
+
+        if (empty($id)) {
+            throw new MissingParametersException(__METHOD__, ['id']);
+        }
+
+        return $this->client->get(
+            $this->getRoute(__FUNCTION__, ['id' => $id])
+        );
     }
 
     /**

--- a/tests/Zendesk/API/UnitTests/BasicTest.php
+++ b/tests/Zendesk/API/UnitTests/BasicTest.php
@@ -11,6 +11,7 @@ use GuzzleHttp\Psr7\MultipartStream;
 use GuzzleHttp\Psr7\Response;
 use PHPUnit_Framework_TestCase;
 use Zendesk\API\HttpClient;
+use Faker\Factory;
 
 /**
  * Basic test class
@@ -21,6 +22,10 @@ abstract class BasicTest extends \PHPUnit_Framework_TestCase
      * @var HttpClient
      */
     protected $client;
+    /**
+     * @var Faker\Factory
+     */
+    protected $faker;
     /**
      * @var string
      */
@@ -78,6 +83,9 @@ abstract class BasicTest extends \PHPUnit_Framework_TestCase
     {
         $this->client = new HttpClient($this->subdomain, $this->username, $this->scheme, $this->hostname, $this->port);
         $this->client->setAuth('oauth', ['token' => $this->oAuthToken]);
+
+        // set up the Faker instance
+        $this->faker = Factory::create();
     }
 
     /**

--- a/tests/Zendesk/API/UnitTests/Core/MacrosTest.php
+++ b/tests/Zendesk/API/UnitTests/Core/MacrosTest.php
@@ -3,6 +3,8 @@
 namespace Zendesk\API\UnitTests\Core;
 
 use Zendesk\API\UnitTests\BasicTest;
+use Zendesk\API\Exceptions\MissingParametersException;
+
 
 /**
  * Macros test class
@@ -14,13 +16,24 @@ class MacrosTest extends BasicTest
      * Test the `GET /api/v2/macros/active.json` endpoint
      * Lists active macros for the current user
      */
-    public function testShowMacro()
+    public function testFind()
     {
-        $id = 1;
-        
+        $id = $this->faker->randomNumber();
+
         $this->assertEndpointCalled(function () use ($id) {
-            $this->client->macros()->showMacro($id);
+            $this->client->macros()->find($id);
         }, "macros/{$id}.json");
+    }
+
+    /**
+     * Test the `GET /api/v2/macros/active.json` endpoint
+     * Lists active macros for the current user
+     */
+    public function testFindThrowsExceptionWhenIdIsMissing()
+    {
+        $this->setExpectedException(MissingParametersException::class);
+
+        $this->client->macros()->find(null);
     }
 
     /**

--- a/tests/Zendesk/API/UnitTests/Core/MacrosTest.php
+++ b/tests/Zendesk/API/UnitTests/Core/MacrosTest.php
@@ -5,7 +5,6 @@ namespace Zendesk\API\UnitTests\Core;
 use Zendesk\API\UnitTests\BasicTest;
 use Zendesk\API\Exceptions\MissingParametersException;
 
-
 /**
  * Macros test class
  * Class MacrosTest

--- a/tests/Zendesk/API/UnitTests/Core/MacrosTest.php
+++ b/tests/Zendesk/API/UnitTests/Core/MacrosTest.php
@@ -16,6 +16,8 @@ class MacrosTest extends BasicTest
      */
     public function testShowMacro()
     {
+        $id = 1;
+        
         $this->assertEndpointCalled(function () use ($id) {
             $this->client->macros()->showMacro($id);
         }, "macros/{$id}.json");

--- a/tests/Zendesk/API/UnitTests/Core/MacrosTest.php
+++ b/tests/Zendesk/API/UnitTests/Core/MacrosTest.php
@@ -14,6 +14,17 @@ class MacrosTest extends BasicTest
      * Test the `GET /api/v2/macros/active.json` endpoint
      * Lists active macros for the current user
      */
+    public function testShowMacro()
+    {
+        $this->assertEndpointCalled(function () use ($id) {
+            $this->client->macros()->showMacro($id);
+        }, "macros/{$id}.json");
+    }
+
+    /**
+     * Test the `GET /api/v2/macros/active.json` endpoint
+     * Lists active macros for the current user
+     */
     public function testActive()
     {
         $this->assertEndpointCalled(function () {


### PR DESCRIPTION
Added a method to return the macro object from an ID. I didn't know what the method should be called, though... When doing the same action with tickets the method is `find()` but the documentation suggested it should be `showMacro()`. I went with the latter but will happily change if recommended.