### PR TITLE
fixed failing test HttpTest::testOriginalRequestExceptionIsPreserved

### DIFF
--- a/tests/Zendesk/API/UnitTests/HttpTest.php
+++ b/tests/Zendesk/API/UnitTests/HttpTest.php
@@ -9,6 +9,7 @@ use GuzzleHttp\Exception\RequestException;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
 use GuzzleHttp\Psr7\Stream;
+use GuzzleHttp\Psr7\Uri;
 use Zendesk\API\Http;
 use Zendesk\API\HttpClient;
 
@@ -78,6 +79,8 @@ class HttpTest extends BasicTest
                       ->getMock();
         $request->method('getBody')
             ->will($this->returnValue($body));
+
+        $request->method('getUri')->will($this->returnValue(new Uri()));
         $response->method('getBody')
             ->will($this->returnValue($body));
 


### PR DESCRIPTION
/cc @zendesk/mintegrations

### Description
* fixed a failing test

### References
* Travis: https://travis-ci.org/zendesk/zendesk_api_client_php/builds/282557312?utm_source=github_status&utm_medium=notification

### Risks
* [low] tests might still fail