### PR TITLE
Pass previous exception so that we don't lose it's message body

### DIFF
--- a/src/Zendesk/API/Http.php
+++ b/src/Zendesk/API/Http.php
@@ -88,7 +88,7 @@ class Http
             }
             $response = $client->guzzle->send($request, $requestOptions);
         } catch (RequestException $e) {
-            $requestException = RequestException::create($e->getRequest(), $e->getResponse());
+            $requestException = RequestException::create($e->getRequest(), $e->getResponse(), $e);
             throw new ApiResponseException($requestException);
         } finally {
             $client->setDebug(

--- a/tests/Zendesk/API/UnitTests/HttpTest.php
+++ b/tests/Zendesk/API/UnitTests/HttpTest.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Zendesk\API\UnitTests;
+
+use Exception;
+use Faker\Factory;
+use GuzzleHttp\Client as GuzzleClient;
+use GuzzleHttp\Exception\RequestException;
+use GuzzleHttp\Psr7\Request;
+use GuzzleHttp\Psr7\Response;
+use Zendesk\API\Http;
+use Zendesk\API\HttpClient;
+
+class HttpTest extends BasicTest
+{
+    /**
+     * Test that original request exception is preserved.
+     *
+     * @expectedException Zendesk\API\Exceptions\ApiResponseException
+     */
+    public function testOriginalRequestExceptionIsPreserved()
+    {
+        $faker = Factory::create();
+
+        $statusCode = $faker->numberBetween(100, 599);
+        $request = new Request('GET', '/');
+        $response = new Response($statusCode);
+        $exceptionMessage = $faker->sentence;
+        $exception = new RequestException($exceptionMessage, $request, $response);
+
+        $guzzleClient = $this->getMockBuilder(GuzzleClient::class)
+                      ->disableOriginalConstructor()
+                      ->getMock();
+        $guzzleClient->expects($this->once())
+            ->method('send')
+            ->will($this->throwException($exception));
+
+        $zendeskClient = $this->getMockBuilder(HttpClient::class)
+                ->setConstructorArgs([
+                    $faker->domainWord,
+                    $faker->userName,
+                    $faker->randomElement([
+                        'https',
+                        'http',
+                    ]),
+                    $faker->domainName,
+                    $faker->numberBetween(1),
+                    $guzzleClient,
+                ])
+                ->getMock();
+
+        $zendeskClient->expects($this->once())
+            ->method('getHeaders')
+            ->will($this->returnValue([]));
+
+        try {
+            Http::send($zendeskClient, '/');
+        } catch (Exception $e) {
+            $originalException = $e->getPrevious()->getPrevious();
+            $this->assertNotNull($originalException);
+            $this->assertEquals($originalException->getMessage(), $exceptionMessage);
+
+            throw $e;
+        }
+    }
+}

--- a/tests/Zendesk/API/UnitTests/HttpTest.php
+++ b/tests/Zendesk/API/UnitTests/HttpTest.php
@@ -8,6 +8,7 @@ use GuzzleHttp\Client as GuzzleClient;
 use GuzzleHttp\Exception\RequestException;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
+use GuzzleHttp\Psr7\Stream;
 use Zendesk\API\Http;
 use Zendesk\API\HttpClient;
 
@@ -22,11 +23,8 @@ class HttpTest extends BasicTest
     {
         $faker = Factory::create();
 
-        $statusCode = $faker->numberBetween(100, 599);
-        $request = new Request('GET', '/');
-        $response = new Response($statusCode);
         $exceptionMessage = $faker->sentence;
-        $exception = new RequestException($exceptionMessage, $request, $response);
+        $exception = $this->mockRequestException($exceptionMessage);
 
         $guzzleClient = $this->getMockBuilder(GuzzleClient::class)
                       ->disableOriginalConstructor()
@@ -62,5 +60,31 @@ class HttpTest extends BasicTest
 
             throw $e;
         }
+    }
+
+    /**
+     * Create a mocked RequestExcpetion
+     *
+     * @param string $message
+     *
+     * @return RequestException
+     */
+    private function mockRequestException($message)
+    {
+        $request = $this->getMockBuilder(Request::class)
+                 ->disableOriginalConstructor()
+                 ->getMock();
+        $response = $this->getMockBuilder(Response::class)
+                  ->disableOriginalConstructor()
+                  ->getMock();
+        $body = $this->getMockBuilder(Stream::class)
+                      ->disableOriginalConstructor()
+                      ->getMock();
+        $request->method('getBody')
+            ->will($this->returnValue($body));
+        $response->method('getBody')
+            ->will($this->returnValue($body));
+
+        return new RequestException($message, $request, $response);
     }
 }

--- a/tests/Zendesk/API/UnitTests/HttpTest.php
+++ b/tests/Zendesk/API/UnitTests/HttpTest.php
@@ -16,8 +16,6 @@ class HttpTest extends BasicTest
 {
     /**
      * Test that original request exception is preserved.
-     *
-     * @expectedException Zendesk\API\Exceptions\ApiResponseException
      */
     public function testOriginalRequestExceptionIsPreserved()
     {
@@ -57,8 +55,6 @@ class HttpTest extends BasicTest
             $originalException = $e->getPrevious()->getPrevious();
             $this->assertNotNull($originalException);
             $this->assertEquals($originalException->getMessage(), $exceptionMessage);
-
-            throw $e;
         }
     }
 


### PR DESCRIPTION
/cc @zendesk/mintegrations

### Description

Underlying error message from curl are being lost because the original execption is not being passed along to the exception wrappers.

Previous exceptions that are returned as

```
PHP Fatal error: Uncaught exception 'GuzzleHttp\Exception\RequestException' with message 'Error completing request' in /var/www/sites/zendesk_api_client_php/vendor/guzzle/src/Exception/RequestException:71
```

should now look more informative. In the case of a curl SSL error, this will now look like:

```
PHP Fatal error: Uncaught exception 'GuzzleHttp\Exception\RequestException' with message 'cURL error 1: Protocol "https" not supported or disabled in libcurl (see http://curl.haxx.se.libcurl/c/libcurl-errors.html)' in /var/ww/sites/zendesk_api_client_php/vendor/guzzlehttp/guzzle/src/handler/CurlFactoryphp:187
```
This will allow people to figure out problems with their setup much easier, which in most cases is just a misconfiguration in cURL or missing php extensions:

* https://github.com/zendesk/zendesk_api_client_php/issues/316
* https://github.com/zendesk/zendesk_api_client_php/issues/248
* https://github.com/zendesk/zendesk_api_client_php/issues/289

### Risks
* [low] Could expose unwanted error messages.
