### PR TITLE
Fix PHP 8 introduced breaking change to call_user_func_array()

### DIFF
--- a/src/Zendesk/API/HttpClient.php
+++ b/src/Zendesk/API/HttpClient.php
@@ -438,7 +438,7 @@ class HttpClient
 
         if (! empty($sideloads = array_intersect_key($params, array_flip($sideloadKeys)))) {
             // Merge to a single array
-            return call_user_func_array('array_merge', $sideloads);
+            return call_user_func_array('array_merge', array_values($sideloads));
         } else {
             return $this->sideload;
         }


### PR DESCRIPTION
`call_user_func_array()` is used by `HttpClient::getSideload(array $params = [])`,  and since PHP 8^  introduced named arguments, the use of an associative array as arguments, will break the code since the array_merge does not support named arguments.

The fix is changing this line:
https://github.com/zendesk/zendesk_api_client_php/blob/b451b743d9d6d81a9abf7cb86e70ec9c5332123e/src/Zendesk/API/HttpClient.php#L441

To this:
```
return call_user_func_array('array_merge', array_values($sideloads));
```
