### PR TITLE
Allow guzzlehttp/psr7 2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
   "require": {
     "php": ">=5.5.0",
     "guzzlehttp/guzzle": "^6.0 || ^7.0",
-    "guzzlehttp/psr7": "^1.7",
+    "guzzlehttp/psr7": "^1.7 || ^2.0",
     "mmucklo/inflect": "0.3.*"
   },
   "require-dev": {


### PR DESCRIPTION
With #469 being merged, this package now supports 1.7+ and 2.0