### PR TITLE
Updating Travis PHP build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,13 @@
 language: php
 php:
-  - 5.6
   - 5.5
+  - 5.6
   - 7.0
   - 7.1
   - 7.2
   - nightly
 matrix:
+  fast_finish: true
   allow_failures:
     - php: 7.2
     - php: nightly

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ php:
   - nightly
 matrix:
   allow_failures:
+    - php: 7.2
     - php: nightly
 install:
   - travis_retry composer self-update && composer install

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,12 @@ php:
   - 5.6
   - 5.5
   - 7.0
+  - 7.1
+  - 7.2
+  - nightly
 matrix:
   allow_failures:
-    - php: 7.0
+    - php: nightly
 install:
   - travis_retry composer self-update && composer install
 script:


### PR DESCRIPTION
Adding PHP 7.1, 7.2 and nightly to build matrix.

Removed PHP 7.0 from the `allow_failures` since it passes.  PHP 7.2 and nightly do not pass currently, so adding those to `allow_failures`.

Added the `fast_finish` setting so that builds return quicker regardless if the `allow_failures` builds pass or not (https://blog.travis-ci.com/2013-11-27-fast-finishing-builds).