### PR TITLE
Update Http.php

### DIFF
--- a/src/Zendesk/API/Http.php
+++ b/src/Zendesk/API/Http.php
@@ -66,7 +66,7 @@ class Http
             $request                     = $request->withoutHeader('Content-Type');
             $requestOptions['multipart'] = $options['multipart'];
         } elseif (! empty($options['postFields'])) {
-            $request = $request->withBody(\GuzzleHttp\Psr7\stream_for(json_encode($options['postFields'])));
+            $request = $request->withBody(\GuzzleHttp\Psr7\Utils::streamFor(json_encode($options['postFields'])));
         } elseif (! empty($options['file'])) {
             if ($options['file'] instanceof StreamInterface) {
                 $request = $request->withBody($options['file']);


### PR DESCRIPTION
Deprecated: stream_for will be removed in guzzlehttp/psr7:2.0. Use Utils::streamFor instead.
Fixes #470