### PR TITLE
File upload stream

### DIFF
--- a/src/Zendesk/API/Http.php
+++ b/src/Zendesk/API/Http.php
@@ -5,6 +5,7 @@ namespace Zendesk\API;
 use GuzzleHttp\Exception\RequestException;
 use GuzzleHttp\Psr7\LazyOpenStream;
 use GuzzleHttp\Psr7\Request;
+use Psr\Http\Message\StreamInterface;
 use Zendesk\API\Exceptions\ApiResponseException;
 use Zendesk\API\Exceptions\AuthException;
 
@@ -67,7 +68,9 @@ class Http
         } elseif (! empty($options['postFields'])) {
             $request = $request->withBody(\GuzzleHttp\Psr7\stream_for(json_encode($options['postFields'])));
         } elseif (! empty($options['file'])) {
-            if (is_file($options['file'])) {
+            if ($options['file'] instanceof StreamInterface) {
+                $request = $request->withBody($options['file']);
+            } elseif (is_file($options['file'])) {
                 $fileStream = new LazyOpenStream($options['file'], 'r');
                 $request    = $request->withBody($fileStream);
             }

--- a/src/Zendesk/API/Http.php
+++ b/src/Zendesk/API/Http.php
@@ -102,10 +102,6 @@ class Http
             $request->getBody()->rewind();
         }
 
-        if (isset($file)) {
-            fclose($file);
-        }
-
         $client->setSideload(null);
 
         return json_decode($response->getBody());

--- a/src/Zendesk/API/Resources/Core/Attachments.php
+++ b/src/Zendesk/API/Resources/Core/Attachments.php
@@ -2,6 +2,7 @@
 
 namespace Zendesk\API\Resources\Core;
 
+use Psr\Http\Message\StreamInterface;
 use Zendesk\API\Exceptions\CustomException;
 use Zendesk\API\Exceptions\MissingParametersException;
 use Zendesk\API\Http;
@@ -49,8 +50,12 @@ class Attachments extends ResourceAbstract
     {
         if (! $this->hasKeys($params, ['file'])) {
             throw new MissingParametersException(__METHOD__, ['file']);
-        } elseif (! file_exists($params['file'])) {
+        } elseif (! $params['file'] instanceof StreamInterface && ! file_exists($params['file'])) {
             throw new CustomException('File ' . $params['file'] . ' could not be found in ' . __METHOD__);
+        }
+
+        if (! isset($params['name']) && $params['file'] instanceof StreamInterface) {
+            $params['name'] = basename($params['file']->getMetadata('uri'));
         }
 
         if (! isset($params['name'])) {

--- a/tests/Zendesk/API/UnitTests/BasicTest.php
+++ b/tests/Zendesk/API/UnitTests/BasicTest.php
@@ -6,10 +6,10 @@ use GuzzleHttp\Client;
 use GuzzleHttp\Handler\MockHandler;
 use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Middleware;
-use GuzzleHttp\Psr7\LazyOpenStream;
 use GuzzleHttp\Psr7\MultipartStream;
 use GuzzleHttp\Psr7\Response;
 use PHPUnit_Framework_TestCase;
+use Psr\Http\Message\StreamInterface;
 use Zendesk\API\HttpClient;
 
 /**
@@ -150,11 +150,15 @@ abstract class BasicTest extends \PHPUnit_Framework_TestCase
 
         if (isset($options['file'])) {
             $body = $request->getBody();
-            $this->assertInstanceOf(LazyOpenStream::class, $body);
+            $this->assertInstanceOf(StreamInterface::class, $body);
             $this->assertGreaterThan(0, $body->getSize());
-            $this->assertEquals($options['file'], $body->getMetadata('uri'));
             $this->assertNotEmpty($header = $request->getHeaderLine('Content-Type'));
             $this->assertEquals('application/binary', $header);
+            if ($options['file'] instanceof StreamInterface) {
+                $this->assertEquals($options['file']->getMetadata('uri'), $body->getMetadata('uri'));
+            } else {
+                $this->assertEquals($options['file'], $body->getMetadata('uri'));
+            }
             unset($options['headers']['Content-Type']);
         }
 

--- a/tests/Zendesk/API/UnitTests/Core/AttachmentsTest.php
+++ b/tests/Zendesk/API/UnitTests/Core/AttachmentsTest.php
@@ -2,6 +2,7 @@
 
 namespace Zendesk\API\UnitTests\Core;
 
+use GuzzleHttp\Psr7\LazyOpenStream;
 use Zendesk\API\UnitTests\BasicTest;
 
 /**
@@ -41,6 +42,53 @@ class AttachmentsTest extends BasicTest
     {
         $attachmentData = [
             'file' => getcwd() . '/tests/assets/UK.png',
+            'type' => 'image/png',
+        ];
+
+        $this->assertEndpointCalled(
+            function () use ($attachmentData) {
+                $this->client->attachments()->upload($attachmentData);
+            },
+            'uploads.json',
+            'POST',
+            [
+                'queryParams' => ['filename' => 'UK.png'], // Taken from file path
+                'file'        => $attachmentData['file'],
+            ]
+        );
+    }
+
+    /**
+     * Test upload of file stream
+     */
+    public function testUploadAttachmentStream()
+    {
+        $attachmentData = [
+            'file' => new LazyOpenStream(getcwd() . '/tests/assets/UK.png', 'r'),
+            'type' => 'image/png',
+            'name' => 'UK test non-alpha chars.png'
+        ];
+
+        $this->assertEndpointCalled(
+            function () use ($attachmentData) {
+                $this->client->attachments()->upload($attachmentData);
+            },
+            'uploads.json',
+            'POST',
+            [
+                'queryParams' => ['filename' => rawurlencode($attachmentData['name'])],
+                'file'        => $attachmentData['file'],
+            ]
+        );
+    }
+
+    /**
+     * Test upload of file stream with no name
+     */
+    public function testUploadAttachmentStreamWithNoName()
+    {
+        $attachmentData = [
+            'file' => new LazyOpenStream(getcwd() . '/tests/assets/UK.png', 'r'),
             'type' => 'image/png',
         ];
 

--- a/tests/Zendesk/API/UnitTests/Core/ResourceTest.php
+++ b/tests/Zendesk/API/UnitTests/Core/ResourceTest.php
@@ -4,6 +4,7 @@ namespace Zendesk\API\UnitTests\Core;
 use GuzzleHttp\Exception\RequestException;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
+use GuzzleHttp\Psr7\LazyOpenStream;
 use Zendesk\API\UnitTests\BasicTest;
 
 /**
@@ -352,6 +353,30 @@ class ResourceTest extends BasicTest
             'dummy_resource/create_or_update_many.json',
             'POST',
             ['postFields' => ['dummies' => $postFields]]
+        );
+    }
+
+    /**
+     * Test multipart upload with streams
+     */
+    public function testUploadStreamMultiPart()
+    {
+        $this->mockAPIResponses([
+            new Response(200, [], '')
+        ]);
+
+        $params = [
+            'file' => new LazyOpenStream(getcwd() . '/tests/assets/UK.png', 'r')
+        ];
+
+        $this->dummyResource->upload($params);
+
+        $this->assertLastRequestIs(
+            [
+                'method' => 'POST',
+                'endpoint' => 'dummy_resource/uploads.json',
+                'multipart' => true,
+            ]
         );
     }
 }


### PR DESCRIPTION
I needed the upload and multipart upload to support any PSR-7 stream.
This gives a lot of flexibility for instance now we can create a PSR-7 stream out of in-memory content and upload the content as an attachment.

I committed the modification independent of each-other so that you might cherry pick them if necessary but feel free to squash them.   