### PR TITLE
Declare dependency on guzzlehttp/psr7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,6 +6,7 @@
   "require": {
     "php": ">=5.5.0",
     "guzzlehttp/guzzle": "^6.0 || ^7.0",
+    "guzzlehttp/psr7": "^1.7",
     "mmucklo/inflect": "0.3.*"
   },
   "require-dev": {


### PR DESCRIPTION
This package uses functions from `guzzlehttp/psr7`, which are removed in psr7 2.0. As no dependency was declared, it was possible to install psr7 2.0 together with this package, resulting in fatal errors. By declaring the dependency, we can limit psr7 to 1.x.

After #469 is merged, the version constraint can be updated to `^1.7 || ^2.0` (as the static method API used in that PR was introduced in 1.7.0).