### PR TITLE
Pagination Iterator with params

### DIFF
--- a/src/Zendesk/API/Resources/Core/SharingAgreements.php
+++ b/src/Zendesk/API/Resources/Core/SharingAgreements.php
@@ -4,7 +4,6 @@ namespace Zendesk\API\Resources\Core;
 
 use Zendesk\API\Resources\ResourceAbstract;
 use Zendesk\API\Traits\Resource\FindAll;
-use Zendesk\API\Traits\Utility\Pagination\ObpStrategy;
 use Zendesk\API\Traits\Utility\Pagination\SinglePageStrategy;
 
 /**

--- a/src/Zendesk/API/Traits/Resource/Pagination.php
+++ b/src/Zendesk/API/Traits/Resource/Pagination.php
@@ -7,7 +7,6 @@ use Zendesk\API\Traits\Utility\Pagination\CbpStrategy;
 use Zendesk\API\Traits\Utility\Pagination\PaginationIterator;
 
 trait Pagination {
-
     /**
      * Usage:
      * foreach ($ticketsIterator as $ticket) {
@@ -19,15 +18,21 @@ trait Pagination {
     public function iterator()
     {
         $strategyClass = $this->paginationStrategyClass();
-        $strategy = new $strategyClass($this, $this->resourcesKey(), AbstractStrategy::DEFAULT_PAGE_SIZE);
-        return new PaginationIterator($strategy);
+        $strategy = new $strategyClass($this->resourcesKey(), AbstractStrategy::DEFAULT_PAGE_SIZE);
+        return new PaginationIterator($this, $strategy);
     }
+
+    /**
+     * Override this method in your resources
+     *
+     * @return string subclass of AbstractStrategy used for fetching pages
+     */
 
     protected function paginationStrategyClass() {
         return CbpStrategy::class;
     }
 
-    /*
+    /**
      * @return string eg: "job_statuses"
      */
     protected function resourcesKey() {

--- a/src/Zendesk/API/Traits/Resource/Pagination.php
+++ b/src/Zendesk/API/Traits/Resource/Pagination.php
@@ -15,11 +15,11 @@ trait Pagination {
      *
      * @return PaginationIterator to fetch all pages.
      */
-    public function iterator()
+    public function iterator($params = [])
     {
         $strategyClass = $this->paginationStrategyClass();
         $strategy = new $strategyClass($this->resourcesKey(), AbstractStrategy::DEFAULT_PAGE_SIZE);
-        return new PaginationIterator($this, $strategy);
+        return new PaginationIterator($this, $strategy, $params);
     }
 
     /**

--- a/src/Zendesk/API/Traits/Utility/Pagination/AbstractStrategy.php
+++ b/src/Zendesk/API/Traits/Utility/Pagination/AbstractStrategy.php
@@ -5,24 +5,18 @@ abstract class AbstractStrategy
 {
     public const DEFAULT_PAGE_SIZE = 100;
 
-    /*
-     * @var mixed use trait FindAll. The object handling the list, Ie: `$client->{clientList}()`
-     */
-    protected $clientList;
-
-    /*
+    /**
      * @var string The response key where the data is returned
      */
     protected $resourcesKey;
     protected $pageSize;
 
-    public function __construct($clientList, $resourcesKey, $pageSize = self::DEFAULT_PAGE_SIZE)
+    public function __construct($resourcesKey, $pageSize = self::DEFAULT_PAGE_SIZE)
     {
-        $this->clientList = $clientList;
         $this->resourcesKey = $resourcesKey;
         $this->pageSize = $pageSize;
     }
 
-    abstract public function getPage();
+    abstract public function getPage($pageFn);
     abstract public function shouldGetPage($position);
 }

--- a/src/Zendesk/API/Traits/Utility/Pagination/CbpStrategy.php
+++ b/src/Zendesk/API/Traits/Utility/Pagination/CbpStrategy.php
@@ -2,19 +2,23 @@
 
 namespace Zendesk\API\Traits\Utility\Pagination;
 
+/**
+ * Cursor Based Pagination
+ * Used in paginationStrategyClass
+ */
 class CbpStrategy extends AbstractStrategy
 {
     private $afterCursor = null;
     private $started = false;
 
-    public function getPage()
+    public function getPage($pageFn)
     {
         $this->started = true;
         $params = ['page[size]' => $this->pageSize];
         if ($this->afterCursor) {
             $params['page[after]'] = $this->afterCursor;
         }
-        $response = $this->clientList->findAll($params);
+        $response = $pageFn($params);
 
         $this->afterCursor = $response->meta->has_more ? $response->meta->after_cursor : null;
         return $response->{$this->resourcesKey};

--- a/src/Zendesk/API/Traits/Utility/Pagination/ObpStrategy.php
+++ b/src/Zendesk/API/Traits/Utility/Pagination/ObpStrategy.php
@@ -2,19 +2,19 @@
 
 namespace Zendesk\API\Traits\Utility\Pagination;
 
-
 /**
  * Offset Based Pagination
+ * Used in paginationStrategyClass
  */
 class ObpStrategy extends AbstractStrategy
 {
     private $pageNumber = 0;
 
-    public function getPage()
+    public function getPage($pageFn)
     {
         ++$this->pageNumber;
         $params = ['page' => $this->pageNumber, 'page_size' => $this->pageSize];
-        $response = $this->clientList->findAll($params);
+        $response = $pageFn($params);
 
         return $response->{$this->resourcesKey};
     }

--- a/src/Zendesk/API/Traits/Utility/Pagination/PaginationIterator.php
+++ b/src/Zendesk/API/Traits/Utility/Pagination/PaginationIterator.php
@@ -9,9 +9,14 @@ class PaginationIterator implements Iterator
     private $position = 0;
     private $page = [];
     private $strategy;
+    /**
+     * @var mixed use trait FindAll. The object handling the list, Ie: `$client->{clientList}()`
+     */
+    private $clientList;
 
-    public function __construct(AbstractStrategy $strategy)
+    public function __construct($clientList, AbstractStrategy $strategy)
     {
+        $this->clientList = $clientList;
         $this->strategy = $strategy;
     }
 
@@ -32,7 +37,7 @@ class PaginationIterator implements Iterator
 
     public function valid()
     {
-        $this->getPageIfNecessary();
+        $this->getPageIfNeeded();
         return !!$this->current();
     }
 
@@ -45,12 +50,16 @@ class PaginationIterator implements Iterator
         }
     }
 
-    private function getPageIfNecessary()
+    private function getPageIfNeeded()
     {
         if (!$this->strategy->shouldGetPage($this->position)) {
             return;
         }
 
-        $this->page = array_merge($this->page, $this->strategy->getPage());
+        $pageFn = function ($params = []) {
+            return $this->clientList->findAll($params);
+        };
+
+        $this->page = array_merge($this->page, $this->strategy->getPage($pageFn));
     }
 }

--- a/src/Zendesk/API/Traits/Utility/Pagination/PaginationIterator.php
+++ b/src/Zendesk/API/Traits/Utility/Pagination/PaginationIterator.php
@@ -9,15 +9,18 @@ class PaginationIterator implements Iterator
     private $position = 0;
     private $page = [];
     private $strategy;
+    private $params;
+
     /**
      * @var mixed use trait FindAll. The object handling the list, Ie: `$client->{clientList}()`
      */
     private $clientList;
 
-    public function __construct($clientList, AbstractStrategy $strategy)
+    public function __construct($clientList, AbstractStrategy $strategy, $params = [])
     {
         $this->clientList = $clientList;
         $this->strategy = $strategy;
+        $this->params = $params;
     }
 
     public function key()
@@ -56,8 +59,8 @@ class PaginationIterator implements Iterator
             return;
         }
 
-        $pageFn = function ($params = []) {
-            return $this->clientList->findAll($params);
+        $pageFn = function ($paginationParams = []) {
+            return $this->clientList->findAll(array_merge($this->params, $paginationParams));
         };
 
         $this->page = array_merge($this->page, $this->strategy->getPage($pageFn));

--- a/src/Zendesk/API/Traits/Utility/Pagination/SinglePageStrategy.php
+++ b/src/Zendesk/API/Traits/Utility/Pagination/SinglePageStrategy.php
@@ -5,15 +5,16 @@ namespace Zendesk\API\Traits\Utility\Pagination;
 
 /**
  * Single Page (no pagination)
+ * Used in paginationStrategyClass
  */
 class SinglePageStrategy extends AbstractStrategy
 {
     protected $started = false;
 
-    public function getPage()
+    public function getPage($pageFn)
     {
         $this->started = true;
-        $response = $this->clientList->findAll();
+        $response = $pageFn();
 
         return $response->{$this->resourcesKey};
     }

--- a/tests/Zendesk/API/UnitTests/Traits/Utility/PaginationTest.php
+++ b/tests/Zendesk/API/UnitTests/Traits/Utility/PaginationTest.php
@@ -48,8 +48,8 @@ class PaginationTest extends BasicTest
             [['id' => 1], ['id' => 2]],
             [['id' => 3], ['id' => 4]]
         ]);
-        $strategy = new CbpStrategy($mockTickets, 'tickets', 2);
-        $iterator = new PaginationIterator($strategy);
+        $strategy = new CbpStrategy('tickets', 2);
+        $iterator = new PaginationIterator($mockTickets, $strategy);
 
         $tickets = iterator_to_array($iterator);
 
@@ -62,8 +62,8 @@ class PaginationTest extends BasicTest
             [['id' => 1, 'name' => 'User 1'], ['id' => 2, 'name' => 'User 2']],
             [['id' => 3, 'name' => 'User 3'], ['id' => 4, 'name' => 'User 4']]
         ]);
-        $strategy = new CbpStrategy($mockUsers, 'users', 2);
-        $iterator = new PaginationIterator($strategy);
+        $strategy = new CbpStrategy('users', 2);
+        $iterator = new PaginationIterator($mockUsers, $strategy);
 
         $users = iterator_to_array($iterator);
 

--- a/tests/Zendesk/API/UnitTests/Traits/Utility/PaginationTest.php
+++ b/tests/Zendesk/API/UnitTests/Traits/Utility/PaginationTest.php
@@ -3,10 +3,12 @@
 namespace Zendesk\API\UnitTests\Core;
 
 use Zendesk\API\Traits\Utility\Pagination\CbpStrategy;
+use Zendesk\API\Traits\Utility\Pagination\SinglePageStrategy;
 use Zendesk\API\UnitTests\BasicTest;
 use Zendesk\API\Traits\Utility\Pagination\PaginationIterator;
 
 class MockResource {
+    public $params;
     private $resources;
     private $resourceName;
     private $callCount = 0;
@@ -29,6 +31,8 @@ class MockResource {
         $afterCursor = $this->callCount === 0 ? 'cursor_for_next_page' : null;
 
         $this->callCount++;
+
+        $this->params = $params;
 
         return (object) [
             $this->resourceName => $resources,
@@ -74,4 +78,42 @@ class PaginationTest extends BasicTest
             ['id' => 4, 'name' => 'User 4']
         ], $users);
     }
+
+    public function testFetchesCbpWithParams()
+    {
+        $mockTickets = new MockResource('tickets', [
+            [['id' => 1], ['id' => 2]],
+            [['id' => 3], ['id' => 4]]
+        ]);
+        $strategy = new CbpStrategy('tickets', 2);
+        $iterator = new PaginationIterator($mockTickets, $strategy, ['sort_name' => 'id', 'sort_order' => 'desc']);
+
+        $tickets = iterator_to_array($iterator);
+
+        $this->assertEquals([['id' => 1], ['id' => 2], ['id' => 3], ['id' => 4]], $tickets);
+        $this->assertEquals([
+            'sort_name' => 'id', 'sort_order' => 'desc',
+            'page[size]' => 2, 'page[after]' => 'cursor_for_next_page'
+        ], $mockTickets->params);
+    }
+
+    public function testFetchesSinglePageWithParams()
+    {
+        $resultsKey = 'results';
+        $userParams = ['param' => 1];
+        $mockResults = new MockResource($resultsKey, [
+            [['id' => 1, 'name' => 'Resource 1'], ['id' => 2, 'name' => 'Resource 2']]
+        ]);
+        $strategy = new SinglePageStrategy($resultsKey);
+        $iterator = new PaginationIterator($mockResults, $strategy, $userParams);
+
+        $resources = iterator_to_array($iterator);
+
+        $this->assertEquals([
+            ['id' => 1, 'name' => 'Resource 1'],
+            ['id' => 2, 'name' => 'Resource 2'],
+        ], $resources);
+        $this->assertEquals($mockResults->params, $userParams);
+    }
+
 }


### PR DESCRIPTION
It's now possible to call the iterator with params as such:

```php
$it = $client->tickets()->iterator(['extra' => 'params']);

foreach ($it as $i) {
    process($i); // Your implementation
}
```

I will update the README in the next card, as I'll probably start the upgrade guide then too.