### PR TITLE
minor: fix doc hint of DeleteMany return type

### DIFF
--- a/src/Zendesk/API/Traits/Resource/DeleteMany.php
+++ b/src/Zendesk/API/Traits/Resource/DeleteMany.php
@@ -17,7 +17,7 @@ trait DeleteMany
      * @param array  $ids Array of IDs to delete
      * @param string $key Could be `id` or `external_id`
      *
-     * @return null
+     * @return \stdClass | null
      *
      */
     public function deleteMany(array $ids = [], $key = 'ids')


### PR DESCRIPTION
Fixes IDE type inspection warnings on response fields access:
```php
            $response = $client->organizationMemberships()->deleteMany($bulk_delete);
            print_r($response->job_status);
```