### PR TITLE
run vendor/bin/phpcbf to fix vendor/bin/phpcs

### DIFF
--- a/src/Zendesk/API/Resources/Core/OrganizationMemberships.php
+++ b/src/Zendesk/API/Resources/Core/OrganizationMemberships.php
@@ -76,7 +76,6 @@ class OrganizationMemberships extends ResourceAbstract
 
             return "{$this->resourceName}.json";
         }
-
     }
 
     /**

--- a/src/Zendesk/API/Resources/Core/PushNotificationDevices.php
+++ b/src/Zendesk/API/Resources/Core/PushNotificationDevices.php
@@ -35,7 +35,6 @@ class PushNotificationDevices extends ResourceAbstract
     {
         if (! isset($params['tokens']) || ! is_array($params['tokens'])) {
             throw new MissingParametersException(__METHOD__, ['tokens']);
-
         }
         $postData = [$this->objectNamePlural => $params['tokens']];
 

--- a/src/Zendesk/API/Resources/Core/Users.php
+++ b/src/Zendesk/API/Resources/Core/Users.php
@@ -376,7 +376,6 @@ class Users extends ResourceAbstract
         unset($params['id']);
 
         return $this->client->put($this->getRoute(__FUNCTION__, ['id' => $id]), $params);
-
     }
 
     /**

--- a/tests/Zendesk/API/UnitTests/Core/AppInstallationsTest.php
+++ b/tests/Zendesk/API/UnitTests/Core/AppInstallationsTest.php
@@ -31,7 +31,6 @@ class AppInstallationsTest extends BasicTest
         $this->assertEndpointCalled(function () use ($postParams) {
             $this->client->appInstallations()->create($postParams);
         }, 'apps/installations.json', 'POST', ['postFields' => $postParams]);
-
     }
 
     /**

--- a/tests/Zendesk/API/UnitTests/Core/DynamicContentItemVariantsTest.php
+++ b/tests/Zendesk/API/UnitTests/Core/DynamicContentItemVariantsTest.php
@@ -18,7 +18,6 @@ class DynamicContentItemVariantsTest extends BasicTest
         $this->assertEndpointCalled(function () use ($itemId) {
             $this->client->dynamicContent()->items($itemId)->variants()->findAll();
         }, "dynamic_content/items/{$itemId}/variants.json");
-
     }
 
     /**

--- a/tests/Zendesk/API/UnitTests/Core/OrganizationMembershipsTest.php
+++ b/tests/Zendesk/API/UnitTests/Core/OrganizationMembershipsTest.php
@@ -67,7 +67,6 @@ class OrganizationMembershipsTest extends BasicTest
         $this->assertEndpointCalled(function () use ($userId) {
             $this->client->users($userId)->organizationMemberships()->findAll();
         }, "users/{$userId}/organization_memberships.json");
-
     }
 
     /**
@@ -132,7 +131,6 @@ class OrganizationMembershipsTest extends BasicTest
                 'postFields' => ['organization_membership' => $postFields],
             ]
         );
-
     }
 
     /**
@@ -161,7 +159,6 @@ class OrganizationMembershipsTest extends BasicTest
                 'postFields' => ['organization_memberships' => $postFields],
             ]
         );
-
     }
 
     /**

--- a/tests/Zendesk/API/UnitTests/Core/OrganizationTicketsTest.php
+++ b/tests/Zendesk/API/UnitTests/Core/OrganizationTicketsTest.php
@@ -19,6 +19,5 @@ class OrganizationTicketsTest extends BasicTest
         $this->assertEndpointCalled(function () use ($organizationId) {
             $this->client->organizations($organizationId)->tickets()->findAll();
         }, "organizations/{$organizationId}/tickets.json");
-
     }
 }

--- a/tests/Zendesk/API/UnitTests/Core/ResourceTest.php
+++ b/tests/Zendesk/API/UnitTests/Core/ResourceTest.php
@@ -184,7 +184,6 @@ class ResourceTest extends BasicTest
                 'postFields'  => ['dummy' => $postFields],
             ]
         );
-
     }
 
     /**
@@ -207,7 +206,6 @@ class ResourceTest extends BasicTest
             'PUT',
             ['postFields' => ['dummies' => $postFields]]
         );
-
     }
 
     /**

--- a/tests/Zendesk/API/UnitTests/Core/TicketCommentsTest.php
+++ b/tests/Zendesk/API/UnitTests/Core/TicketCommentsTest.php
@@ -19,7 +19,6 @@ class TicketCommentsTest extends BasicTest
         $this->assertEndpointCalled(function () use ($ticketId) {
             $this->client->tickets($ticketId)->comments()->findAll();
         }, "tickets/{$ticketId}/comments.json");
-
     }
 
     /**


### PR DESCRIPTION
 /cc @zendesk/mintegrations

### Description
* run `vendor/bin/phpcbf --extensions=php --standard=PSR2 --report=summary -np src/ tests/` to fix phpcs errors. I guess PSR2 got stricter.

### References
* PR that failed due to phpcs: https://github.com/zendesk/zendesk_api_client_php/pull/341

### Risks
* [low] might still fail in the future if criteria becomes more stricter