### PR TITLE
Debug headers as JSON - Fix #465

### DIFF
--- a/src/Zendesk/API/Debug.php
+++ b/src/Zendesk/API/Debug.php
@@ -20,7 +20,7 @@ class Debug
      */
     public $lastResponseCode;
     /**
-     * @var string
+     * @var mixed
      */
     public $lastResponseHeaders;
     /**
@@ -39,8 +39,8 @@ class Debug
         }
         $output = 'LastResponseCode: ' . $this->lastResponseCode
                   . ', LastResponseError: ' . $lastError
-                  . ', LastResponseHeaders: ' . $this->lastResponseHeaders
-                  . ', LastRequestHeaders: ' . $this->lastRequestHeaders
+                  . ', LastResponseHeaders: ' . json_encode($this->lastResponseHeaders)
+                  . ', LastRequestHeaders: ' . json_encode($this->lastRequestHeaders)
                   . ', LastRequestBody: ' . $this->lastRequestBody;
 
         return $output;


### PR DESCRIPTION
Fix #465

Headers as JSON will be more helpful for debugging.

No tests, but this is dev only.

## Example

### Before

```
> (string) $client->getDebug();
= LastResponseCode: 200, LastResponseError: null, LastResponseHeaders: Array, LastRequestHeaders: Array, LastRequestBody:
```

### After

```
> (string) $client->getDebug();
= "LastResponseCode: 200, LastResponseError: null, LastResponseHeaders: {"Date":["Mon, 20 May 2024 02:11:12 GMT"],"Content-Type":["application\/json; charset=utf-8"],"Transfer-Encoding":["chunked"],"Connection":["keep-alive"],"x-zendesk-api-version":["v2"],"x-zendesk-application-version":["v20929"],"x-frame-options":["SAMEORIGIN...."]}, LastRequestHeaders: {"Host":["z3n-api-client-rb.zendesk.com"],"Accept":["application\/json"],"Content-Type":["application\/json"],"User-Agent":["ZendeskAPI PHP 3.0.1"]}, LastRequestBody: "
```