### PR TITLE
[MI-1512] Add test to check consistent version

### DIFF
--- a/tests/Zendesk/API/UnitTests/VersionTest.php
+++ b/tests/Zendesk/API/UnitTests/VersionTest.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Zendesk\API\UnitTests;
+
+use Faker\Factory;
+use Zendesk\API\HttpClient;
+use Zendesk\API\UnitTests\BasicTest;
+
+/**
+ * Class VersionTest
+ */
+class VersionTest extends BasicTest
+{
+    /**
+     * Test that the versions used across the package are consistent
+     */
+    public function testVersionsAreConsistent()
+    {
+        $faker = Factory::create();
+
+        $fileVersion = trim(file_get_contents(__DIR__ . '/../../../../VERSION'));
+        $client = new HttpClient($faker->word);
+
+        $this->assertEquals("ZendeskAPI PHP {$fileVersion}", $client->getUserAgent());
+    }
+}


### PR DESCRIPTION
/cc @zendesk/mintegrations

### Description

Add test to check consistent version to avoid instances where the version class constant in the [HttpClient class](https://github.com/zendesk/zendesk_api_client_php/blob/89630494acaad3515622e7fa2153b7a9ac9f77e5/src/Zendesk/API/HttpClient.php#L108) and the version [file](https://github.com/zendesk/zendesk_api_client_php/blob/89630494acaad3515622e7fa2153b7a9ac9f77e5/VERSION#L1) becomes different.

### References
* JIRA: https://zendesk.atlassian.net/browse/MI-1512
* Issue: https://github.com/zendesk/zendesk_api_client_php/issues/312

### Risks
* [low] Virtually none, just added a new test.
