### PR TITLE
Update OAuth.php

### DIFF
--- a/src/Zendesk/API/Utilities/OAuth.php
+++ b/src/Zendesk/API/Utilities/OAuth.php
@@ -38,7 +38,7 @@ class OAuth
 
         try {
             $request = new Request('POST', $authUrl, ['Content-Type' => 'application/json']);
-            $request = $request->withBody(\GuzzleHttp\Psr7\stream_for(json_encode($params)));
+            $request = $request->withBody(\GuzzleHttp\Psr7\Utils::streamFor(json_encode($params)));
             $response = $client->send($request);
         } catch (RequestException $e) {
             throw new ApiResponseException($e);


### PR DESCRIPTION
Deprecated: stream_for will be removed in guzzlehttp/psr7:2.0. Use Utils::streamFor instead.
Fixes #470