### PR TITLE
Fix php 8.4 nullable parameters deprecations

### DIFF
--- a/src/Zendesk/API/Exceptions/CustomException.php
+++ b/src/Zendesk/API/Exceptions/CustomException.php
@@ -14,7 +14,7 @@ class CustomException extends \Exception
      * @param int $code
      * @param \Exception $previous
      */
-    public function __construct($message, $code = 0, \Exception $previous = null)
+    public function __construct($message, $code = 0, ?\Exception $previous = null)
     {
         parent::__construct($message, $code, $previous);
     }

--- a/src/Zendesk/API/Exceptions/MissingParametersException.php
+++ b/src/Zendesk/API/Exceptions/MissingParametersException.php
@@ -15,7 +15,7 @@ class MissingParametersException extends \Exception
      * @param int $code
      * @param \Exception $previous
      */
-    public function __construct($method, array $params, $code = 0, \Exception $previous = null)
+    public function __construct($method, array $params, $code = 0, ?\Exception $previous = null)
     {
         parent::__construct(
             'Missing parameters: \'' . implode("', '", $params) . '\' must be supplied for ' . $method,

--- a/src/Zendesk/API/Exceptions/ResponseException.php
+++ b/src/Zendesk/API/Exceptions/ResponseException.php
@@ -17,7 +17,7 @@ class ResponseException extends \Exception
      * @param int        $code
      * @param \Exception $previous
      */
-    public function __construct($method, $detail = '', $code = 0, \Exception $previous = null)
+    public function __construct($method, $detail = '', $code = 0, ?\Exception $previous = null)
     {
         parent::__construct(
             'Response to ' . $method . ' is not valid. Call $client->getDebug() for details' . $detail,

--- a/src/Zendesk/API/HttpClient.php
+++ b/src/Zendesk/API/HttpClient.php
@@ -442,7 +442,7 @@ class HttpClient
      *
      * @return HttpClient
      */
-    public function setSideload(array $fields = null)
+    public function setSideload(?array $fields = null)
     {
         $this->sideload = $fields;
 


### PR DESCRIPTION
Hi, 

Here are some fixes for PHP 8.4 deprecations about Implicity Nullable Parameter
More informations : https://www.php.net/manual/en/migration84.deprecated.php#migration84.deprecated.core.implicitly-nullable-parameter

Regards