### PR TITLE
[MI-1397] Add resource to support installing chat apps.

### DIFF
--- a/src/Zendesk/API/HttpClient.php
+++ b/src/Zendesk/API/HttpClient.php
@@ -11,6 +11,7 @@ use GuzzleHttp\Exception\RequestException;
 use GuzzleHttp\HandlerStack;
 use Zendesk\API\Exceptions\AuthException;
 use Zendesk\API\Middleware\RetryHandler;
+use Zendesk\API\Resources\Chat;
 use Zendesk\API\Resources\Core\Activities;
 use Zendesk\API\Resources\Core\AppInstallations;
 use Zendesk\API\Resources\Core\Apps;
@@ -162,14 +163,21 @@ class HttpClient
      * @var HelpCenter
      */
     public $helpCenter;
+
     /**
      * @var Voice
      */
     public $voice;
+
     /**
      * @var Embeddable
      */
     public $embeddable;
+
+    /**
+     * @var Chat
+     */
+    public $chat;
 
     /**
      * @param string $subdomain
@@ -213,6 +221,7 @@ class HttpClient
         $this->helpCenter = new HelpCenter($this);
         $this->voice      = new Voice($this);
         $this->embeddable = new Embeddable($this);
+        $this->chat       = new Chat($this);
     }
 
     /**

--- a/src/Zendesk/API/Resources/Chat.php
+++ b/src/Zendesk/API/Resources/Chat.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Zendesk\API\Resources;
+
+use Zendesk\API\HttpClient;
+use Zendesk\API\Resources\Chat\Apps;
+use Zendesk\API\Traits\Utility\ChainedParametersTrait;
+use Zendesk\API\Traits\Utility\InstantiatorTrait;
+
+/**
+ * This class serves as a container to allow calls to $this->client->chat
+ *
+ * @method Apps apps()
+ */
+class Chat
+{
+    use ChainedParametersTrait;
+    use InstantiatorTrait;
+
+    public $client;
+
+    /**
+     * Sets the client to be used
+     *
+     * @param HttpClient $client
+     */
+    public function __construct(HttpClient $client)
+    {
+        $this->client = $client;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public static function getValidSubResources()
+    {
+        return [
+            'apps' => Apps::class,
+        ];
+    }
+}

--- a/src/Zendesk/API/Resources/Chat/Apps.php
+++ b/src/Zendesk/API/Resources/Chat/Apps.php
@@ -16,9 +16,11 @@ class Apps extends ResourceAbstract
     {
         parent::setUpRoutes();
 
-        $this->setRoutes([
+        $this->setRoutes(
+            [
             'install' => "{$this->resourceName}/installations.json",
-        ]);
+            ]
+        );
     }
 
     /**

--- a/src/Zendesk/API/Resources/Chat/Apps.php
+++ b/src/Zendesk/API/Resources/Chat/Apps.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Zendesk\API\Resources\Chat;
+
+/**
+ * The Apps class exposes app management methods
+ *
+ * @method Apps install()
+ */
+class Apps extends ResourceAbstract
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected function setUpRoutes()
+    {
+        parent::setUpRoutes();
+
+        $this->setRoutes([
+            'install' => "{$this->resourceName}/installations.json",
+        ]);
+    }
+
+    /**
+     * Installs a Chat App on the account. app_id is required, as is a settings hash containing keys for all required
+     * parameters for the app.
+     * Any values in settings that don't correspond to a parameter that the app declares will be silently ignored.
+     *
+     * @param array $params
+     *
+     * @return \stdClass | null
+     */
+    public function install(array $params)
+    {
+        return $this->client->post($this->getRoute(__FUNCTION__), $params);
+    }
+}

--- a/src/Zendesk/API/Resources/Chat/ResourceAbstract.php
+++ b/src/Zendesk/API/Resources/Chat/ResourceAbstract.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Zendesk\API\Resources\Chat;
+
+use Zendesk\API\Traits\Resource\ResourceName;
+
+/**
+ * Abstract class for Chat resources
+ */
+abstract class ResourceAbstract extends \Zendesk\API\Resources\ResourceAbstract
+{
+    use ResourceName;
+
+    /**
+     * @var string
+     */
+    protected $prefix = 'api/chat/';
+
+    /**
+     * @var string
+     */
+    protected $apiBasePath = '';
+}

--- a/tests/Zendesk/API/UnitTests/Chat/AppsTest.php
+++ b/tests/Zendesk/API/UnitTests/Chat/AppsTest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Zendesk\API\UnitTests\Chat;
+
+use Faker\Factory;
+use Zendesk\API\UnitTests\BasicTest;
+
+class AppsTest extends BasicTest
+{
+    /**
+     * Tests if the client can install a Chat app
+     */
+    public function testInstall()
+    {
+        $faker = Factory::create();
+        $postFields = [
+            'app_id'   => $faker->numberBetween(1),
+            'settings' =>
+            [
+                'name'      => $faker->word,
+                'api_token' => $faker->md5,
+            ],
+        ];
+
+        $this->assertEndpointCalled(function () use ($postFields) {
+             $this->client->chat->apps()->install($postFields);
+        }, 'api/chat/apps/installations.json', 'POST', ['postFields' => $postFields]);
+    }
+}


### PR DESCRIPTION
/cc @zendesk/mintegrations

### Description

Add additional resource  for installing Chat apps.

```
$this->client->chat->apps()->install($postFields);
```

which POSTs to the `api/chat/apps/installations.json` endpoint as opposed to the `api/v2/apps/installations.json` for ZendeskSupport apps.


### References
* JIRA: https://zendesk.atlassian.net/browse/MI-1397

### Risks
* [low] Adds a new resource. Could cause some confusion between this and the [regular apps installation endpoint](https://developer.zendesk.com/rest_api/docs/core/apps#list-app-installations)

