### PR TITLE
Update license identifier

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
   "name": "zendesk/zendesk_api_client_php",
   "description": "PHP Client for Zendesk REST API. See http://developer.zendesk.com/api-docs",
-  "license": "Apache License Version 2.0",
+  "license": "Apache-2.0",
   "homepage": "https://github.com/zendesk/zendesk_api_client_php",
   "require": {
     "php": ">=5.5.0",


### PR DESCRIPTION
/cc @zendesk/mintegrations 

### Description
Update license identifier. When running `composer validate` we get the following notice.
```
./composer.json is valid, but with a few warnings
See https://getcomposer.org/doc/04-schema.md for details on the schema
License "Apache License Version 2.0" is not a valid SPDX license identifier, see https://spdx.org/licenses/ if you use an open license.
If the software is closed-source, you may use "proprietary" as license.
```

### References
* Github issue: https://github.com/composer/packagist/issues/858#issuecomment-359272204

### Risks
* [none]