### PR TITLE
change stream_for() to Utils::streamFor() to retain Guzzle 7.2 compatibility 

### DIFF
--- a/src/Zendesk/API/Http.php
+++ b/src/Zendesk/API/Http.php
@@ -5,6 +5,7 @@ namespace Zendesk\API;
 use GuzzleHttp\Exception\RequestException;
 use GuzzleHttp\Psr7\LazyOpenStream;
 use GuzzleHttp\Psr7\Request;
+use GuzzleHttp\Psr7\Utils;
 use Psr\Http\Message\StreamInterface;
 use Zendesk\API\Exceptions\ApiResponseException;
 use Zendesk\API\Exceptions\AuthException;
@@ -66,7 +67,7 @@ class Http
             $request                     = $request->withoutHeader('Content-Type');
             $requestOptions['multipart'] = $options['multipart'];
         } elseif (! empty($options['postFields'])) {
-            $request = $request->withBody(\GuzzleHttp\Psr7\stream_for(json_encode($options['postFields'])));
+            $request = $request->withBody(Utils::streamFor(json_encode($options['postFields'])));
         } elseif (! empty($options['file'])) {
             if ($options['file'] instanceof StreamInterface) {
                 $request = $request->withBody($options['file']);
@@ -87,7 +88,7 @@ class Http
         try {
             // enable anonymous access
             if ($client->getAuth()) {
-                list ($request, $requestOptions) = $client->getAuth()->prepareRequest($request, $requestOptions);
+                list($request, $requestOptions) = $client->getAuth()->prepareRequest($request, $requestOptions);
             }
             $response = $client->guzzle->send($request, $requestOptions);
         } catch (RequestException $e) {

--- a/src/Zendesk/API/Http.php
+++ b/src/Zendesk/API/Http.php
@@ -88,7 +88,7 @@ class Http
         try {
             // enable anonymous access
             if ($client->getAuth()) {
-                list($request, $requestOptions) = $client->getAuth()->prepareRequest($request, $requestOptions);
+                list ($request, $requestOptions) = $client->getAuth()->prepareRequest($request, $requestOptions);
             }
             $response = $client->guzzle->send($request, $requestOptions);
         } catch (RequestException $e) {

--- a/src/Zendesk/API/Utilities/OAuth.php
+++ b/src/Zendesk/API/Utilities/OAuth.php
@@ -6,6 +6,7 @@ use InvalidArgumentException;
 use GuzzleHttp\Client;
 use GuzzleHttp\Exception\RequestException;
 use GuzzleHttp\Psr7\Request;
+use GuzzleHttp\Psr7\Utils;
 use Zendesk\API\Exceptions\ApiResponseException;
 
 class OAuth
@@ -38,7 +39,7 @@ class OAuth
 
         try {
             $request = new Request('POST', $authUrl, ['Content-Type' => 'application/json']);
-            $request = $request->withBody(\GuzzleHttp\Psr7\stream_for(json_encode($params)));
+            $request = $request->withBody(Utils::streamFor(json_encode($params)));
             $response = $client->send($request);
         } catch (RequestException $e) {
             throw new ApiResponseException($e);


### PR DESCRIPTION
`\GuzzleHttp\Psr7\stream_for` has been deprecated, `GuzzleHttp\Psr7\Utils::streamFor()` is the replacement method, and has been replaced below. 

https://docs.aws.amazon.com/aws-sdk-php/v3/api/function-GuzzleHttp.Psr7.stream_for.html