### PR TITLE
Use trusty to run tests for php 5.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: trusty
 language: php
 php:
   - 5.5


### PR DESCRIPTION
### Description

This will fix php 5.5 issues with `xenial`  This will update the dist to `trusty`

### References:
* https://blog.travis-ci.com/2019-04-15-xenial-default-build-environment
* https://travis-ci.community/t/php-5-4-and-5-5-archives-missing/3723

### Risks:
* Low: Whole test suite will now run on trusty. 