### PR TITLE
Removes confusion of appending /token to usernames

### DIFF
--- a/src/Zendesk/API/Utilities/Auth.php
+++ b/src/Zendesk/API/Utilities/Auth.php
@@ -84,7 +84,7 @@ class Auth
         if ($this->authStrategy === self::BASIC) {
             $requestOptions = array_merge($requestOptions, [
                 'auth' => [
-                    $this->authOptions['username'] . '/token',
+                    (substr($this->authOptions['username'], -6) === '/token') ? $this->authOptions['username'] : $this->authOptions['username'] . '/token',
                     $this->authOptions['token'],
                     'basic'
                 ]


### PR DESCRIPTION
The Zendesk API docs state that if using a token, you should append /token to the username.

I myself personally appended /token to the username as there was no clarity without looking through the code that /token was appended automatically

This PR allows the user to both omit or include /token appendage