### PR TITLE
[RED-2643] Cherry-pick fix for issue when iterating over help center categories

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,6 @@
+.PHONY: test all
+
+test:
+	composer test:unit
+
+all: test

--- a/src/Zendesk/API/Resources/HelpCenter/Articles.php
+++ b/src/Zendesk/API/Resources/HelpCenter/Articles.php
@@ -20,12 +20,15 @@ class Articles extends ResourceAbstract
     use Search;
 
     /**
-     * @{inheritdoc}
+     * {@inheritdoc}
      */
     protected $objectName = 'article';
-
     /**
-     * @{inheritdoc}
+     * {@inheritdoc}
+     */
+    protected $objectNamePlural = 'articles';
+    /**
+     * {@inheritdoc}
      */
     protected function setupRoutes()
     {

--- a/src/Zendesk/API/Resources/HelpCenter/Categories.php
+++ b/src/Zendesk/API/Resources/HelpCenter/Categories.php
@@ -21,6 +21,10 @@ class Categories extends ResourceAbstract
      * {@inheritdoc}
      */
     protected $objectName = 'category';
+    /**
+     * {@inheritdoc}
+     */
+    protected $objectNamePlural = 'categories';
 
     /**
      * {@inheritdoc}

--- a/src/Zendesk/API/Resources/HelpCenter/Sections.php
+++ b/src/Zendesk/API/Resources/HelpCenter/Sections.php
@@ -23,6 +23,10 @@ class Sections extends ResourceAbstract
      * {@inheritdoc}
      */
     protected $objectName = 'section';
+    /**
+     * {@inheritdoc}
+     */
+    protected $objectNamePlural = 'sections';
 
     /**
      * @inheritdoc

--- a/tests/Zendesk/API/LiveTests/HelpCenterTest.php
+++ b/tests/Zendesk/API/LiveTests/HelpCenterTest.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Zendesk\API\LiveTests;
+
+class HelpCenterTest extends BasicTest
+{
+    /**
+     * @throws \Zendesk\API\Exceptions\MissingParametersException
+     */
+    public function testIterateOverHelpCenterArticles()
+    {
+        $iterator = $this->client->helpCenter->articles()->iterator();
+
+        $actual = iterator_to_array($iterator);
+
+        // Generally, there should be at least one article in the help center, even if these are just the default articles.
+        $this->assertTrue(is_array($actual) && count($actual) > 0, 'Should return a non-empty array of articles.');
+    }
+
+    public function testIterateOverHelpCenterSections()
+    {
+        $iterator = $this->client->helpCenter->sections()->iterator();
+
+        $actual = iterator_to_array($iterator);
+
+        // Generally, there should be at least one section in the help center, even if these are just the default sections.
+        $this->assertTrue(is_array($actual) && count($actual) > 0, 'Should return a non-empty array of sections.');
+    }
+
+    public function testIterateOverHelpCenterCategories()
+    {
+        $iterator = $this->client->helpCenter->categories()->iterator();
+
+        $actual = iterator_to_array($iterator);
+
+        // Generally, there should be at least one category in the help center, even if these are just the default categories.
+        $this->assertTrue(is_array($actual) && count($actual) > 0, 'Should return a non-empty array of categories.');
+    }
+}


### PR DESCRIPTION
#### In brief

Cherry-picks this change https://github.com/zendesk/zendesk_api_client_php/pull/548 to make it available to consumers still using v3.x.x of the client.

#### References

https://github.com/zendesk/zendesk_api_client_php/pull/548

#### Risks

- Low: Might break help-center api interactivity of the client