### PR TITLE
[DON'T MERGE] Iterator keeping only one page in memory

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,8 +7,8 @@ services:
     volumes:
       - .:/app
       - vendor:/app/vendor
-    command: vendor/bin/phpunit --testsuite "Zendesk API Unit Test Suites"
-    # command: vendor/bin/phpunit tests/Zendesk/API/UnitTests/Traits/Utility/PaginationIteratorTest.php
+    # command: vendor/bin/phpunit --testsuite "Zendesk API Unit Test Suites"
+    command: vendor/bin/phpunit tests/Zendesk/API/UnitTests/Traits/Utility/PaginationIteratorTest.php
     # command: vendor/bin/phpunit tests/Zendesk/API/UnitTests/Core/TicketsTest.php
     # command: vendor/bin/phpunit tests/Zendesk/API/UnitTests/Core/OrganizationMembershipsTest.php
 

--- a/src/Zendesk/API/Traits/Utility/Pagination/CbpStrategy.php
+++ b/src/Zendesk/API/Traits/Utility/Pagination/CbpStrategy.php
@@ -21,7 +21,13 @@ class CbpStrategy extends AbstractStrategy
     }
 
     public function shouldGetPage($position) {
-        return !$this->started || $this->afterCursor;
+        print("!!!!!!!!!!!! src/Zendesk/API/Traits/Utility/Pagination/CbpStrategy.php:24 shouldGetPage\n");
+        print("started :"); print_r($this->started); print(" \n");
+        print("afterCursor :"); print_r($this->afterCursor); print(" \n");
+        print("position :"); print_r($position); print(" \n");
+        print("page size :"); print_r($this->pageSize()); print(" \n");
+        print("result :"); print_r(!$this->started || !$this->afterCursor && $position == $this->pageSize() ? "true" : "false"); print(" \n");
+        return !$this->started || $this->afterCursor && $position == $this->pageSize();
     }
 
     public function params()

--- a/src/Zendesk/API/Traits/Utility/Pagination/PaginationIterator.php
+++ b/src/Zendesk/API/Traits/Utility/Pagination/PaginationIterator.php
@@ -60,11 +60,14 @@ class PaginationIterator implements Iterator
         if (!$this->strategy->shouldGetPage($this->position)) {
             return;
         }
+        print("!!!!!!!!!!!! src/Zendesk/API/Traits/Utility/Pagination/PaginationIterator.php:63 getPage\n");
+        print_r($this->position); print(" \n");
 
         $getPageFn = function () {
             return $this->clientList->{$this->method}($this->strategy->params());
         };
 
-        $this->page = array_merge($this->page, $this->strategy->page($getPageFn));
+        $this->page = $this->strategy->page($getPageFn);
+        $this->position = 0;
     }
 }

--- a/tests/Zendesk/API/UnitTests/Traits/Utility/PaginationIteratorTest.php
+++ b/tests/Zendesk/API/UnitTests/Traits/Utility/PaginationIteratorTest.php
@@ -74,118 +74,128 @@ class PaginationIteratorTest extends BasicTest
         $strategy = new CbpStrategy('tickets', ['page[size]' => 2]);
         $iterator = new PaginationIterator($mockTickets, $strategy);
 
-        $tickets = iterator_to_array($iterator);
-
-        $this->assertEquals([['id' => 1], ['id' => 2], ['id' => 3], ['id' => 4]], $tickets);
-    }
-
-    public function testFetchesUsers()
-    {
-        $mockUsers = new MockResource('users', [
-            [['id' => 1, 'name' => 'User 1'], ['id' => 2, 'name' => 'User 2']],
-            [['id' => 3, 'name' => 'User 3'], ['id' => 4, 'name' => 'User 4']]
-        ]);
-        $strategy = new CbpStrategy('users', ['page[size]' => 2]);
-        $iterator = new PaginationIterator($mockUsers, $strategy);
-
-        $users = iterator_to_array($iterator);
-
-        $this->assertEquals([
-            ['id' => 1, 'name' => 'User 1'],
-            ['id' => 2, 'name' => 'User 2'],
-            ['id' => 3, 'name' => 'User 3'],
-            ['id' => 4, 'name' => 'User 4']
-        ], $users);
-    }
-
-    public function testFetchesCbpWithParams()
-    {
-        $mockTickets = new MockResource('tickets', [
-            [['id' => 1], ['id' => 2]],
-            [['id' => 3], ['id' => 4]]
-        ]);
-        $strategy = new CbpStrategy('tickets', ['page[size]' => 2, 'any' => 'param']);
-        $iterator = new PaginationIterator($mockTickets, $strategy);
-
-        $tickets = iterator_to_array($iterator);
-
-        $this->assertEquals([['id' => 1], ['id' => 2], ['id' => 3], ['id' => 4]], $tickets);
-        $this->assertEquals([
-            'any' => 'param',
-            'page[size]' => 2, 'page[after]' => 'cursor_for_next_page'
-        ], $mockTickets->params);
-    }
-
-    public function testCorrectsParamsToCbp()
-    {
-        $mockTickets = new MockResource('tickets', [
-            [['id' => 1], ['id' => 2]],
-            [['id' => 3], ['id' => 4]]
-        ]);
-        $strategy = new CbpStrategy('tickets', ['per_page' => 2, 'sort_by' => 'id', 'sort_order' => 'desc']);
-        $iterator = new PaginationIterator($mockTickets, $strategy);
-
-        iterator_to_array($iterator);
-
-        $this->assertEquals([
-            'sort' => '-id',
-            'page[size]' => 2, 'page[after]' => 'cursor_for_next_page'
-        ], $mockTickets->params);
-    }
-
-    public function testFetchesSinglePageWithParams()
-    {
-        $resultsKey = 'results';
-        $userParams = ['param' => 1];
-        $mockResults = new MockResource($resultsKey, [
-            [['id' => 1, 'name' => 'Resource 1'], ['id' => 2, 'name' => 'Resource 2']]
-        ]);
-        $strategy = new SinglePageStrategy($resultsKey, $userParams);
-        $iterator = new PaginationIterator($mockResults, $strategy);
-
-        $resources = iterator_to_array($iterator);
-
-        $this->assertEquals([
-            ['id' => 1, 'name' => 'Resource 1'],
-            ['id' => 2, 'name' => 'Resource 2'],
-        ], $resources);
-        $this->assertEquals($mockResults->params, $userParams);
-    }
-    public function testCustomMethod()
-    {
-        $resultsKey = 'results';
-        $userParams = ['param' => 1];
-        $mockResults = new MockResource($resultsKey, [
-            [['id' => 1, 'name' => 'Resource 1'], ['id' => 2, 'name' => 'Resource 2']]
-        ]);
-        $strategy = new SinglePageStrategy($resultsKey, $userParams);
-        $iterator = new PaginationIterator($mockResults, $strategy, 'findDifferent');
-
-        $resources = iterator_to_array($iterator);
-
-        $this->assertEquals([
-            ['id' => 1, 'name' => 'Resource 1'],
-            ['id' => 2, 'name' => 'Resource 2'],
-        ], $resources);
-        $this->assertEquals(true, $mockResults->foundDifferent);
-        $this->assertEquals($userParams, $mockResults->params);
-    }
-
-    public function testHandlesError()
-    {
-        $expectedErrorMessage = "BOOM!";
-        $resultsKey = 'results';
-        $userParams = [];
-        $mockResults = new MockResource($resultsKey, [], $expectedErrorMessage);
-        $strategy = new CbpStrategy($resultsKey, $userParams);
-        $iterator = new PaginationIterator($mockResults, $strategy);
-
-        try {
-            iterator_to_array($iterator);
-        } catch (ApiResponseException $e) {
-            $actualErrorMessage = $e->getMessage();
+        // WORKS
+        $tickets = [];
+        foreach ($iterator as $ticket) {
+            print("!!!!!!!!!!!! LOOP \n");
+            print_r($tickets); print(" \n");
+            $tickets[] = $ticket;
         }
 
-        $this->assertEquals($expectedErrorMessage, $actualErrorMessage);
+        // DOESN'T WORK
+        // $tickets = iterator_to_array($iterator);
+
+        $this->assertEquals([['id' => 1], ['id' => 2], ['id' => 3], ['id' => 4]], $tickets);
     }
+
+    // public function testFetchesUsers()
+    // {
+    //     $mockUsers = new MockResource('users', [
+    //         [['id' => 1, 'name' => 'User 1'], ['id' => 2, 'name' => 'User 2']],
+    //         [['id' => 3, 'name' => 'User 3'], ['id' => 4, 'name' => 'User 4']]
+    //     ]);
+    //     $strategy = new CbpStrategy('users', ['page[size]' => 2]);
+    //     $iterator = new PaginationIterator($mockUsers, $strategy);
+
+    //     $users = iterator_to_array($iterator);
+
+    //     $this->assertEquals([
+    //         ['id' => 1, 'name' => 'User 1'],
+    //         ['id' => 2, 'name' => 'User 2'],
+    //         ['id' => 3, 'name' => 'User 3'],
+    //         ['id' => 4, 'name' => 'User 4']
+    //     ], $users);
+    // }
+
+    // public function testFetchesCbpWithParams()
+    // {
+    //     $mockTickets = new MockResource('tickets', [
+    //         [['id' => 1], ['id' => 2]],
+    //         [['id' => 3], ['id' => 4]]
+    //     ]);
+    //     $strategy = new CbpStrategy('tickets', ['page[size]' => 2, 'any' => 'param']);
+    //     $iterator = new PaginationIterator($mockTickets, $strategy);
+
+    //     $tickets = iterator_to_array($iterator);
+
+    //     $this->assertEquals([['id' => 1], ['id' => 2], ['id' => 3], ['id' => 4]], $tickets);
+    //     $this->assertEquals([
+    //         'any' => 'param',
+    //         'page[size]' => 2, 'page[after]' => 'cursor_for_next_page'
+    //     ], $mockTickets->params);
+    // }
+
+    // public function testCorrectsParamsToCbp()
+    // {
+    //     $mockTickets = new MockResource('tickets', [
+    //         [['id' => 1], ['id' => 2]],
+    //         [['id' => 3], ['id' => 4]]
+    //     ]);
+    //     $strategy = new CbpStrategy('tickets', ['per_page' => 2, 'sort_by' => 'id', 'sort_order' => 'desc']);
+    //     $iterator = new PaginationIterator($mockTickets, $strategy);
+
+    //     iterator_to_array($iterator);
+
+    //     $this->assertEquals([
+    //         'sort' => '-id',
+    //         'page[size]' => 2, 'page[after]' => 'cursor_for_next_page'
+    //     ], $mockTickets->params);
+    // }
+
+    // public function testFetchesSinglePageWithParams()
+    // {
+    //     $resultsKey = 'results';
+    //     $userParams = ['param' => 1];
+    //     $mockResults = new MockResource($resultsKey, [
+    //         [['id' => 1, 'name' => 'Resource 1'], ['id' => 2, 'name' => 'Resource 2']]
+    //     ]);
+    //     $strategy = new SinglePageStrategy($resultsKey, $userParams);
+    //     $iterator = new PaginationIterator($mockResults, $strategy);
+
+    //     $resources = iterator_to_array($iterator);
+
+    //     $this->assertEquals([
+    //         ['id' => 1, 'name' => 'Resource 1'],
+    //         ['id' => 2, 'name' => 'Resource 2'],
+    //     ], $resources);
+    //     $this->assertEquals($mockResults->params, $userParams);
+    // }
+    // public function testCustomMethod()
+    // {
+    //     $resultsKey = 'results';
+    //     $userParams = ['param' => 1];
+    //     $mockResults = new MockResource($resultsKey, [
+    //         [['id' => 1, 'name' => 'Resource 1'], ['id' => 2, 'name' => 'Resource 2']]
+    //     ]);
+    //     $strategy = new SinglePageStrategy($resultsKey, $userParams);
+    //     $iterator = new PaginationIterator($mockResults, $strategy, 'findDifferent');
+
+    //     $resources = iterator_to_array($iterator);
+
+    //     $this->assertEquals([
+    //         ['id' => 1, 'name' => 'Resource 1'],
+    //         ['id' => 2, 'name' => 'Resource 2'],
+    //     ], $resources);
+    //     $this->assertEquals(true, $mockResults->foundDifferent);
+    //     $this->assertEquals($userParams, $mockResults->params);
+    // }
+
+    // public function testHandlesError()
+    // {
+    //     $expectedErrorMessage = "BOOM!";
+    //     $resultsKey = 'results';
+    //     $userParams = [];
+    //     $mockResults = new MockResource($resultsKey, [], $expectedErrorMessage);
+    //     $strategy = new CbpStrategy($resultsKey, $userParams);
+    //     $iterator = new PaginationIterator($mockResults, $strategy);
+
+    //     try {
+    //         iterator_to_array($iterator);
+    //         $actualErrorMessage = null;
+    //     } catch (ApiResponseException $e) {
+    //         $actualErrorMessage = $e->getMessage();
+    //     }
+
+    //     $this->assertEquals($expectedErrorMessage, $actualErrorMessage);
+    // }
 }


### PR DESCRIPTION
This works with:

```php
        $tickets = [];
        foreach ($iterator as $ticket) {
            $tickets[] = $ticket;
        }
```

BUT doesn't seem to work with the method `iterator_to_array`.