### PR TITLE
Implement HelpCenter Article creation

### DIFF
--- a/samples/helpcenter/createArticles.php
+++ b/samples/helpcenter/createArticles.php
@@ -1,0 +1,31 @@
+<?php
+
+include('../../vendor/autoload.php');
+
+use Zendesk\API\HttpClient as ZendeskAPI;
+
+/**
+ * Replace the following with your own.
+ */
+
+$subdomain = "subdomain";
+$username = "email@example.com";
+$token = "6wiIBWbGkBMo1mRDMuVwkw1EPsNkeUj95PIz2akv";
+
+$client = new ZendeskAPI($subdomain);
+$client->setAuth('basic', ['username' => $username, 'token' => $token]);
+
+try {
+    // Create a new HelpCenter Article
+    $sectionId = 1;
+    $article = $client->helpCenter->sections($sectionId)->articles()->create([
+        'locale' => 'en-us',
+        'title' => 'Smartest Fish in the World',
+    ]);
+    echo "<pre>";
+    print_r($article);
+    echo "</pre>";
+} catch (\Zendesk\API\Exceptions\ApiResponseException $e) {
+    echo $e->getMessage().'</br>';
+}
+

--- a/src/Zendesk/API/Resources/HelpCenter/Articles.php
+++ b/src/Zendesk/API/Resources/HelpCenter/Articles.php
@@ -14,7 +14,9 @@ use Zendesk\API\Traits\Resource\Search;
 class Articles extends ResourceAbstract
 {
     use Defaults;
-    use Locales;
+    use Locales {
+        getRoute as protected localesGetRoute;
+    }
     use Search;
 
     /**
@@ -30,6 +32,7 @@ class Articles extends ResourceAbstract
         parent::setUpRoutes();
         $this->setRoutes([
             'bulkAttach'            =>  "$this->resourceName/{articleId}/bulk_attachments.json",
+            'create'                =>  "{$this->prefix}sections/{section_id}/articles.json",
             'updateSourceLocale'    =>  "$this->resourceName/{articleId}/source_locale.json",
         ]);
     }
@@ -59,5 +62,17 @@ class Articles extends ResourceAbstract
             $route,
             ['attachment_ids' => $params]
         );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getRoute($name, array $params = [])
+    {
+        $params = $this->addChainedParametersToParams($params, [
+            'section_id' => Sections::class,
+        ]);
+
+        return $this->localesGetRoute($name, $params);
     }
 }

--- a/src/Zendesk/API/Resources/HelpCenter/Sections.php
+++ b/src/Zendesk/API/Resources/HelpCenter/Sections.php
@@ -4,6 +4,7 @@ namespace Zendesk\API\Resources\HelpCenter;
 
 use Zendesk\API\Traits\Resource\Defaults;
 use Zendesk\API\Traits\Resource\Locales;
+use Zendesk\API\Traits\Utility\InstantiatorTrait;
 
 /**
  * Class Sections
@@ -11,6 +12,8 @@ use Zendesk\API\Traits\Resource\Locales;
  */
 class Sections extends ResourceAbstract
 {
+    use InstantiatorTrait;
+
     use Defaults;
     use Locales {
         getRoute as protected localesGetRoute;
@@ -30,6 +33,16 @@ class Sections extends ResourceAbstract
             'updateSourceLocale' =>  "{$this->resourceName}/{sectionId}/source_locale.json",
             'create' =>  "{$this->prefix}categories/{category_id}/sections.json",
         ]);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function getValidSubResources()
+    {
+        return [
+            'articles' => Articles::class,
+        ];
     }
 
     /**

--- a/tests/Zendesk/API/UnitTests/HelpCenter/ArticlesTest.php
+++ b/tests/Zendesk/API/UnitTests/HelpCenter/ArticlesTest.php
@@ -78,4 +78,20 @@ class ArticlesTest extends BasicTest
             $this->client->helpCenter->articles()->search($params);
         }, 'help_center/articles/search.json', 'GET', ['queryParams' => $params]);
     }
+
+    /**
+     * Test if Create article endpoint is called with correct params.
+     */
+    public function testCreate()
+    {
+        $faker = Factory::create();
+        $sectionId = $faker->numberBetween(1);
+        $params = ['title' => $faker->word, 'locale' => 'en'];
+
+        $this->assertEndpointCalled(function () use ($params, $sectionId) {
+            $this->client->helpCenter->sections($sectionId)->articles()->create($params);
+        }, "help_center/sections/{$sectionId}/articles.json", 'POST', [
+            'postFields' => ['article' => $params],
+        ]);
+    }
 }


### PR DESCRIPTION
This patch adds support for Article creation via chaining, e.g.:

    $article = $client->helpCenter->sections($sectionId)->articles()->create([
        'locale' => 'en-us',
        'title' => 'Smartest Fish in the World',
    ]);

The unit tests pass. I had some trouble running the "Live" tests against a Sandbox instance.

My team is relatively new to this code base, so I apologize in advance if any of this is off! Creation via chaining *seemed* to be the expected implementation.