### PR TITLE
Allow guzzle 7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
   "homepage": "https://github.com/zendesk/zendesk_api_client_php",
   "require": {
     "php": ">=5.5.0",
-    "guzzlehttp/guzzle": "^6.0",
+    "guzzlehttp/guzzle": "^6.0 || ^7.0",
     "mmucklo/inflect": "0.3.*"
   },
   "require-dev": {


### PR DESCRIPTION
Hi,

We have recently tagged a new version 7 of guzzle.

https://github.com/guzzle/guzzle/releases/tag/7.0.0

🎉 