### PR TITLE
Demonstrate how to get help center articles using the php client

### DIFF
--- a/samples/helpcenter/findArticlesBySectionId.php
+++ b/samples/helpcenter/findArticlesBySectionId.php
@@ -1,6 +1,6 @@
 <?php
 
-include("../../vendor/autoload.php");
+require_once __DIR__ . '/../../vendor/autoload.php';
 
 use Zendesk\API\HttpClient as ZendeskAPI;
 
@@ -11,14 +11,15 @@ use Zendesk\API\HttpClient as ZendeskAPI;
 $subdomain = "subdomain";
 $username = "email@example.com";
 $token = "6wiIBWbGkBMo1mRDMuVwkw1EPsNkeUj95PIz2akv";
+$section_id = 10801195364239; // replace this with your section id
 
 $client = new ZendeskAPI($subdomain);
 $client->setAuth('basic', ['username' => $username, 'token' => $token]);
 $help_center_client = new Zendesk\API\Resources\HelpCenter($client);
 
 try {
-    // Find all helpcenter categories
-    $articles = $help_center_client->articles()->findAll();
+    // Find all helpcenter category with the given section id
+    $articles = $help_center_client->sections($section_id)->articles()->findAll();
 
     echo "<pre>";
     print_r($articles);


### PR DESCRIPTION
Thank you @adnen-chouibi for pinpointing this gap in the samples per comment here: https://github.com/zendesk/zendesk_api_client_php/issues/390#issuecomment-2344567569

## Description
Demonstrate how to get help center articles by section_id
- We need to wrap the client in a help center resource, otherwise the request
  will not have what it needs to retrieve all articles, rather than a given
  section
- Provide a specific example demonstrating how to list articles by section_id

## References
- Comment from @adnen-chouibi: https://github.com/zendesk/zendesk_api_client_php/issues/390#issuecomment-2344567569

## Risks
- Low: Added a sample only, does not impact functionality of php client