### PR TITLE
Add CURLOPT_PROTOCOLS = CURLPROTO_HTTP | CURLPROTO_HTTPS

### DIFF
--- a/src/Zendesk/API/Http.php
+++ b/src/Zendesk/API/Http.php
@@ -127,6 +127,7 @@ class Http
         $curl->setopt(CURLOPT_HEADER, true);
         $curl->setopt(CURLOPT_VERBOSE, true);
         $curl->setopt(CURLOPT_FOLLOWLOCATION, true);
+        $curl->setopt(CURLOPT_PROTOCOLS, CURLPROTO_HTTP | CURLPROTO_HTTPS);
         $curl->setopt(CURLOPT_MAXREDIRS, 3);
 
         $response = $curl->exec();
@@ -194,6 +195,7 @@ class Http
         $curl->setopt(CURLOPT_HEADER, true);
         $curl->setopt(CURLOPT_VERBOSE, true);
         $curl->setopt(CURLOPT_FOLLOWLOCATION, true);
+        $curl->setopt(CURLOPT_PROTOCOLS, CURLPROTO_HTTP | CURLPROTO_HTTPS);
         $curl->setopt(CURLOPT_MAXREDIRS, 3);
         $response = $curl->exec();
         if ($response === false) {


### PR DESCRIPTION
Without this option set, this is a security vulnerability where the remote server can respond with a non-http protocol such as FTP for example, and curl will happily just follow the redirect.
This needs applying to the V2 track also.