### PR TITLE
Remove getContents()

### DIFF
--- a/src/Zendesk/API/Http.php
+++ b/src/Zendesk/API/Http.php
@@ -93,7 +93,7 @@ class Http
         } finally {
             $client->setDebug(
                 $request->getHeaders(),
-                $request->getBody()->getContents(),
+                $request->getBody(),
                 isset($response) ? $response->getStatusCode() : null,
                 isset($response) ? $response->getHeaders() : null,
                 isset($e) ? $e : null
@@ -108,6 +108,6 @@ class Http
 
         $client->setSideload(null);
 
-        return json_decode($response->getBody()->getContents());
+        return json_decode($response->getBody());
     }
 }


### PR DESCRIPTION
In the documentation from Guzzle, it is indicated that you can simply cast the getBody() to a string to use the response. The method getContents() will only read the remaining contents if a previous read() is performed.
see: http://docs.guzzlephp.org/en/latest/quickstart.html?#using-responses

This causes problems if you install a Guzzle Log middleware. This will read the body causing getContents() te become empty.