### PR TITLE
Renamed findTwicket() to findTicket() in the Tickets core.

### DIFF
--- a/src/Zendesk/API/Resources/Core/Tickets.php
+++ b/src/Zendesk/API/Resources/Core/Tickets.php
@@ -113,7 +113,7 @@ class Tickets extends ResourceAbstract
      *
      * @return \stdClass | null
      */
-    public function findTwicket(array $params = [])
+    public function findTicket(array $params = [])
     {
         $params = $this->addChainedParametersToParams($params, ['id' => get_class($this)]);
 


### PR DESCRIPTION
Simple renamed `findTwicket()` to `findTicket()` as this is a simple spelling mistake. 