### PR TITLE
[MI-1783] Set Tags resource object name

### DIFF
--- a/src/Zendesk/API/Resources/Core/Tags.php
+++ b/src/Zendesk/API/Resources/Core/Tags.php
@@ -16,6 +16,15 @@ class Tags extends ResourceAbstract
     use Defaults;
 
     /**
+     * {@inheritdoc}
+     */
+    protected $objectName = 'tags';
+    /**
+     * {@inheritdoc}
+     */
+    protected $objectNamePlural = 'tags';
+
+    /**
      * Returns a route and replaces tokenized parts of the string with
      * the passed params
      *

--- a/tests/Zendesk/API/LiveTests/TicketsTest.php
+++ b/tests/Zendesk/API/LiveTests/TicketsTest.php
@@ -303,4 +303,27 @@ class TicketsTest extends BasicTest
         $this->client->groups()->delete($group->id);
         $this->client->tickets()->delete($ticket->id);
     }
+
+    /**
+     * Test if tags are updated on ticket updated.
+     *
+     * @throws \Zendesk\API\Exceptions\MissingParametersException
+     */
+    public function testTagsAdded()
+    {
+        $faker = Factory::create();
+
+        $tags = array_map(function () use ($faker) {
+            return $faker->word;
+        }, array_fill(0, 10, null));
+
+        $ticket = $this->createTestTicket();
+        $this->client->tickets($ticket->id)->tags()->update(null, $tags);
+
+        $updatedTicket = $this->client->tickets()->find($ticket->id);
+
+        $this->assertEmpty(array_diff($tags, $updatedTicket->ticket->tags), 'Tags should be updated.');
+
+        $this->client->tickets()->delete($ticket->id);
+    }
 }

--- a/tests/Zendesk/API/LiveTests/TicketsTest.php
+++ b/tests/Zendesk/API/LiveTests/TicketsTest.php
@@ -313,9 +313,7 @@ class TicketsTest extends BasicTest
     {
         $faker = Factory::create();
 
-        $tags = array_map(function () use ($faker) {
-            return $faker->word;
-        }, array_fill(0, 10, null));
+        $tags = $faker->words(10);
 
         $ticket = $this->createTestTicket();
         $this->client->tickets($ticket->id)->tags()->update(null, $tags);


### PR DESCRIPTION
/cc @zendesk/mintegrations

### Description

Set Tags resource object name to prevent magically singularizing it.

### References
* JIRA: https://zendesk.atlassian.net/browse/MI-1783
* Issue: #343 

### Risks
* [Low] A 'tag' return value could be returned and may not be read by the client in the future, because objectName is plural.