### PR TITLE
Add `Translations` as a resource name and be able to specify the apiBaseUrl

### DIFF
--- a/src/Zendesk/API/Resources/Core/Translations.php
+++ b/src/Zendesk/API/Resources/Core/Translations.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Zendesk\API\Resources\Core;
+
+use Zendesk\API\Resources\ResourceAbstract;
+use Zendesk\API\Traits\Resource\FindAll;
+
+/**
+ * The Translations class finds the manifest files for localizations
+ */
+
+class Translations extends ResourceAbstract
+{
+    use FindAll;
+    /**
+     * {@inheritdoc}
+     */
+    protected function setUpRoutes()
+    {
+        $this->setRoutes([
+            'manifest'      => "{$this->resourceName}/manifest.json",
+        ]);
+    }
+
+    /**
+     * Get the manifest json file
+     *
+     * @param array $params
+     *
+     * @throws \Exception
+     *
+     * @return \stdClass | null
+     */
+    public function manifest(array $params = [])
+    {
+        return $this->findAll($params, __FUNCTION__);
+    }
+
+}

--- a/src/Zendesk/API/Resources/Core/Translations.php
+++ b/src/Zendesk/API/Resources/Core/Translations.php
@@ -3,7 +3,7 @@
 namespace Zendesk\API\Resources\Core;
 
 use Zendesk\API\Resources\ResourceAbstract;
-use Zendesk\API\Traits\Resource\FindAll;
+use Zendesk\API\Traits\Resource\Find;
 
 /**
  * The Translations class finds the manifest files for localizations
@@ -11,7 +11,7 @@ use Zendesk\API\Traits\Resource\FindAll;
 
 class Translations extends ResourceAbstract
 {
-    use FindAll;
+    use Find;
     /**
      * {@inheritdoc}
      */
@@ -33,7 +33,7 @@ class Translations extends ResourceAbstract
      */
     public function manifest(array $params = [])
     {
-        return $this->findAll($params, __FUNCTION__);
+        return $this->find(null, $params, __FUNCTION__);
     }
 
 }

--- a/src/Zendesk/API/Resources/Core/Translations.php
+++ b/src/Zendesk/API/Resources/Core/Translations.php
@@ -3,7 +3,7 @@
 namespace Zendesk\API\Resources\Core;
 
 use Zendesk\API\Resources\ResourceAbstract;
-use Zendesk\API\Traits\Resource\Find;
+use Zendesk\API\Traits\Resource\FindAll;
 
 /**
  * The Translations class finds the manifest files for localizations
@@ -11,7 +11,7 @@ use Zendesk\API\Traits\Resource\Find;
 
 class Translations extends ResourceAbstract
 {
-    use Find;
+    use FindAll;
     /**
      * {@inheritdoc}
      */
@@ -33,7 +33,7 @@ class Translations extends ResourceAbstract
      */
     public function manifest(array $params = [])
     {
-        return $this->find(null, $params, __FUNCTION__);
+        return $this->findAll($params, __FUNCTION__);
     }
 
 }

--- a/src/Zendesk/API/Resources/ResourceAbstract.php
+++ b/src/Zendesk/API/Resources/ResourceAbstract.php
@@ -51,13 +51,14 @@ abstract class ResourceAbstract
     /**
      * @var string
      */
-    protected $apiBasePath = 'api/v2/';
+    protected $apiBasePath;
 
     /**
      * @param HttpClient $client
      */
-    public function __construct(HttpClient $client)
+    public function __construct(HttpClient $client, $apiBasePath='api/v2/')
     {
+        $this->apiBasePath = $apiBasePath;
         $this->client = $client;
         $this->client->setApiBasePath($this->apiBasePath);
 

--- a/tests/Zendesk/API/UnitTests/Core/TranslationsTest.php
+++ b/tests/Zendesk/API/UnitTests/Core/TranslationsTest.php
@@ -7,7 +7,7 @@ use Zendesk\API\UnitTests\BasicTest;
 /**
  * Translations test class
  */
-class LocalesTest extends BasicTest
+class TranslationsTest extends BasicTest
 {
 /**
  * Test manifest method

--- a/tests/Zendesk/API/UnitTests/Core/TranslationsTest.php
+++ b/tests/Zendesk/API/UnitTests/Core/TranslationsTest.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Zendesk\API\UnitTests\Core;
+
+use Zendesk\API\UnitTests\BasicTest;
+
+/**
+ * Translations test class
+ */
+class LocalesTest extends BasicTest
+{
+/**
+ * Test manifest method
+ */
+public function testFindManifest()
+{
+    $this->assertEndpointCalled(function () {
+        $this->client->translations()->manifest();
+    }, 'translations/slack-auth-service/manifest.json');
+}
+}


### PR DESCRIPTION
**Goal of this PR:**

[laravel-i18n-command](https://github.com/zendesk/laravel-i18n-command ) is a translation library that uses this library to pull down translations files in json format. As we move the endpoint 
from: https://support.zendesk.com/api/v2/locales/en.json?include=translations&packages=slack-auth-service
to: https://static.zdassets.com/translations/slack-auth-service/manifest.json

This is a need to specify the domain and resources to be other than `api/v2`. 

We want to be able to do this:

```
$this->client->translations()->find();
```
to return back the contents of the manifest file for a particular service such as `slack-auth-service`. 